### PR TITLE
New Record Medium Track: 14.34min (-470 steps, -90s) MUDD Connections & MUDD Style Gate 

### DIFF
--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/0f0f8a50-40be-4583-84a3-002faf0cd8a0.txt
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/0f0f8a50-40be-4583-84a3-002faf0cd8a0.txt
@@ -1,0 +1,6376 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+import numpy as np
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
+
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = False # turn off fp8 for now -> requires tuning of scales which hasnt been done on medium track
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(16, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
+
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
+        self.yarn = Yarn(head_dim, max_seq_len)
+
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+        self.embed.weight.label = 'embed'
+
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
+        self.embed2.weight.label = 'embed2'
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [2, 4, 6]
+        skip_out = [9, 10, 11]
+        backout_layer = 11
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
+            short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
+
+        skip_idx = 0
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve_list[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
+            )
+            next_ve_gate = None
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
+                skip_idx += 1
+                x = x + skip_gate_out * skip_connections.pop()
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
+            else:
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                h_backout_snap = x
+
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
+        x = norm(x)
+
+        if not self.training:
+            loss = 0
+            for i in range(4):
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
+                logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+                loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
+            return loss
+
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return min(11,args.ws_schedule[ws_idx] // 2), args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/12:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/12:
+        lr_max = 1.73  # (24/8)**0.5
+    if x > 3/12:
+        lr_max = 2.0
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
+
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / (args.num_scheduled_iterations/4)
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        # only apply yarn for first few
+        if new_ws_long != self.ws_long and new_ws_long<=13:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
+                                524288, 524288, 524288, 524288,
+                                524288, 524288, 524288, 524288
+                               )
+    train_bs_extension: int = 32 * 2048 * 8
+    train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3/4
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11, 13,
+                          15, 17, 19, 21,
+                          23, 23, 23, 23)
+    ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
+    ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=16,
+    num_heads=8,
+    head_dim=128,
+    model_dim=1024,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Mon Apr 27 07:06:18 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   47C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   39C    P0            117W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   46C    P0            117W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   40C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   45C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   42C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          264663      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    1   N/A  N/A          264664      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    2   N/A  N/A          264665      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    3   N/A  N/A          264666      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    4   N/A  N/A          264667      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    5   N/A  N/A          264668      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    6   N/A  N/A          264669      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    7   N/A  N/A          264670      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 343, 344, 345, 687, 688, 689, 1031, 1032, 1033, 1374, 1375, 1376, 1718, 1719, 1720, 2062, 2063, 2064, 2406, 2407, 2408, 2749, 2750, 2751] for warmup
+Resetting Model
+step:0/4150 val_loss:10.8313 train_time:0ms step_avg:0.04ms
+step:1/4150 train_time:68ms step_avg:68.36ms
+step:2/4150 train_time:124ms step_avg:62.25ms
+step:3/4150 train_time:193ms step_avg:64.42ms
+step:4/4150 train_time:259ms step_avg:64.83ms
+step:5/4150 train_time:328ms step_avg:65.68ms
+step:6/4150 train_time:393ms step_avg:65.58ms
+step:7/4150 train_time:462ms step_avg:66.06ms
+step:8/4150 train_time:528ms step_avg:66.03ms
+step:9/4150 train_time:597ms step_avg:66.36ms
+step:10/4150 train_time:663ms step_avg:66.27ms
+step:11/4150 train_time:732ms step_avg:66.54ms
+step:12/4150 train_time:797ms step_avg:66.45ms
+step:13/4150 train_time:867ms step_avg:66.69ms
+step:14/4150 train_time:933ms step_avg:66.62ms
+step:15/4150 train_time:1003ms step_avg:66.86ms
+step:16/4150 train_time:1069ms step_avg:66.83ms
+step:17/4150 train_time:1140ms step_avg:67.09ms
+step:18/4150 train_time:1207ms step_avg:67.07ms
+step:19/4150 train_time:1277ms step_avg:67.23ms
+step:20/4150 train_time:1344ms step_avg:67.18ms
+step:21/4150 train_time:1413ms step_avg:67.31ms
+step:22/4150 train_time:1479ms step_avg:67.23ms
+step:23/4150 train_time:1549ms step_avg:67.36ms
+step:24/4150 train_time:1615ms step_avg:67.29ms
+step:25/4150 train_time:1684ms step_avg:67.37ms
+step:26/4150 train_time:1750ms step_avg:67.29ms
+step:27/4150 train_time:1819ms step_avg:67.37ms
+step:28/4150 train_time:1885ms step_avg:67.33ms
+step:29/4150 train_time:1955ms step_avg:67.42ms
+step:30/4150 train_time:2021ms step_avg:67.37ms
+step:31/4150 train_time:2091ms step_avg:67.46ms
+step:32/4150 train_time:2157ms step_avg:67.40ms
+step:33/4150 train_time:2227ms step_avg:67.48ms
+step:34/4150 train_time:2293ms step_avg:67.43ms
+step:35/4150 train_time:2363ms step_avg:67.50ms
+step:36/4150 train_time:2428ms step_avg:67.45ms
+step:37/4150 train_time:2498ms step_avg:67.53ms
+step:38/4150 train_time:2564ms step_avg:67.48ms
+step:39/4150 train_time:2634ms step_avg:67.55ms
+step:40/4150 train_time:2701ms step_avg:67.52ms
+step:41/4150 train_time:2771ms step_avg:67.58ms
+step:42/4150 train_time:2836ms step_avg:67.52ms
+step:43/4150 train_time:2906ms step_avg:67.57ms
+step:44/4150 train_time:2972ms step_avg:67.54ms
+step:45/4150 train_time:3041ms step_avg:67.58ms
+step:46/4150 train_time:3108ms step_avg:67.57ms
+step:47/4150 train_time:3178ms step_avg:67.61ms
+step:48/4150 train_time:3243ms step_avg:67.57ms
+step:49/4150 train_time:3314ms step_avg:67.63ms
+step:50/4150 train_time:3379ms step_avg:67.59ms
+step:51/4150 train_time:3450ms step_avg:67.64ms
+step:52/4150 train_time:3515ms step_avg:67.60ms
+step:53/4150 train_time:3585ms step_avg:67.64ms
+step:54/4150 train_time:3650ms step_avg:67.60ms
+step:55/4150 train_time:3720ms step_avg:67.64ms
+step:56/4150 train_time:3786ms step_avg:67.61ms
+step:57/4150 train_time:3856ms step_avg:67.65ms
+step:58/4150 train_time:3922ms step_avg:67.62ms
+step:59/4150 train_time:3991ms step_avg:67.65ms
+step:60/4150 train_time:4057ms step_avg:67.62ms
+step:61/4150 train_time:4127ms step_avg:67.66ms
+step:62/4150 train_time:4193ms step_avg:67.63ms
+step:63/4150 train_time:4263ms step_avg:67.66ms
+step:64/4150 train_time:4329ms step_avg:67.64ms
+step:65/4150 train_time:4398ms step_avg:67.67ms
+step:66/4150 train_time:4464ms step_avg:67.64ms
+step:67/4150 train_time:4534ms step_avg:67.67ms
+step:68/4150 train_time:4600ms step_avg:67.64ms
+step:69/4150 train_time:4669ms step_avg:67.67ms
+step:70/4150 train_time:4734ms step_avg:67.64ms
+step:71/4150 train_time:4804ms step_avg:67.67ms
+step:72/4150 train_time:4870ms step_avg:67.64ms
+step:73/4150 train_time:4940ms step_avg:67.67ms
+step:74/4150 train_time:5005ms step_avg:67.64ms
+step:75/4150 train_time:5075ms step_avg:67.66ms
+step:76/4150 train_time:5140ms step_avg:67.63ms
+step:77/4150 train_time:5210ms step_avg:67.66ms
+step:78/4150 train_time:5276ms step_avg:67.64ms
+step:79/4150 train_time:5345ms step_avg:67.66ms
+step:80/4150 train_time:5411ms step_avg:67.64ms
+step:81/4150 train_time:5481ms step_avg:67.67ms
+step:82/4150 train_time:5547ms step_avg:67.64ms
+step:83/4150 train_time:5616ms step_avg:67.66ms
+step:84/4150 train_time:5682ms step_avg:67.64ms
+step:85/4150 train_time:5751ms step_avg:67.66ms
+step:86/4150 train_time:5817ms step_avg:67.64ms
+step:87/4150 train_time:5886ms step_avg:67.66ms
+step:88/4150 train_time:5952ms step_avg:67.63ms
+step:89/4150 train_time:6021ms step_avg:67.65ms
+step:90/4150 train_time:6088ms step_avg:67.64ms
+step:91/4150 train_time:6157ms step_avg:67.66ms
+step:92/4150 train_time:6222ms step_avg:67.64ms
+step:93/4150 train_time:6292ms step_avg:67.66ms
+step:94/4150 train_time:6357ms step_avg:67.63ms
+step:95/4150 train_time:6427ms step_avg:67.65ms
+step:96/4150 train_time:6493ms step_avg:67.63ms
+step:97/4150 train_time:6562ms step_avg:67.65ms
+step:98/4150 train_time:6628ms step_avg:67.63ms
+step:99/4150 train_time:6697ms step_avg:67.65ms
+step:100/4150 train_time:6763ms step_avg:67.63ms
+step:101/4150 train_time:6833ms step_avg:67.65ms
+step:102/4150 train_time:6899ms step_avg:67.63ms
+step:103/4150 train_time:6968ms step_avg:67.65ms
+step:104/4150 train_time:7034ms step_avg:67.64ms
+step:105/4150 train_time:7104ms step_avg:67.66ms
+step:106/4150 train_time:7170ms step_avg:67.64ms
+step:107/4150 train_time:7239ms step_avg:67.66ms
+step:108/4150 train_time:7305ms step_avg:67.64ms
+step:109/4150 train_time:7374ms step_avg:67.65ms
+step:110/4150 train_time:7439ms step_avg:67.63ms
+step:111/4150 train_time:7509ms step_avg:67.65ms
+step:112/4150 train_time:7575ms step_avg:67.63ms
+step:113/4150 train_time:7644ms step_avg:67.65ms
+step:114/4150 train_time:7709ms step_avg:67.62ms
+step:115/4150 train_time:7779ms step_avg:67.65ms
+step:116/4150 train_time:7846ms step_avg:67.63ms
+step:117/4150 train_time:7916ms step_avg:67.66ms
+step:118/4150 train_time:7981ms step_avg:67.64ms
+step:119/4150 train_time:8051ms step_avg:67.65ms
+step:120/4150 train_time:8116ms step_avg:67.63ms
+step:121/4150 train_time:8186ms step_avg:67.65ms
+step:122/4150 train_time:8251ms step_avg:67.63ms
+step:123/4150 train_time:8321ms step_avg:67.65ms
+step:124/4150 train_time:8387ms step_avg:67.63ms
+step:125/4150 train_time:8457ms step_avg:67.65ms
+step:126/4150 train_time:8522ms step_avg:67.64ms
+step:127/4150 train_time:8593ms step_avg:67.66ms
+step:128/4150 train_time:8658ms step_avg:67.64ms
+step:129/4150 train_time:8728ms step_avg:67.66ms
+step:130/4150 train_time:8793ms step_avg:67.64ms
+step:131/4150 train_time:8863ms step_avg:67.65ms
+step:132/4150 train_time:8928ms step_avg:67.64ms
+step:133/4150 train_time:8998ms step_avg:67.66ms
+step:134/4150 train_time:9064ms step_avg:67.64ms
+step:135/4150 train_time:9134ms step_avg:67.66ms
+step:136/4150 train_time:9199ms step_avg:67.64ms
+step:137/4150 train_time:9269ms step_avg:67.65ms
+step:138/4150 train_time:9334ms step_avg:67.64ms
+step:139/4150 train_time:9404ms step_avg:67.66ms
+step:140/4150 train_time:9470ms step_avg:67.64ms
+step:141/4150 train_time:9540ms step_avg:67.66ms
+step:142/4150 train_time:9605ms step_avg:67.64ms
+step:143/4150 train_time:9674ms step_avg:67.65ms
+step:144/4150 train_time:9739ms step_avg:67.64ms
+step:145/4150 train_time:9810ms step_avg:67.65ms
+step:146/4150 train_time:9875ms step_avg:67.64ms
+step:147/4150 train_time:9944ms step_avg:67.65ms
+step:148/4150 train_time:10009ms step_avg:67.63ms
+step:149/4150 train_time:10079ms step_avg:67.64ms
+step:150/4150 train_time:10145ms step_avg:67.63ms
+step:151/4150 train_time:10214ms step_avg:67.64ms
+step:152/4150 train_time:10279ms step_avg:67.62ms
+step:153/4150 train_time:10348ms step_avg:67.64ms
+step:154/4150 train_time:10413ms step_avg:67.62ms
+step:155/4150 train_time:10483ms step_avg:67.63ms
+step:156/4150 train_time:10549ms step_avg:67.62ms
+step:157/4150 train_time:10618ms step_avg:67.63ms
+step:158/4150 train_time:10683ms step_avg:67.62ms
+step:159/4150 train_time:10753ms step_avg:67.63ms
+step:160/4150 train_time:10818ms step_avg:67.61ms
+step:161/4150 train_time:10887ms step_avg:67.62ms
+step:162/4150 train_time:10953ms step_avg:67.61ms
+step:163/4150 train_time:11022ms step_avg:67.62ms
+step:164/4150 train_time:11088ms step_avg:67.61ms
+step:165/4150 train_time:11157ms step_avg:67.62ms
+step:166/4150 train_time:11223ms step_avg:67.61ms
+step:167/4150 train_time:11292ms step_avg:67.62ms
+step:168/4150 train_time:11358ms step_avg:67.60ms
+step:169/4150 train_time:11428ms step_avg:67.62ms
+step:170/4150 train_time:11493ms step_avg:67.60ms
+step:171/4150 train_time:11562ms step_avg:67.61ms
+step:172/4150 train_time:11628ms step_avg:67.60ms
+step:173/4150 train_time:11697ms step_avg:67.61ms
+step:174/4150 train_time:11762ms step_avg:67.60ms
+step:175/4150 train_time:11832ms step_avg:67.61ms
+step:176/4150 train_time:11897ms step_avg:67.60ms
+step:177/4150 train_time:11967ms step_avg:67.61ms
+step:178/4150 train_time:12032ms step_avg:67.60ms
+step:179/4150 train_time:12102ms step_avg:67.61ms
+step:180/4150 train_time:12168ms step_avg:67.60ms
+step:181/4150 train_time:12238ms step_avg:67.61ms
+step:182/4150 train_time:12304ms step_avg:67.60ms
+step:183/4150 train_time:12374ms step_avg:67.61ms
+step:184/4150 train_time:12439ms step_avg:67.60ms
+step:185/4150 train_time:12508ms step_avg:67.61ms
+step:186/4150 train_time:12572ms step_avg:67.59ms
+step:187/4150 train_time:12642ms step_avg:67.60ms
+step:188/4150 train_time:12707ms step_avg:67.59ms
+step:189/4150 train_time:12776ms step_avg:67.60ms
+step:190/4150 train_time:12841ms step_avg:67.59ms
+step:191/4150 train_time:12911ms step_avg:67.60ms
+step:192/4150 train_time:12976ms step_avg:67.58ms
+step:193/4150 train_time:13045ms step_avg:67.59ms
+step:194/4150 train_time:13110ms step_avg:67.58ms
+step:195/4150 train_time:13180ms step_avg:67.59ms
+step:196/4150 train_time:13245ms step_avg:67.58ms
+step:197/4150 train_time:13314ms step_avg:67.58ms
+step:198/4150 train_time:13379ms step_avg:67.57ms
+step:199/4150 train_time:13448ms step_avg:67.58ms
+step:200/4150 train_time:13513ms step_avg:67.57ms
+step:201/4150 train_time:13582ms step_avg:67.57ms
+step:202/4150 train_time:13648ms step_avg:67.56ms
+step:203/4150 train_time:13717ms step_avg:67.57ms
+step:204/4150 train_time:13782ms step_avg:67.56ms
+step:205/4150 train_time:13852ms step_avg:67.57ms
+step:206/4150 train_time:13917ms step_avg:67.56ms
+step:207/4150 train_time:13987ms step_avg:67.57ms
+step:208/4150 train_time:14052ms step_avg:67.56ms
+step:209/4150 train_time:14121ms step_avg:67.57ms
+step:210/4150 train_time:14187ms step_avg:67.56ms
+step:211/4150 train_time:14257ms step_avg:67.57ms
+step:212/4150 train_time:14322ms step_avg:67.56ms
+step:213/4150 train_time:14391ms step_avg:67.56ms
+step:214/4150 train_time:14456ms step_avg:67.55ms
+step:215/4150 train_time:14526ms step_avg:67.56ms
+step:216/4150 train_time:14591ms step_avg:67.55ms
+step:217/4150 train_time:14660ms step_avg:67.56ms
+step:218/4150 train_time:14726ms step_avg:67.55ms
+step:219/4150 train_time:14796ms step_avg:67.56ms
+step:220/4150 train_time:14861ms step_avg:67.55ms
+step:221/4150 train_time:14932ms step_avg:67.56ms
+step:222/4150 train_time:14997ms step_avg:67.55ms
+step:223/4150 train_time:15066ms step_avg:67.56ms
+step:224/4150 train_time:15131ms step_avg:67.55ms
+step:225/4150 train_time:15200ms step_avg:67.55ms
+step:226/4150 train_time:15266ms step_avg:67.55ms
+step:227/4150 train_time:15336ms step_avg:67.56ms
+step:228/4150 train_time:15402ms step_avg:67.55ms
+step:229/4150 train_time:15472ms step_avg:67.56ms
+step:230/4150 train_time:15537ms step_avg:67.55ms
+step:231/4150 train_time:15606ms step_avg:67.56ms
+step:232/4150 train_time:15672ms step_avg:67.55ms
+step:233/4150 train_time:15741ms step_avg:67.56ms
+step:234/4150 train_time:15805ms step_avg:67.54ms
+step:235/4150 train_time:15875ms step_avg:67.55ms
+step:236/4150 train_time:15940ms step_avg:67.54ms
+step:237/4150 train_time:16009ms step_avg:67.55ms
+step:238/4150 train_time:16074ms step_avg:67.54ms
+step:239/4150 train_time:16143ms step_avg:67.54ms
+step:240/4150 train_time:16209ms step_avg:67.54ms
+step:241/4150 train_time:16278ms step_avg:67.54ms
+step:242/4150 train_time:16343ms step_avg:67.53ms
+step:243/4150 train_time:16412ms step_avg:67.54ms
+step:244/4150 train_time:16477ms step_avg:67.53ms
+step:245/4150 train_time:16547ms step_avg:67.54ms
+step:246/4150 train_time:16612ms step_avg:67.53ms
+step:247/4150 train_time:16681ms step_avg:67.54ms
+step:248/4150 train_time:16746ms step_avg:67.53ms
+step:249/4150 train_time:16816ms step_avg:67.53ms
+step:250/4150 train_time:16881ms step_avg:67.52ms
+step:250/4150 val_loss:4.4759 train_time:16947ms step_avg:67.79ms
+step:251/4150 train_time:16968ms step_avg:67.60ms
+step:252/4150 train_time:17019ms step_avg:67.53ms
+step:253/4150 train_time:17087ms step_avg:67.54ms
+step:254/4150 train_time:17153ms step_avg:67.53ms
+step:255/4150 train_time:17223ms step_avg:67.54ms
+step:256/4150 train_time:17291ms step_avg:67.54ms
+step:257/4150 train_time:17362ms step_avg:67.55ms
+step:258/4150 train_time:17427ms step_avg:67.54ms
+step:259/4150 train_time:17496ms step_avg:67.55ms
+step:260/4150 train_time:17561ms step_avg:67.54ms
+step:261/4150 train_time:17630ms step_avg:67.55ms
+step:262/4150 train_time:17695ms step_avg:67.54ms
+step:263/4150 train_time:17764ms step_avg:67.54ms
+step:264/4150 train_time:17829ms step_avg:67.53ms
+step:265/4150 train_time:17897ms step_avg:67.54ms
+step:266/4150 train_time:17962ms step_avg:67.53ms
+step:267/4150 train_time:18031ms step_avg:67.53ms
+step:268/4150 train_time:18096ms step_avg:67.52ms
+step:269/4150 train_time:18165ms step_avg:67.53ms
+step:270/4150 train_time:18230ms step_avg:67.52ms
+step:271/4150 train_time:18299ms step_avg:67.53ms
+step:272/4150 train_time:18365ms step_avg:67.52ms
+step:273/4150 train_time:18435ms step_avg:67.53ms
+step:274/4150 train_time:18500ms step_avg:67.52ms
+step:275/4150 train_time:18569ms step_avg:67.52ms
+step:276/4150 train_time:18634ms step_avg:67.51ms
+step:277/4150 train_time:18703ms step_avg:67.52ms
+step:278/4150 train_time:18768ms step_avg:67.51ms
+step:279/4150 train_time:18836ms step_avg:67.51ms
+step:280/4150 train_time:18901ms step_avg:67.50ms
+step:281/4150 train_time:18970ms step_avg:67.51ms
+step:282/4150 train_time:19035ms step_avg:67.50ms
+step:283/4150 train_time:19104ms step_avg:67.50ms
+step:284/4150 train_time:19169ms step_avg:67.50ms
+step:285/4150 train_time:19238ms step_avg:67.50ms
+step:286/4150 train_time:19303ms step_avg:67.49ms
+step:287/4150 train_time:19373ms step_avg:67.50ms
+step:288/4150 train_time:19438ms step_avg:67.49ms
+step:289/4150 train_time:19507ms step_avg:67.50ms
+step:290/4150 train_time:19573ms step_avg:67.49ms
+step:291/4150 train_time:19642ms step_avg:67.50ms
+step:292/4150 train_time:19707ms step_avg:67.49ms
+step:293/4150 train_time:19776ms step_avg:67.50ms
+step:294/4150 train_time:19841ms step_avg:67.49ms
+step:295/4150 train_time:19910ms step_avg:67.49ms
+step:296/4150 train_time:19975ms step_avg:67.48ms
+step:297/4150 train_time:20044ms step_avg:67.49ms
+step:298/4150 train_time:20109ms step_avg:67.48ms
+step:299/4150 train_time:20178ms step_avg:67.49ms
+step:300/4150 train_time:20243ms step_avg:67.48ms
+step:301/4150 train_time:20311ms step_avg:67.48ms
+step:302/4150 train_time:20376ms step_avg:67.47ms
+step:303/4150 train_time:20445ms step_avg:67.48ms
+step:304/4150 train_time:20510ms step_avg:67.47ms
+step:305/4150 train_time:20579ms step_avg:67.47ms
+step:306/4150 train_time:20644ms step_avg:67.46ms
+step:307/4150 train_time:20714ms step_avg:67.47ms
+step:308/4150 train_time:20779ms step_avg:67.46ms
+step:309/4150 train_time:20848ms step_avg:67.47ms
+step:310/4150 train_time:20913ms step_avg:67.46ms
+step:311/4150 train_time:20983ms step_avg:67.47ms
+step:312/4150 train_time:21048ms step_avg:67.46ms
+step:313/4150 train_time:21117ms step_avg:67.47ms
+step:314/4150 train_time:21182ms step_avg:67.46ms
+step:315/4150 train_time:21252ms step_avg:67.47ms
+step:316/4150 train_time:21317ms step_avg:67.46ms
+step:317/4150 train_time:21386ms step_avg:67.46ms
+step:318/4150 train_time:21451ms step_avg:67.46ms
+step:319/4150 train_time:21520ms step_avg:67.46ms
+step:320/4150 train_time:21585ms step_avg:67.45ms
+step:321/4150 train_time:21655ms step_avg:67.46ms
+step:322/4150 train_time:21720ms step_avg:67.45ms
+step:323/4150 train_time:21789ms step_avg:67.46ms
+step:324/4150 train_time:21853ms step_avg:67.45ms
+step:325/4150 train_time:21923ms step_avg:67.45ms
+step:326/4150 train_time:21988ms step_avg:67.45ms
+step:327/4150 train_time:22057ms step_avg:67.45ms
+step:328/4150 train_time:22122ms step_avg:67.45ms
+step:329/4150 train_time:22192ms step_avg:67.45ms
+step:330/4150 train_time:22257ms step_avg:67.45ms
+step:331/4150 train_time:22326ms step_avg:67.45ms
+step:332/4150 train_time:22392ms step_avg:67.45ms
+step:333/4150 train_time:22461ms step_avg:67.45ms
+step:334/4150 train_time:22525ms step_avg:67.44ms
+step:335/4150 train_time:22595ms step_avg:67.45ms
+step:336/4150 train_time:22659ms step_avg:67.44ms
+step:337/4150 train_time:22728ms step_avg:67.44ms
+step:338/4150 train_time:22793ms step_avg:67.44ms
+step:339/4150 train_time:22863ms step_avg:67.44ms
+step:340/4150 train_time:22928ms step_avg:67.44ms
+step:341/4150 train_time:22997ms step_avg:67.44ms
+step:342/4150 train_time:23062ms step_avg:67.43ms
+step:343/4150 train_time:23131ms step_avg:67.44ms
+step:344/4150 train_time:23196ms step_avg:67.43ms
+step:345/4150 train_time:23271ms step_avg:67.45ms
+step:346/4150 train_time:23392ms step_avg:67.61ms
+step:347/4150 train_time:23514ms step_avg:67.76ms
+step:348/4150 train_time:23635ms step_avg:67.92ms
+step:349/4150 train_time:23757ms step_avg:68.07ms
+step:350/4150 train_time:23877ms step_avg:68.22ms
+step:351/4150 train_time:23999ms step_avg:68.37ms
+step:352/4150 train_time:24121ms step_avg:68.53ms
+step:353/4150 train_time:24243ms step_avg:68.68ms
+step:354/4150 train_time:24364ms step_avg:68.83ms
+step:355/4150 train_time:24487ms step_avg:68.98ms
+step:356/4150 train_time:24608ms step_avg:69.12ms
+step:357/4150 train_time:24730ms step_avg:69.27ms
+step:358/4150 train_time:24852ms step_avg:69.42ms
+step:359/4150 train_time:24973ms step_avg:69.56ms
+step:360/4150 train_time:25094ms step_avg:69.71ms
+step:361/4150 train_time:25216ms step_avg:69.85ms
+step:362/4150 train_time:25336ms step_avg:69.99ms
+step:363/4150 train_time:25457ms step_avg:70.13ms
+step:364/4150 train_time:25577ms step_avg:70.27ms
+step:365/4150 train_time:25699ms step_avg:70.41ms
+step:366/4150 train_time:25819ms step_avg:70.54ms
+step:367/4150 train_time:25942ms step_avg:70.69ms
+step:368/4150 train_time:26062ms step_avg:70.82ms
+step:369/4150 train_time:26186ms step_avg:70.97ms
+step:370/4150 train_time:26308ms step_avg:71.10ms
+step:371/4150 train_time:26431ms step_avg:71.24ms
+step:372/4150 train_time:26553ms step_avg:71.38ms
+step:373/4150 train_time:26675ms step_avg:71.52ms
+step:374/4150 train_time:26796ms step_avg:71.65ms
+step:375/4150 train_time:26917ms step_avg:71.78ms
+step:376/4150 train_time:27036ms step_avg:71.90ms
+step:377/4150 train_time:27158ms step_avg:72.04ms
+step:378/4150 train_time:27279ms step_avg:72.17ms
+step:379/4150 train_time:27401ms step_avg:72.30ms
+step:380/4150 train_time:27522ms step_avg:72.43ms
+step:381/4150 train_time:27643ms step_avg:72.55ms
+step:382/4150 train_time:27765ms step_avg:72.68ms
+step:383/4150 train_time:27888ms step_avg:72.81ms
+step:384/4150 train_time:28009ms step_avg:72.94ms
+step:385/4150 train_time:28131ms step_avg:73.07ms
+step:386/4150 train_time:28250ms step_avg:73.19ms
+step:387/4150 train_time:28374ms step_avg:73.32ms
+step:388/4150 train_time:28494ms step_avg:73.44ms
+step:389/4150 train_time:28617ms step_avg:73.56ms
+step:390/4150 train_time:28737ms step_avg:73.68ms
+step:391/4150 train_time:28859ms step_avg:73.81ms
+step:392/4150 train_time:28978ms step_avg:73.92ms
+step:393/4150 train_time:29100ms step_avg:74.05ms
+step:394/4150 train_time:29221ms step_avg:74.16ms
+step:395/4150 train_time:29342ms step_avg:74.28ms
+step:396/4150 train_time:29463ms step_avg:74.40ms
+step:397/4150 train_time:29587ms step_avg:74.53ms
+step:398/4150 train_time:29709ms step_avg:74.65ms
+step:399/4150 train_time:29831ms step_avg:74.77ms
+step:400/4150 train_time:29952ms step_avg:74.88ms
+step:401/4150 train_time:30073ms step_avg:74.99ms
+step:402/4150 train_time:30194ms step_avg:75.11ms
+step:403/4150 train_time:30315ms step_avg:75.22ms
+step:404/4150 train_time:30435ms step_avg:75.33ms
+step:405/4150 train_time:30557ms step_avg:75.45ms
+step:406/4150 train_time:30677ms step_avg:75.56ms
+step:407/4150 train_time:30799ms step_avg:75.67ms
+step:408/4150 train_time:30918ms step_avg:75.78ms
+step:409/4150 train_time:31041ms step_avg:75.89ms
+step:410/4150 train_time:31161ms step_avg:76.00ms
+step:411/4150 train_time:31284ms step_avg:76.12ms
+step:412/4150 train_time:31404ms step_avg:76.22ms
+step:413/4150 train_time:31527ms step_avg:76.34ms
+step:414/4150 train_time:31649ms step_avg:76.45ms
+step:415/4150 train_time:31771ms step_avg:76.56ms
+step:416/4150 train_time:31891ms step_avg:76.66ms
+step:417/4150 train_time:32013ms step_avg:76.77ms
+step:418/4150 train_time:32133ms step_avg:76.87ms
+step:419/4150 train_time:32254ms step_avg:76.98ms
+step:420/4150 train_time:32373ms step_avg:77.08ms
+step:421/4150 train_time:32495ms step_avg:77.18ms
+step:422/4150 train_time:32615ms step_avg:77.29ms
+step:423/4150 train_time:32738ms step_avg:77.39ms
+step:424/4150 train_time:32858ms step_avg:77.49ms
+step:425/4150 train_time:32979ms step_avg:77.60ms
+step:426/4150 train_time:33101ms step_avg:77.70ms
+step:427/4150 train_time:33223ms step_avg:77.81ms
+step:428/4150 train_time:33343ms step_avg:77.90ms
+step:429/4150 train_time:33464ms step_avg:78.01ms
+step:430/4150 train_time:33585ms step_avg:78.11ms
+step:431/4150 train_time:33708ms step_avg:78.21ms
+step:432/4150 train_time:33829ms step_avg:78.31ms
+step:433/4150 train_time:33953ms step_avg:78.41ms
+step:434/4150 train_time:34072ms step_avg:78.51ms
+step:435/4150 train_time:34195ms step_avg:78.61ms
+step:436/4150 train_time:34315ms step_avg:78.70ms
+step:437/4150 train_time:34437ms step_avg:78.80ms
+step:438/4150 train_time:34555ms step_avg:78.89ms
+step:439/4150 train_time:34677ms step_avg:78.99ms
+step:440/4150 train_time:34797ms step_avg:79.08ms
+step:441/4150 train_time:34919ms step_avg:79.18ms
+step:442/4150 train_time:35040ms step_avg:79.27ms
+step:443/4150 train_time:35162ms step_avg:79.37ms
+step:444/4150 train_time:35283ms step_avg:79.47ms
+step:445/4150 train_time:35403ms step_avg:79.56ms
+step:446/4150 train_time:35523ms step_avg:79.65ms
+step:447/4150 train_time:35645ms step_avg:79.74ms
+step:448/4150 train_time:35766ms step_avg:79.83ms
+step:449/4150 train_time:35890ms step_avg:79.93ms
+step:450/4150 train_time:36011ms step_avg:80.02ms
+step:451/4150 train_time:36134ms step_avg:80.12ms
+step:452/4150 train_time:36253ms step_avg:80.21ms
+step:453/4150 train_time:36375ms step_avg:80.30ms
+step:454/4150 train_time:36495ms step_avg:80.39ms
+step:455/4150 train_time:36617ms step_avg:80.48ms
+step:456/4150 train_time:36737ms step_avg:80.56ms
+step:457/4150 train_time:36859ms step_avg:80.65ms
+step:458/4150 train_time:36979ms step_avg:80.74ms
+step:459/4150 train_time:37101ms step_avg:80.83ms
+step:460/4150 train_time:37222ms step_avg:80.92ms
+step:461/4150 train_time:37344ms step_avg:81.01ms
+step:462/4150 train_time:37465ms step_avg:81.09ms
+step:463/4150 train_time:37587ms step_avg:81.18ms
+step:464/4150 train_time:37708ms step_avg:81.27ms
+step:465/4150 train_time:37830ms step_avg:81.36ms
+step:466/4150 train_time:37951ms step_avg:81.44ms
+step:467/4150 train_time:38075ms step_avg:81.53ms
+step:468/4150 train_time:38196ms step_avg:81.62ms
+step:469/4150 train_time:38318ms step_avg:81.70ms
+step:470/4150 train_time:38437ms step_avg:81.78ms
+step:471/4150 train_time:38558ms step_avg:81.86ms
+step:472/4150 train_time:38677ms step_avg:81.94ms
+step:473/4150 train_time:38799ms step_avg:82.03ms
+step:474/4150 train_time:38921ms step_avg:82.11ms
+step:475/4150 train_time:39042ms step_avg:82.19ms
+step:476/4150 train_time:39163ms step_avg:82.28ms
+step:477/4150 train_time:39285ms step_avg:82.36ms
+step:478/4150 train_time:39406ms step_avg:82.44ms
+step:479/4150 train_time:39528ms step_avg:82.52ms
+step:480/4150 train_time:39648ms step_avg:82.60ms
+step:481/4150 train_time:39771ms step_avg:82.68ms
+step:482/4150 train_time:39890ms step_avg:82.76ms
+step:483/4150 train_time:40013ms step_avg:82.84ms
+step:484/4150 train_time:40132ms step_avg:82.92ms
+step:485/4150 train_time:40253ms step_avg:83.00ms
+step:486/4150 train_time:40374ms step_avg:83.07ms
+step:487/4150 train_time:40496ms step_avg:83.15ms
+step:488/4150 train_time:40616ms step_avg:83.23ms
+step:489/4150 train_time:40737ms step_avg:83.31ms
+step:490/4150 train_time:40856ms step_avg:83.38ms
+step:491/4150 train_time:40977ms step_avg:83.46ms
+step:492/4150 train_time:41098ms step_avg:83.53ms
+step:493/4150 train_time:41219ms step_avg:83.61ms
+step:494/4150 train_time:41339ms step_avg:83.68ms
+step:495/4150 train_time:41462ms step_avg:83.76ms
+step:496/4150 train_time:41582ms step_avg:83.83ms
+step:497/4150 train_time:41704ms step_avg:83.91ms
+step:498/4150 train_time:41825ms step_avg:83.99ms
+step:499/4150 train_time:41948ms step_avg:84.06ms
+step:500/4150 train_time:42068ms step_avg:84.14ms
+step:500/4150 val_loss:3.9186 train_time:42180ms step_avg:84.36ms
+step:501/4150 train_time:42201ms step_avg:84.23ms
+step:502/4150 train_time:42311ms step_avg:84.28ms
+step:503/4150 train_time:42436ms step_avg:84.37ms
+step:504/4150 train_time:42559ms step_avg:84.44ms
+step:505/4150 train_time:42681ms step_avg:84.52ms
+step:506/4150 train_time:42801ms step_avg:84.59ms
+step:507/4150 train_time:42922ms step_avg:84.66ms
+step:508/4150 train_time:43042ms step_avg:84.73ms
+step:509/4150 train_time:43166ms step_avg:84.80ms
+step:510/4150 train_time:43285ms step_avg:84.87ms
+step:511/4150 train_time:43408ms step_avg:84.95ms
+step:512/4150 train_time:43529ms step_avg:85.02ms
+step:513/4150 train_time:43652ms step_avg:85.09ms
+step:514/4150 train_time:43772ms step_avg:85.16ms
+step:515/4150 train_time:43892ms step_avg:85.23ms
+step:516/4150 train_time:44011ms step_avg:85.29ms
+step:517/4150 train_time:44133ms step_avg:85.36ms
+step:518/4150 train_time:44252ms step_avg:85.43ms
+step:519/4150 train_time:44375ms step_avg:85.50ms
+step:520/4150 train_time:44497ms step_avg:85.57ms
+step:521/4150 train_time:44620ms step_avg:85.64ms
+step:522/4150 train_time:44741ms step_avg:85.71ms
+step:523/4150 train_time:44863ms step_avg:85.78ms
+step:524/4150 train_time:44983ms step_avg:85.84ms
+step:525/4150 train_time:45105ms step_avg:85.91ms
+step:526/4150 train_time:45224ms step_avg:85.98ms
+step:527/4150 train_time:45346ms step_avg:86.05ms
+step:528/4150 train_time:45468ms step_avg:86.11ms
+step:529/4150 train_time:45591ms step_avg:86.18ms
+step:530/4150 train_time:45711ms step_avg:86.25ms
+step:531/4150 train_time:45834ms step_avg:86.32ms
+step:532/4150 train_time:45955ms step_avg:86.38ms
+step:533/4150 train_time:46077ms step_avg:86.45ms
+step:534/4150 train_time:46198ms step_avg:86.51ms
+step:535/4150 train_time:46322ms step_avg:86.58ms
+step:536/4150 train_time:46443ms step_avg:86.65ms
+step:537/4150 train_time:46567ms step_avg:86.72ms
+step:538/4150 train_time:46688ms step_avg:86.78ms
+step:539/4150 train_time:46811ms step_avg:86.85ms
+step:540/4150 train_time:46932ms step_avg:86.91ms
+step:541/4150 train_time:47053ms step_avg:86.97ms
+step:542/4150 train_time:47173ms step_avg:87.03ms
+step:543/4150 train_time:47295ms step_avg:87.10ms
+step:544/4150 train_time:47415ms step_avg:87.16ms
+step:545/4150 train_time:47537ms step_avg:87.22ms
+step:546/4150 train_time:47660ms step_avg:87.29ms
+step:547/4150 train_time:47783ms step_avg:87.35ms
+step:548/4150 train_time:47903ms step_avg:87.41ms
+step:549/4150 train_time:48025ms step_avg:87.48ms
+step:550/4150 train_time:48145ms step_avg:87.54ms
+step:551/4150 train_time:48269ms step_avg:87.60ms
+step:552/4150 train_time:48388ms step_avg:87.66ms
+step:553/4150 train_time:48511ms step_avg:87.72ms
+step:554/4150 train_time:48631ms step_avg:87.78ms
+step:555/4150 train_time:48753ms step_avg:87.84ms
+step:556/4150 train_time:48875ms step_avg:87.90ms
+step:557/4150 train_time:48996ms step_avg:87.96ms
+step:558/4150 train_time:49117ms step_avg:88.02ms
+step:559/4150 train_time:49239ms step_avg:88.08ms
+step:560/4150 train_time:49361ms step_avg:88.14ms
+step:561/4150 train_time:49484ms step_avg:88.21ms
+step:562/4150 train_time:49604ms step_avg:88.26ms
+step:563/4150 train_time:49727ms step_avg:88.32ms
+step:564/4150 train_time:49847ms step_avg:88.38ms
+step:565/4150 train_time:49970ms step_avg:88.44ms
+step:566/4150 train_time:50089ms step_avg:88.50ms
+step:567/4150 train_time:50211ms step_avg:88.56ms
+step:568/4150 train_time:50332ms step_avg:88.61ms
+step:569/4150 train_time:50454ms step_avg:88.67ms
+step:570/4150 train_time:50574ms step_avg:88.73ms
+step:571/4150 train_time:50696ms step_avg:88.78ms
+step:572/4150 train_time:50816ms step_avg:88.84ms
+step:573/4150 train_time:50938ms step_avg:88.90ms
+step:574/4150 train_time:51060ms step_avg:88.95ms
+step:575/4150 train_time:51182ms step_avg:89.01ms
+step:576/4150 train_time:51302ms step_avg:89.07ms
+step:577/4150 train_time:51423ms step_avg:89.12ms
+step:578/4150 train_time:51544ms step_avg:89.18ms
+step:579/4150 train_time:51666ms step_avg:89.23ms
+step:580/4150 train_time:51787ms step_avg:89.29ms
+step:581/4150 train_time:51909ms step_avg:89.34ms
+step:582/4150 train_time:52030ms step_avg:89.40ms
+step:583/4150 train_time:52152ms step_avg:89.45ms
+step:584/4150 train_time:52271ms step_avg:89.51ms
+step:585/4150 train_time:52392ms step_avg:89.56ms
+step:586/4150 train_time:52512ms step_avg:89.61ms
+step:587/4150 train_time:52635ms step_avg:89.67ms
+step:588/4150 train_time:52755ms step_avg:89.72ms
+step:589/4150 train_time:52877ms step_avg:89.77ms
+step:590/4150 train_time:52997ms step_avg:89.83ms
+step:591/4150 train_time:53120ms step_avg:89.88ms
+step:592/4150 train_time:53242ms step_avg:89.94ms
+step:593/4150 train_time:53364ms step_avg:89.99ms
+step:594/4150 train_time:53484ms step_avg:90.04ms
+step:595/4150 train_time:53605ms step_avg:90.09ms
+step:596/4150 train_time:53726ms step_avg:90.14ms
+step:597/4150 train_time:53849ms step_avg:90.20ms
+step:598/4150 train_time:53969ms step_avg:90.25ms
+step:599/4150 train_time:54090ms step_avg:90.30ms
+step:600/4150 train_time:54209ms step_avg:90.35ms
+step:601/4150 train_time:54331ms step_avg:90.40ms
+step:602/4150 train_time:54452ms step_avg:90.45ms
+step:603/4150 train_time:54574ms step_avg:90.50ms
+step:604/4150 train_time:54694ms step_avg:90.55ms
+step:605/4150 train_time:54816ms step_avg:90.61ms
+step:606/4150 train_time:54937ms step_avg:90.66ms
+step:607/4150 train_time:55060ms step_avg:90.71ms
+step:608/4150 train_time:55181ms step_avg:90.76ms
+step:609/4150 train_time:55303ms step_avg:90.81ms
+step:610/4150 train_time:55425ms step_avg:90.86ms
+step:611/4150 train_time:55548ms step_avg:90.91ms
+step:612/4150 train_time:55667ms step_avg:90.96ms
+step:613/4150 train_time:55788ms step_avg:91.01ms
+step:614/4150 train_time:55907ms step_avg:91.05ms
+step:615/4150 train_time:56029ms step_avg:91.10ms
+step:616/4150 train_time:56149ms step_avg:91.15ms
+step:617/4150 train_time:56271ms step_avg:91.20ms
+step:618/4150 train_time:56391ms step_avg:91.25ms
+step:619/4150 train_time:56514ms step_avg:91.30ms
+step:620/4150 train_time:56635ms step_avg:91.35ms
+step:621/4150 train_time:56758ms step_avg:91.40ms
+step:622/4150 train_time:56879ms step_avg:91.45ms
+step:623/4150 train_time:57000ms step_avg:91.49ms
+step:624/4150 train_time:57121ms step_avg:91.54ms
+step:625/4150 train_time:57244ms step_avg:91.59ms
+step:626/4150 train_time:57365ms step_avg:91.64ms
+step:627/4150 train_time:57488ms step_avg:91.69ms
+step:628/4150 train_time:57607ms step_avg:91.73ms
+step:629/4150 train_time:57731ms step_avg:91.78ms
+step:630/4150 train_time:57851ms step_avg:91.83ms
+step:631/4150 train_time:57971ms step_avg:91.87ms
+step:632/4150 train_time:58092ms step_avg:91.92ms
+step:633/4150 train_time:58215ms step_avg:91.97ms
+step:634/4150 train_time:58337ms step_avg:92.01ms
+step:635/4150 train_time:58460ms step_avg:92.06ms
+step:636/4150 train_time:58580ms step_avg:92.11ms
+step:637/4150 train_time:58702ms step_avg:92.15ms
+step:638/4150 train_time:58823ms step_avg:92.20ms
+step:639/4150 train_time:58946ms step_avg:92.25ms
+step:640/4150 train_time:59066ms step_avg:92.29ms
+step:641/4150 train_time:59187ms step_avg:92.33ms
+step:642/4150 train_time:59306ms step_avg:92.38ms
+step:643/4150 train_time:59428ms step_avg:92.42ms
+step:644/4150 train_time:59549ms step_avg:92.47ms
+step:645/4150 train_time:59671ms step_avg:92.51ms
+step:646/4150 train_time:59791ms step_avg:92.56ms
+step:647/4150 train_time:59913ms step_avg:92.60ms
+step:648/4150 train_time:60034ms step_avg:92.65ms
+step:649/4150 train_time:60155ms step_avg:92.69ms
+step:650/4150 train_time:60277ms step_avg:92.73ms
+step:651/4150 train_time:60400ms step_avg:92.78ms
+step:652/4150 train_time:60522ms step_avg:92.82ms
+step:653/4150 train_time:60645ms step_avg:92.87ms
+step:654/4150 train_time:60766ms step_avg:92.91ms
+step:655/4150 train_time:60887ms step_avg:92.96ms
+step:656/4150 train_time:61007ms step_avg:93.00ms
+step:657/4150 train_time:61129ms step_avg:93.04ms
+step:658/4150 train_time:61249ms step_avg:93.08ms
+step:659/4150 train_time:61370ms step_avg:93.13ms
+step:660/4150 train_time:61490ms step_avg:93.17ms
+step:661/4150 train_time:61612ms step_avg:93.21ms
+step:662/4150 train_time:61731ms step_avg:93.25ms
+step:663/4150 train_time:61853ms step_avg:93.29ms
+step:664/4150 train_time:61973ms step_avg:93.33ms
+step:665/4150 train_time:62094ms step_avg:93.37ms
+step:666/4150 train_time:62213ms step_avg:93.41ms
+step:667/4150 train_time:62336ms step_avg:93.46ms
+step:668/4150 train_time:62456ms step_avg:93.50ms
+step:669/4150 train_time:62579ms step_avg:93.54ms
+step:670/4150 train_time:62700ms step_avg:93.58ms
+step:671/4150 train_time:62822ms step_avg:93.62ms
+step:672/4150 train_time:62942ms step_avg:93.66ms
+step:673/4150 train_time:63065ms step_avg:93.71ms
+step:674/4150 train_time:63186ms step_avg:93.75ms
+step:675/4150 train_time:63309ms step_avg:93.79ms
+step:676/4150 train_time:63430ms step_avg:93.83ms
+step:677/4150 train_time:63551ms step_avg:93.87ms
+step:678/4150 train_time:63671ms step_avg:93.91ms
+step:679/4150 train_time:63793ms step_avg:93.95ms
+step:680/4150 train_time:63913ms step_avg:93.99ms
+step:681/4150 train_time:64035ms step_avg:94.03ms
+step:682/4150 train_time:64155ms step_avg:94.07ms
+step:683/4150 train_time:64278ms step_avg:94.11ms
+step:684/4150 train_time:64399ms step_avg:94.15ms
+step:685/4150 train_time:64521ms step_avg:94.19ms
+step:686/4150 train_time:64642ms step_avg:94.23ms
+step:687/4150 train_time:64765ms step_avg:94.27ms
+step:688/4150 train_time:64885ms step_avg:94.31ms
+step:689/4150 train_time:65012ms step_avg:94.36ms
+step:690/4150 train_time:65191ms step_avg:94.48ms
+step:691/4150 train_time:65370ms step_avg:94.60ms
+step:692/4150 train_time:65549ms step_avg:94.72ms
+step:693/4150 train_time:65729ms step_avg:94.85ms
+step:694/4150 train_time:65908ms step_avg:94.97ms
+step:695/4150 train_time:66088ms step_avg:95.09ms
+step:696/4150 train_time:66266ms step_avg:95.21ms
+step:697/4150 train_time:66446ms step_avg:95.33ms
+step:698/4150 train_time:66627ms step_avg:95.45ms
+step:699/4150 train_time:66807ms step_avg:95.58ms
+step:700/4150 train_time:66988ms step_avg:95.70ms
+step:701/4150 train_time:67169ms step_avg:95.82ms
+step:702/4150 train_time:67348ms step_avg:95.94ms
+step:703/4150 train_time:67526ms step_avg:96.05ms
+step:704/4150 train_time:67707ms step_avg:96.17ms
+step:705/4150 train_time:67885ms step_avg:96.29ms
+step:706/4150 train_time:68065ms step_avg:96.41ms
+step:707/4150 train_time:68245ms step_avg:96.53ms
+step:708/4150 train_time:68424ms step_avg:96.64ms
+step:709/4150 train_time:68602ms step_avg:96.76ms
+step:710/4150 train_time:68780ms step_avg:96.87ms
+step:711/4150 train_time:68958ms step_avg:96.99ms
+step:712/4150 train_time:69139ms step_avg:97.10ms
+step:713/4150 train_time:69317ms step_avg:97.22ms
+step:714/4150 train_time:69498ms step_avg:97.34ms
+step:715/4150 train_time:69678ms step_avg:97.45ms
+step:716/4150 train_time:69857ms step_avg:97.57ms
+step:717/4150 train_time:70034ms step_avg:97.68ms
+step:718/4150 train_time:70215ms step_avg:97.79ms
+step:719/4150 train_time:70393ms step_avg:97.90ms
+step:720/4150 train_time:70573ms step_avg:98.02ms
+step:721/4150 train_time:70751ms step_avg:98.13ms
+step:722/4150 train_time:70930ms step_avg:98.24ms
+step:723/4150 train_time:71112ms step_avg:98.36ms
+step:724/4150 train_time:71290ms step_avg:98.47ms
+step:725/4150 train_time:71469ms step_avg:98.58ms
+step:726/4150 train_time:71650ms step_avg:98.69ms
+step:727/4150 train_time:71828ms step_avg:98.80ms
+step:728/4150 train_time:72008ms step_avg:98.91ms
+step:729/4150 train_time:72188ms step_avg:99.02ms
+step:730/4150 train_time:72368ms step_avg:99.13ms
+step:731/4150 train_time:72547ms step_avg:99.24ms
+step:732/4150 train_time:72726ms step_avg:99.35ms
+step:733/4150 train_time:72905ms step_avg:99.46ms
+step:734/4150 train_time:73084ms step_avg:99.57ms
+step:735/4150 train_time:73262ms step_avg:99.68ms
+step:736/4150 train_time:73443ms step_avg:99.79ms
+step:737/4150 train_time:73625ms step_avg:99.90ms
+step:738/4150 train_time:73807ms step_avg:100.01ms
+step:739/4150 train_time:73987ms step_avg:100.12ms
+step:740/4150 train_time:74167ms step_avg:100.23ms
+step:741/4150 train_time:74345ms step_avg:100.33ms
+step:742/4150 train_time:74525ms step_avg:100.44ms
+step:743/4150 train_time:74704ms step_avg:100.54ms
+step:744/4150 train_time:74886ms step_avg:100.65ms
+step:745/4150 train_time:75064ms step_avg:100.76ms
+step:746/4150 train_time:75245ms step_avg:100.86ms
+step:747/4150 train_time:75422ms step_avg:100.97ms
+step:748/4150 train_time:75604ms step_avg:101.07ms
+step:749/4150 train_time:75784ms step_avg:101.18ms
+step:750/4150 train_time:75965ms step_avg:101.29ms
+step:750/4150 val_loss:3.5620 train_time:76128ms step_avg:101.50ms
+step:751/4150 train_time:76150ms step_avg:101.40ms
+step:752/4150 train_time:76325ms step_avg:101.50ms
+step:753/4150 train_time:76512ms step_avg:101.61ms
+step:754/4150 train_time:76692ms step_avg:101.71ms
+step:755/4150 train_time:76869ms step_avg:101.81ms
+step:756/4150 train_time:77045ms step_avg:101.91ms
+step:757/4150 train_time:77222ms step_avg:102.01ms
+step:758/4150 train_time:77406ms step_avg:102.12ms
+step:759/4150 train_time:77587ms step_avg:102.22ms
+step:760/4150 train_time:77766ms step_avg:102.32ms
+step:761/4150 train_time:77944ms step_avg:102.42ms
+step:762/4150 train_time:78122ms step_avg:102.52ms
+step:763/4150 train_time:78300ms step_avg:102.62ms
+step:764/4150 train_time:78482ms step_avg:102.73ms
+step:765/4150 train_time:78664ms step_avg:102.83ms
+step:766/4150 train_time:78845ms step_avg:102.93ms
+step:767/4150 train_time:79024ms step_avg:103.03ms
+step:768/4150 train_time:79202ms step_avg:103.13ms
+step:769/4150 train_time:79380ms step_avg:103.23ms
+step:770/4150 train_time:79563ms step_avg:103.33ms
+step:771/4150 train_time:79742ms step_avg:103.43ms
+step:772/4150 train_time:79924ms step_avg:103.53ms
+step:773/4150 train_time:80102ms step_avg:103.63ms
+step:774/4150 train_time:80279ms step_avg:103.72ms
+step:775/4150 train_time:80456ms step_avg:103.81ms
+step:776/4150 train_time:80637ms step_avg:103.91ms
+step:777/4150 train_time:80816ms step_avg:104.01ms
+step:778/4150 train_time:80996ms step_avg:104.11ms
+step:779/4150 train_time:81175ms step_avg:104.20ms
+step:780/4150 train_time:81352ms step_avg:104.30ms
+step:781/4150 train_time:81529ms step_avg:104.39ms
+step:782/4150 train_time:81710ms step_avg:104.49ms
+step:783/4150 train_time:81891ms step_avg:104.59ms
+step:784/4150 train_time:82072ms step_avg:104.68ms
+step:785/4150 train_time:82251ms step_avg:104.78ms
+step:786/4150 train_time:82431ms step_avg:104.87ms
+step:787/4150 train_time:82608ms step_avg:104.97ms
+step:788/4150 train_time:82791ms step_avg:105.07ms
+step:789/4150 train_time:82970ms step_avg:105.16ms
+step:790/4150 train_time:83152ms step_avg:105.26ms
+step:791/4150 train_time:83329ms step_avg:105.35ms
+step:792/4150 train_time:83509ms step_avg:105.44ms
+step:793/4150 train_time:83688ms step_avg:105.53ms
+step:794/4150 train_time:83870ms step_avg:105.63ms
+step:795/4150 train_time:84050ms step_avg:105.72ms
+step:796/4150 train_time:84230ms step_avg:105.82ms
+step:797/4150 train_time:84407ms step_avg:105.91ms
+step:798/4150 train_time:84589ms step_avg:106.00ms
+step:799/4150 train_time:84768ms step_avg:106.09ms
+step:800/4150 train_time:84947ms step_avg:106.18ms
+step:801/4150 train_time:85126ms step_avg:106.28ms
+step:802/4150 train_time:85307ms step_avg:106.37ms
+step:803/4150 train_time:85486ms step_avg:106.46ms
+step:804/4150 train_time:85666ms step_avg:106.55ms
+step:805/4150 train_time:85846ms step_avg:106.64ms
+step:806/4150 train_time:86027ms step_avg:106.73ms
+step:807/4150 train_time:86207ms step_avg:106.82ms
+step:808/4150 train_time:86387ms step_avg:106.91ms
+step:809/4150 train_time:86565ms step_avg:107.00ms
+step:810/4150 train_time:86745ms step_avg:107.09ms
+step:811/4150 train_time:86924ms step_avg:107.18ms
+step:812/4150 train_time:87106ms step_avg:107.27ms
+step:813/4150 train_time:87286ms step_avg:107.36ms
+step:814/4150 train_time:87464ms step_avg:107.45ms
+step:815/4150 train_time:87642ms step_avg:107.54ms
+step:816/4150 train_time:87823ms step_avg:107.63ms
+step:817/4150 train_time:88001ms step_avg:107.71ms
+step:818/4150 train_time:88182ms step_avg:107.80ms
+step:819/4150 train_time:88360ms step_avg:107.89ms
+step:820/4150 train_time:88538ms step_avg:107.97ms
+step:821/4150 train_time:88717ms step_avg:108.06ms
+step:822/4150 train_time:88896ms step_avg:108.15ms
+step:823/4150 train_time:89075ms step_avg:108.23ms
+step:824/4150 train_time:89256ms step_avg:108.32ms
+step:825/4150 train_time:89433ms step_avg:108.40ms
+step:826/4150 train_time:89613ms step_avg:108.49ms
+step:827/4150 train_time:89790ms step_avg:108.57ms
+step:828/4150 train_time:89971ms step_avg:108.66ms
+step:829/4150 train_time:90150ms step_avg:108.74ms
+step:830/4150 train_time:90330ms step_avg:108.83ms
+step:831/4150 train_time:90508ms step_avg:108.91ms
+step:832/4150 train_time:90686ms step_avg:109.00ms
+step:833/4150 train_time:90863ms step_avg:109.08ms
+step:834/4150 train_time:91044ms step_avg:109.17ms
+step:835/4150 train_time:91222ms step_avg:109.25ms
+step:836/4150 train_time:91405ms step_avg:109.34ms
+step:837/4150 train_time:91583ms step_avg:109.42ms
+step:838/4150 train_time:91762ms step_avg:109.50ms
+step:839/4150 train_time:91941ms step_avg:109.58ms
+step:840/4150 train_time:92123ms step_avg:109.67ms
+step:841/4150 train_time:92301ms step_avg:109.75ms
+step:842/4150 train_time:92482ms step_avg:109.84ms
+step:843/4150 train_time:92661ms step_avg:109.92ms
+step:844/4150 train_time:92840ms step_avg:110.00ms
+step:845/4150 train_time:93020ms step_avg:110.08ms
+step:846/4150 train_time:93200ms step_avg:110.17ms
+step:847/4150 train_time:93381ms step_avg:110.25ms
+step:848/4150 train_time:93563ms step_avg:110.33ms
+step:849/4150 train_time:93742ms step_avg:110.41ms
+step:850/4150 train_time:93922ms step_avg:110.50ms
+step:851/4150 train_time:94101ms step_avg:110.58ms
+step:852/4150 train_time:94283ms step_avg:110.66ms
+step:853/4150 train_time:94460ms step_avg:110.74ms
+step:854/4150 train_time:94640ms step_avg:110.82ms
+step:855/4150 train_time:94819ms step_avg:110.90ms
+step:856/4150 train_time:95000ms step_avg:110.98ms
+step:857/4150 train_time:95178ms step_avg:111.06ms
+step:858/4150 train_time:95358ms step_avg:111.14ms
+step:859/4150 train_time:95535ms step_avg:111.22ms
+step:860/4150 train_time:95717ms step_avg:111.30ms
+step:861/4150 train_time:95895ms step_avg:111.38ms
+step:862/4150 train_time:96074ms step_avg:111.46ms
+step:863/4150 train_time:96253ms step_avg:111.53ms
+step:864/4150 train_time:96431ms step_avg:111.61ms
+step:865/4150 train_time:96609ms step_avg:111.69ms
+step:866/4150 train_time:96789ms step_avg:111.77ms
+step:867/4150 train_time:96969ms step_avg:111.84ms
+step:868/4150 train_time:97150ms step_avg:111.92ms
+step:869/4150 train_time:97330ms step_avg:112.00ms
+step:870/4150 train_time:97511ms step_avg:112.08ms
+step:871/4150 train_time:97692ms step_avg:112.16ms
+step:872/4150 train_time:97871ms step_avg:112.24ms
+step:873/4150 train_time:98050ms step_avg:112.31ms
+step:874/4150 train_time:98233ms step_avg:112.39ms
+step:875/4150 train_time:98413ms step_avg:112.47ms
+step:876/4150 train_time:98591ms step_avg:112.55ms
+step:877/4150 train_time:98770ms step_avg:112.62ms
+step:878/4150 train_time:98951ms step_avg:112.70ms
+step:879/4150 train_time:99128ms step_avg:112.77ms
+step:880/4150 train_time:99309ms step_avg:112.85ms
+step:881/4150 train_time:99488ms step_avg:112.93ms
+step:882/4150 train_time:99667ms step_avg:113.00ms
+step:883/4150 train_time:99846ms step_avg:113.08ms
+step:884/4150 train_time:100027ms step_avg:113.15ms
+step:885/4150 train_time:100206ms step_avg:113.23ms
+step:886/4150 train_time:100388ms step_avg:113.30ms
+step:887/4150 train_time:100566ms step_avg:113.38ms
+step:888/4150 train_time:100747ms step_avg:113.45ms
+step:889/4150 train_time:100925ms step_avg:113.53ms
+step:890/4150 train_time:101106ms step_avg:113.60ms
+step:891/4150 train_time:101287ms step_avg:113.68ms
+step:892/4150 train_time:101468ms step_avg:113.75ms
+step:893/4150 train_time:101647ms step_avg:113.83ms
+step:894/4150 train_time:101826ms step_avg:113.90ms
+step:895/4150 train_time:102004ms step_avg:113.97ms
+step:896/4150 train_time:102185ms step_avg:114.05ms
+step:897/4150 train_time:102364ms step_avg:114.12ms
+step:898/4150 train_time:102544ms step_avg:114.19ms
+step:899/4150 train_time:102723ms step_avg:114.26ms
+step:900/4150 train_time:102903ms step_avg:114.34ms
+step:901/4150 train_time:103081ms step_avg:114.41ms
+step:902/4150 train_time:103261ms step_avg:114.48ms
+step:903/4150 train_time:103439ms step_avg:114.55ms
+step:904/4150 train_time:103618ms step_avg:114.62ms
+step:905/4150 train_time:103797ms step_avg:114.69ms
+step:906/4150 train_time:103979ms step_avg:114.77ms
+step:907/4150 train_time:104155ms step_avg:114.83ms
+step:908/4150 train_time:104335ms step_avg:114.91ms
+step:909/4150 train_time:104513ms step_avg:114.98ms
+step:910/4150 train_time:104692ms step_avg:115.05ms
+step:911/4150 train_time:104869ms step_avg:115.11ms
+step:912/4150 train_time:105050ms step_avg:115.19ms
+step:913/4150 train_time:105229ms step_avg:115.26ms
+step:914/4150 train_time:105410ms step_avg:115.33ms
+step:915/4150 train_time:105586ms step_avg:115.39ms
+step:916/4150 train_time:105766ms step_avg:115.47ms
+step:917/4150 train_time:105945ms step_avg:115.53ms
+step:918/4150 train_time:106126ms step_avg:115.61ms
+step:919/4150 train_time:106307ms step_avg:115.68ms
+step:920/4150 train_time:106485ms step_avg:115.74ms
+step:921/4150 train_time:106665ms step_avg:115.81ms
+step:922/4150 train_time:106847ms step_avg:115.89ms
+step:923/4150 train_time:107025ms step_avg:115.95ms
+step:924/4150 train_time:107206ms step_avg:116.02ms
+step:925/4150 train_time:107386ms step_avg:116.09ms
+step:926/4150 train_time:107564ms step_avg:116.16ms
+step:927/4150 train_time:107742ms step_avg:116.23ms
+step:928/4150 train_time:107923ms step_avg:116.30ms
+step:929/4150 train_time:108102ms step_avg:116.36ms
+step:930/4150 train_time:108284ms step_avg:116.43ms
+step:931/4150 train_time:108463ms step_avg:116.50ms
+step:932/4150 train_time:108643ms step_avg:116.57ms
+step:933/4150 train_time:108822ms step_avg:116.64ms
+step:934/4150 train_time:109001ms step_avg:116.70ms
+step:935/4150 train_time:109181ms step_avg:116.77ms
+step:936/4150 train_time:109361ms step_avg:116.84ms
+step:937/4150 train_time:109540ms step_avg:116.91ms
+step:938/4150 train_time:109720ms step_avg:116.97ms
+step:939/4150 train_time:109898ms step_avg:117.04ms
+step:940/4150 train_time:110078ms step_avg:117.10ms
+step:941/4150 train_time:110255ms step_avg:117.17ms
+step:942/4150 train_time:110434ms step_avg:117.23ms
+step:943/4150 train_time:110612ms step_avg:117.30ms
+step:944/4150 train_time:110791ms step_avg:117.36ms
+step:945/4150 train_time:110969ms step_avg:117.43ms
+step:946/4150 train_time:111149ms step_avg:117.49ms
+step:947/4150 train_time:111330ms step_avg:117.56ms
+step:948/4150 train_time:111508ms step_avg:117.62ms
+step:949/4150 train_time:111687ms step_avg:117.69ms
+step:950/4150 train_time:111866ms step_avg:117.75ms
+step:951/4150 train_time:112046ms step_avg:117.82ms
+step:952/4150 train_time:112227ms step_avg:117.89ms
+step:953/4150 train_time:112408ms step_avg:117.95ms
+step:954/4150 train_time:112586ms step_avg:118.01ms
+step:955/4150 train_time:112763ms step_avg:118.08ms
+step:956/4150 train_time:112944ms step_avg:118.14ms
+step:957/4150 train_time:113122ms step_avg:118.21ms
+step:958/4150 train_time:113306ms step_avg:118.27ms
+step:959/4150 train_time:113486ms step_avg:118.34ms
+step:960/4150 train_time:113666ms step_avg:118.40ms
+step:961/4150 train_time:113845ms step_avg:118.46ms
+step:962/4150 train_time:114025ms step_avg:118.53ms
+step:963/4150 train_time:114204ms step_avg:118.59ms
+step:964/4150 train_time:114386ms step_avg:118.66ms
+step:965/4150 train_time:114566ms step_avg:118.72ms
+step:966/4150 train_time:114746ms step_avg:118.78ms
+step:967/4150 train_time:114924ms step_avg:118.85ms
+step:968/4150 train_time:115104ms step_avg:118.91ms
+step:969/4150 train_time:115284ms step_avg:118.97ms
+step:970/4150 train_time:115464ms step_avg:119.04ms
+step:971/4150 train_time:115642ms step_avg:119.10ms
+step:972/4150 train_time:115822ms step_avg:119.16ms
+step:973/4150 train_time:116001ms step_avg:119.22ms
+step:974/4150 train_time:116182ms step_avg:119.28ms
+step:975/4150 train_time:116361ms step_avg:119.35ms
+step:976/4150 train_time:116543ms step_avg:119.41ms
+step:977/4150 train_time:116722ms step_avg:119.47ms
+step:978/4150 train_time:116903ms step_avg:119.53ms
+step:979/4150 train_time:117081ms step_avg:119.59ms
+step:980/4150 train_time:117264ms step_avg:119.66ms
+step:981/4150 train_time:117445ms step_avg:119.72ms
+step:982/4150 train_time:117624ms step_avg:119.78ms
+step:983/4150 train_time:117802ms step_avg:119.84ms
+step:984/4150 train_time:117980ms step_avg:119.90ms
+step:985/4150 train_time:118160ms step_avg:119.96ms
+step:986/4150 train_time:118339ms step_avg:120.02ms
+step:987/4150 train_time:118518ms step_avg:120.08ms
+step:988/4150 train_time:118698ms step_avg:120.14ms
+step:989/4150 train_time:118875ms step_avg:120.20ms
+step:990/4150 train_time:119054ms step_avg:120.26ms
+step:991/4150 train_time:119233ms step_avg:120.32ms
+step:992/4150 train_time:119414ms step_avg:120.38ms
+step:993/4150 train_time:119593ms step_avg:120.44ms
+step:994/4150 train_time:119771ms step_avg:120.49ms
+step:995/4150 train_time:119950ms step_avg:120.55ms
+step:996/4150 train_time:120130ms step_avg:120.61ms
+step:997/4150 train_time:120309ms step_avg:120.67ms
+step:998/4150 train_time:120488ms step_avg:120.73ms
+step:999/4150 train_time:120667ms step_avg:120.79ms
+step:1000/4150 train_time:120846ms step_avg:120.85ms
+step:1000/4150 val_loss:3.4385 train_time:121011ms step_avg:121.01ms
+step:1001/4150 train_time:121032ms step_avg:120.91ms
+step:1002/4150 train_time:121204ms step_avg:120.96ms
+step:1003/4150 train_time:121385ms step_avg:121.02ms
+step:1004/4150 train_time:121563ms step_avg:121.08ms
+step:1005/4150 train_time:121741ms step_avg:121.14ms
+step:1006/4150 train_time:121919ms step_avg:121.19ms
+step:1007/4150 train_time:122100ms step_avg:121.25ms
+step:1008/4150 train_time:122281ms step_avg:121.31ms
+step:1009/4150 train_time:122462ms step_avg:121.37ms
+step:1010/4150 train_time:122641ms step_avg:121.43ms
+step:1011/4150 train_time:122819ms step_avg:121.48ms
+step:1012/4150 train_time:122998ms step_avg:121.54ms
+step:1013/4150 train_time:123178ms step_avg:121.60ms
+step:1014/4150 train_time:123361ms step_avg:121.66ms
+step:1015/4150 train_time:123540ms step_avg:121.71ms
+step:1016/4150 train_time:123719ms step_avg:121.77ms
+step:1017/4150 train_time:123896ms step_avg:121.83ms
+step:1018/4150 train_time:124076ms step_avg:121.88ms
+step:1019/4150 train_time:124256ms step_avg:121.94ms
+step:1020/4150 train_time:124438ms step_avg:122.00ms
+step:1021/4150 train_time:124617ms step_avg:122.05ms
+step:1022/4150 train_time:124799ms step_avg:122.11ms
+step:1023/4150 train_time:124978ms step_avg:122.17ms
+step:1024/4150 train_time:125158ms step_avg:122.22ms
+step:1025/4150 train_time:125338ms step_avg:122.28ms
+step:1026/4150 train_time:125521ms step_avg:122.34ms
+step:1027/4150 train_time:125699ms step_avg:122.39ms
+step:1028/4150 train_time:125880ms step_avg:122.45ms
+step:1029/4150 train_time:126059ms step_avg:122.51ms
+step:1030/4150 train_time:126240ms step_avg:122.56ms
+step:1031/4150 train_time:126419ms step_avg:122.62ms
+step:1032/4150 train_time:126600ms step_avg:122.67ms
+step:1033/4150 train_time:126783ms step_avg:122.73ms
+step:1034/4150 train_time:127017ms step_avg:122.84ms
+step:1035/4150 train_time:127253ms step_avg:122.95ms
+step:1036/4150 train_time:127488ms step_avg:123.06ms
+step:1037/4150 train_time:127721ms step_avg:123.16ms
+step:1038/4150 train_time:127955ms step_avg:123.27ms
+step:1039/4150 train_time:128185ms step_avg:123.37ms
+step:1040/4150 train_time:128420ms step_avg:123.48ms
+step:1041/4150 train_time:128652ms step_avg:123.58ms
+step:1042/4150 train_time:128886ms step_avg:123.69ms
+step:1043/4150 train_time:129118ms step_avg:123.79ms
+step:1044/4150 train_time:129356ms step_avg:123.90ms
+step:1045/4150 train_time:129585ms step_avg:124.00ms
+step:1046/4150 train_time:129820ms step_avg:124.11ms
+step:1047/4150 train_time:130055ms step_avg:124.22ms
+step:1048/4150 train_time:130291ms step_avg:124.32ms
+step:1049/4150 train_time:130524ms step_avg:124.43ms
+step:1050/4150 train_time:130762ms step_avg:124.53ms
+step:1051/4150 train_time:130998ms step_avg:124.64ms
+step:1052/4150 train_time:131233ms step_avg:124.75ms
+step:1053/4150 train_time:131463ms step_avg:124.85ms
+step:1054/4150 train_time:131698ms step_avg:124.95ms
+step:1055/4150 train_time:131930ms step_avg:125.05ms
+step:1056/4150 train_time:132166ms step_avg:125.16ms
+step:1057/4150 train_time:132396ms step_avg:125.26ms
+step:1058/4150 train_time:132628ms step_avg:125.36ms
+step:1059/4150 train_time:132861ms step_avg:125.46ms
+step:1060/4150 train_time:133097ms step_avg:125.56ms
+step:1061/4150 train_time:133327ms step_avg:125.66ms
+step:1062/4150 train_time:133562ms step_avg:125.76ms
+step:1063/4150 train_time:133793ms step_avg:125.86ms
+step:1064/4150 train_time:134030ms step_avg:125.97ms
+step:1065/4150 train_time:134260ms step_avg:126.07ms
+step:1066/4150 train_time:134496ms step_avg:126.17ms
+step:1067/4150 train_time:134727ms step_avg:126.27ms
+step:1068/4150 train_time:134962ms step_avg:126.37ms
+step:1069/4150 train_time:135194ms step_avg:126.47ms
+step:1070/4150 train_time:135430ms step_avg:126.57ms
+step:1071/4150 train_time:135663ms step_avg:126.67ms
+step:1072/4150 train_time:135897ms step_avg:126.77ms
+step:1073/4150 train_time:136128ms step_avg:126.87ms
+step:1074/4150 train_time:136363ms step_avg:126.97ms
+step:1075/4150 train_time:136596ms step_avg:127.07ms
+step:1076/4150 train_time:136832ms step_avg:127.17ms
+step:1077/4150 train_time:137064ms step_avg:127.26ms
+step:1078/4150 train_time:137298ms step_avg:127.36ms
+step:1079/4150 train_time:137528ms step_avg:127.46ms
+step:1080/4150 train_time:137763ms step_avg:127.56ms
+step:1081/4150 train_time:137996ms step_avg:127.66ms
+step:1082/4150 train_time:138230ms step_avg:127.75ms
+step:1083/4150 train_time:138463ms step_avg:127.85ms
+step:1084/4150 train_time:138697ms step_avg:127.95ms
+step:1085/4150 train_time:138928ms step_avg:128.04ms
+step:1086/4150 train_time:139165ms step_avg:128.14ms
+step:1087/4150 train_time:139399ms step_avg:128.24ms
+step:1088/4150 train_time:139633ms step_avg:128.34ms
+step:1089/4150 train_time:139865ms step_avg:128.43ms
+step:1090/4150 train_time:140097ms step_avg:128.53ms
+step:1091/4150 train_time:140328ms step_avg:128.62ms
+step:1092/4150 train_time:140564ms step_avg:128.72ms
+step:1093/4150 train_time:140798ms step_avg:128.82ms
+step:1094/4150 train_time:141033ms step_avg:128.92ms
+step:1095/4150 train_time:141265ms step_avg:129.01ms
+step:1096/4150 train_time:141500ms step_avg:129.11ms
+step:1097/4150 train_time:141734ms step_avg:129.20ms
+step:1098/4150 train_time:141968ms step_avg:129.30ms
+step:1099/4150 train_time:142198ms step_avg:129.39ms
+step:1100/4150 train_time:142430ms step_avg:129.48ms
+step:1101/4150 train_time:142663ms step_avg:129.58ms
+step:1102/4150 train_time:142896ms step_avg:129.67ms
+step:1103/4150 train_time:143127ms step_avg:129.76ms
+step:1104/4150 train_time:143362ms step_avg:129.86ms
+step:1105/4150 train_time:143593ms step_avg:129.95ms
+step:1106/4150 train_time:143827ms step_avg:130.04ms
+step:1107/4150 train_time:144059ms step_avg:130.13ms
+step:1108/4150 train_time:144294ms step_avg:130.23ms
+step:1109/4150 train_time:144527ms step_avg:130.32ms
+step:1110/4150 train_time:144763ms step_avg:130.42ms
+step:1111/4150 train_time:144994ms step_avg:130.51ms
+step:1112/4150 train_time:145228ms step_avg:130.60ms
+step:1113/4150 train_time:145459ms step_avg:130.69ms
+step:1114/4150 train_time:145694ms step_avg:130.78ms
+step:1115/4150 train_time:145925ms step_avg:130.87ms
+step:1116/4150 train_time:146161ms step_avg:130.97ms
+step:1117/4150 train_time:146394ms step_avg:131.06ms
+step:1118/4150 train_time:146630ms step_avg:131.15ms
+step:1119/4150 train_time:146863ms step_avg:131.24ms
+step:1120/4150 train_time:147098ms step_avg:131.34ms
+step:1121/4150 train_time:147328ms step_avg:131.43ms
+step:1122/4150 train_time:147562ms step_avg:131.52ms
+step:1123/4150 train_time:147795ms step_avg:131.61ms
+step:1124/4150 train_time:148032ms step_avg:131.70ms
+step:1125/4150 train_time:148264ms step_avg:131.79ms
+step:1126/4150 train_time:148498ms step_avg:131.88ms
+step:1127/4150 train_time:148730ms step_avg:131.97ms
+step:1128/4150 train_time:148966ms step_avg:132.06ms
+step:1129/4150 train_time:149198ms step_avg:132.15ms
+step:1130/4150 train_time:149435ms step_avg:132.24ms
+step:1131/4150 train_time:149666ms step_avg:132.33ms
+step:1132/4150 train_time:149901ms step_avg:132.42ms
+step:1133/4150 train_time:150133ms step_avg:132.51ms
+step:1134/4150 train_time:150366ms step_avg:132.60ms
+step:1135/4150 train_time:150597ms step_avg:132.68ms
+step:1136/4150 train_time:150833ms step_avg:132.78ms
+step:1137/4150 train_time:151065ms step_avg:132.86ms
+step:1138/4150 train_time:151299ms step_avg:132.95ms
+step:1139/4150 train_time:151530ms step_avg:133.04ms
+step:1140/4150 train_time:151765ms step_avg:133.13ms
+step:1141/4150 train_time:152000ms step_avg:133.22ms
+step:1142/4150 train_time:152234ms step_avg:133.30ms
+step:1143/4150 train_time:152467ms step_avg:133.39ms
+step:1144/4150 train_time:152701ms step_avg:133.48ms
+step:1145/4150 train_time:152935ms step_avg:133.57ms
+step:1146/4150 train_time:153172ms step_avg:133.66ms
+step:1147/4150 train_time:153401ms step_avg:133.74ms
+step:1148/4150 train_time:153637ms step_avg:133.83ms
+step:1149/4150 train_time:153867ms step_avg:133.91ms
+step:1150/4150 train_time:154103ms step_avg:134.00ms
+step:1151/4150 train_time:154334ms step_avg:134.09ms
+step:1152/4150 train_time:154566ms step_avg:134.17ms
+step:1153/4150 train_time:154799ms step_avg:134.26ms
+step:1154/4150 train_time:155038ms step_avg:134.35ms
+step:1155/4150 train_time:155268ms step_avg:134.43ms
+step:1156/4150 train_time:155501ms step_avg:134.52ms
+step:1157/4150 train_time:155735ms step_avg:134.60ms
+step:1158/4150 train_time:155968ms step_avg:134.69ms
+step:1159/4150 train_time:156199ms step_avg:134.77ms
+step:1160/4150 train_time:156434ms step_avg:134.86ms
+step:1161/4150 train_time:156665ms step_avg:134.94ms
+step:1162/4150 train_time:156900ms step_avg:135.03ms
+step:1163/4150 train_time:157131ms step_avg:135.11ms
+step:1164/4150 train_time:157365ms step_avg:135.19ms
+step:1165/4150 train_time:157597ms step_avg:135.28ms
+step:1166/4150 train_time:157833ms step_avg:135.36ms
+step:1167/4150 train_time:158065ms step_avg:135.45ms
+step:1168/4150 train_time:158298ms step_avg:135.53ms
+step:1169/4150 train_time:158527ms step_avg:135.61ms
+step:1170/4150 train_time:158761ms step_avg:135.69ms
+step:1171/4150 train_time:158994ms step_avg:135.78ms
+step:1172/4150 train_time:159230ms step_avg:135.86ms
+step:1173/4150 train_time:159463ms step_avg:135.94ms
+step:1174/4150 train_time:159697ms step_avg:136.03ms
+step:1175/4150 train_time:159927ms step_avg:136.11ms
+step:1176/4150 train_time:160162ms step_avg:136.19ms
+step:1177/4150 train_time:160396ms step_avg:136.27ms
+step:1178/4150 train_time:160633ms step_avg:136.36ms
+step:1179/4150 train_time:160864ms step_avg:136.44ms
+step:1180/4150 train_time:161100ms step_avg:136.53ms
+step:1181/4150 train_time:161332ms step_avg:136.61ms
+step:1182/4150 train_time:161568ms step_avg:136.69ms
+step:1183/4150 train_time:161800ms step_avg:136.77ms
+step:1184/4150 train_time:162036ms step_avg:136.85ms
+step:1185/4150 train_time:162266ms step_avg:136.93ms
+step:1186/4150 train_time:162500ms step_avg:137.02ms
+step:1187/4150 train_time:162731ms step_avg:137.09ms
+step:1188/4150 train_time:162964ms step_avg:137.18ms
+step:1189/4150 train_time:163197ms step_avg:137.26ms
+step:1190/4150 train_time:163432ms step_avg:137.34ms
+step:1191/4150 train_time:163663ms step_avg:137.42ms
+step:1192/4150 train_time:163899ms step_avg:137.50ms
+step:1193/4150 train_time:164129ms step_avg:137.58ms
+step:1194/4150 train_time:164363ms step_avg:137.66ms
+step:1195/4150 train_time:164596ms step_avg:137.74ms
+step:1196/4150 train_time:164832ms step_avg:137.82ms
+step:1197/4150 train_time:165063ms step_avg:137.90ms
+step:1198/4150 train_time:165297ms step_avg:137.98ms
+step:1199/4150 train_time:165527ms step_avg:138.05ms
+step:1200/4150 train_time:165762ms step_avg:138.13ms
+step:1201/4150 train_time:165994ms step_avg:138.21ms
+step:1202/4150 train_time:166228ms step_avg:138.29ms
+step:1203/4150 train_time:166459ms step_avg:138.37ms
+step:1204/4150 train_time:166697ms step_avg:138.45ms
+step:1205/4150 train_time:166932ms step_avg:138.53ms
+step:1206/4150 train_time:167167ms step_avg:138.61ms
+step:1207/4150 train_time:167398ms step_avg:138.69ms
+step:1208/4150 train_time:167635ms step_avg:138.77ms
+step:1209/4150 train_time:167867ms step_avg:138.85ms
+step:1210/4150 train_time:168102ms step_avg:138.93ms
+step:1211/4150 train_time:168333ms step_avg:139.00ms
+step:1212/4150 train_time:168567ms step_avg:139.08ms
+step:1213/4150 train_time:168800ms step_avg:139.16ms
+step:1214/4150 train_time:169035ms step_avg:139.24ms
+step:1215/4150 train_time:169266ms step_avg:139.31ms
+step:1216/4150 train_time:169499ms step_avg:139.39ms
+step:1217/4150 train_time:169731ms step_avg:139.47ms
+step:1218/4150 train_time:169963ms step_avg:139.54ms
+step:1219/4150 train_time:170197ms step_avg:139.62ms
+step:1220/4150 train_time:170431ms step_avg:139.70ms
+step:1221/4150 train_time:170662ms step_avg:139.77ms
+step:1222/4150 train_time:170895ms step_avg:139.85ms
+step:1223/4150 train_time:171126ms step_avg:139.92ms
+step:1224/4150 train_time:171362ms step_avg:140.00ms
+step:1225/4150 train_time:171594ms step_avg:140.08ms
+step:1226/4150 train_time:171826ms step_avg:140.15ms
+step:1227/4150 train_time:172059ms step_avg:140.23ms
+step:1228/4150 train_time:172293ms step_avg:140.30ms
+step:1229/4150 train_time:172526ms step_avg:140.38ms
+step:1230/4150 train_time:172762ms step_avg:140.46ms
+step:1231/4150 train_time:172994ms step_avg:140.53ms
+step:1232/4150 train_time:173228ms step_avg:140.61ms
+step:1233/4150 train_time:173460ms step_avg:140.68ms
+step:1234/4150 train_time:173697ms step_avg:140.76ms
+step:1235/4150 train_time:173929ms step_avg:140.83ms
+step:1236/4150 train_time:174164ms step_avg:140.91ms
+step:1237/4150 train_time:174400ms step_avg:140.99ms
+step:1238/4150 train_time:174635ms step_avg:141.06ms
+step:1239/4150 train_time:174865ms step_avg:141.13ms
+step:1240/4150 train_time:175098ms step_avg:141.21ms
+step:1241/4150 train_time:175329ms step_avg:141.28ms
+step:1242/4150 train_time:175563ms step_avg:141.36ms
+step:1243/4150 train_time:175795ms step_avg:141.43ms
+step:1244/4150 train_time:176031ms step_avg:141.50ms
+step:1245/4150 train_time:176261ms step_avg:141.58ms
+step:1246/4150 train_time:176497ms step_avg:141.65ms
+step:1247/4150 train_time:176727ms step_avg:141.72ms
+step:1248/4150 train_time:176963ms step_avg:141.80ms
+step:1249/4150 train_time:177195ms step_avg:141.87ms
+step:1250/4150 train_time:177429ms step_avg:141.94ms
+step:1250/4150 val_loss:3.3560 train_time:177642ms step_avg:142.11ms
+step:1251/4150 train_time:177665ms step_avg:142.02ms
+step:1252/4150 train_time:177900ms step_avg:142.09ms
+step:1253/4150 train_time:178132ms step_avg:142.16ms
+step:1254/4150 train_time:178366ms step_avg:142.24ms
+step:1255/4150 train_time:178596ms step_avg:142.31ms
+step:1256/4150 train_time:178832ms step_avg:142.38ms
+step:1257/4150 train_time:179066ms step_avg:142.45ms
+step:1258/4150 train_time:179296ms step_avg:142.52ms
+step:1259/4150 train_time:179525ms step_avg:142.59ms
+step:1260/4150 train_time:179758ms step_avg:142.66ms
+step:1261/4150 train_time:179993ms step_avg:142.74ms
+step:1262/4150 train_time:180229ms step_avg:142.81ms
+step:1263/4150 train_time:180456ms step_avg:142.88ms
+step:1264/4150 train_time:180689ms step_avg:142.95ms
+step:1265/4150 train_time:180920ms step_avg:143.02ms
+step:1266/4150 train_time:181156ms step_avg:143.09ms
+step:1267/4150 train_time:181387ms step_avg:143.16ms
+step:1268/4150 train_time:181619ms step_avg:143.23ms
+step:1269/4150 train_time:181854ms step_avg:143.31ms
+step:1270/4150 train_time:182091ms step_avg:143.38ms
+step:1271/4150 train_time:182323ms step_avg:143.45ms
+step:1272/4150 train_time:182556ms step_avg:143.52ms
+step:1273/4150 train_time:182789ms step_avg:143.59ms
+step:1274/4150 train_time:183023ms step_avg:143.66ms
+step:1275/4150 train_time:183254ms step_avg:143.73ms
+step:1276/4150 train_time:183490ms step_avg:143.80ms
+step:1277/4150 train_time:183718ms step_avg:143.87ms
+step:1278/4150 train_time:183952ms step_avg:143.94ms
+step:1279/4150 train_time:184184ms step_avg:144.01ms
+step:1280/4150 train_time:184418ms step_avg:144.08ms
+step:1281/4150 train_time:184650ms step_avg:144.14ms
+step:1282/4150 train_time:184883ms step_avg:144.21ms
+step:1283/4150 train_time:185115ms step_avg:144.28ms
+step:1284/4150 train_time:185353ms step_avg:144.36ms
+step:1285/4150 train_time:185585ms step_avg:144.42ms
+step:1286/4150 train_time:185818ms step_avg:144.49ms
+step:1287/4150 train_time:186050ms step_avg:144.56ms
+step:1288/4150 train_time:186287ms step_avg:144.63ms
+step:1289/4150 train_time:186518ms step_avg:144.70ms
+step:1290/4150 train_time:186751ms step_avg:144.77ms
+step:1291/4150 train_time:186984ms step_avg:144.84ms
+step:1292/4150 train_time:187215ms step_avg:144.90ms
+step:1293/4150 train_time:187445ms step_avg:144.97ms
+step:1294/4150 train_time:187681ms step_avg:145.04ms
+step:1295/4150 train_time:187913ms step_avg:145.11ms
+step:1296/4150 train_time:188147ms step_avg:145.18ms
+step:1297/4150 train_time:188378ms step_avg:145.24ms
+step:1298/4150 train_time:188614ms step_avg:145.31ms
+step:1299/4150 train_time:188845ms step_avg:145.38ms
+step:1300/4150 train_time:189080ms step_avg:145.45ms
+step:1301/4150 train_time:189312ms step_avg:145.51ms
+step:1302/4150 train_time:189546ms step_avg:145.58ms
+step:1303/4150 train_time:189779ms step_avg:145.65ms
+step:1304/4150 train_time:190013ms step_avg:145.72ms
+step:1305/4150 train_time:190247ms step_avg:145.78ms
+step:1306/4150 train_time:190481ms step_avg:145.85ms
+step:1307/4150 train_time:190711ms step_avg:145.91ms
+step:1308/4150 train_time:190947ms step_avg:145.98ms
+step:1309/4150 train_time:191179ms step_avg:146.05ms
+step:1310/4150 train_time:191413ms step_avg:146.12ms
+step:1311/4150 train_time:191646ms step_avg:146.18ms
+step:1312/4150 train_time:191882ms step_avg:146.25ms
+step:1313/4150 train_time:192113ms step_avg:146.32ms
+step:1314/4150 train_time:192347ms step_avg:146.38ms
+step:1315/4150 train_time:192577ms step_avg:146.45ms
+step:1316/4150 train_time:192810ms step_avg:146.51ms
+step:1317/4150 train_time:193040ms step_avg:146.58ms
+step:1318/4150 train_time:193276ms step_avg:146.64ms
+step:1319/4150 train_time:193505ms step_avg:146.71ms
+step:1320/4150 train_time:193742ms step_avg:146.77ms
+step:1321/4150 train_time:193975ms step_avg:146.84ms
+step:1322/4150 train_time:194206ms step_avg:146.90ms
+step:1323/4150 train_time:194437ms step_avg:146.97ms
+step:1324/4150 train_time:194672ms step_avg:147.03ms
+step:1325/4150 train_time:194906ms step_avg:147.10ms
+step:1326/4150 train_time:195139ms step_avg:147.16ms
+step:1327/4150 train_time:195372ms step_avg:147.23ms
+step:1328/4150 train_time:195607ms step_avg:147.29ms
+step:1329/4150 train_time:195838ms step_avg:147.36ms
+step:1330/4150 train_time:196072ms step_avg:147.42ms
+step:1331/4150 train_time:196302ms step_avg:147.48ms
+step:1332/4150 train_time:196535ms step_avg:147.55ms
+step:1333/4150 train_time:196766ms step_avg:147.61ms
+step:1334/4150 train_time:197000ms step_avg:147.68ms
+step:1335/4150 train_time:197232ms step_avg:147.74ms
+step:1336/4150 train_time:197469ms step_avg:147.81ms
+step:1337/4150 train_time:197701ms step_avg:147.87ms
+step:1338/4150 train_time:197935ms step_avg:147.93ms
+step:1339/4150 train_time:198166ms step_avg:148.00ms
+step:1340/4150 train_time:198401ms step_avg:148.06ms
+step:1341/4150 train_time:198634ms step_avg:148.12ms
+step:1342/4150 train_time:198867ms step_avg:148.19ms
+step:1343/4150 train_time:199098ms step_avg:148.25ms
+step:1344/4150 train_time:199333ms step_avg:148.31ms
+step:1345/4150 train_time:199565ms step_avg:148.38ms
+step:1346/4150 train_time:199799ms step_avg:148.44ms
+step:1347/4150 train_time:200030ms step_avg:148.50ms
+step:1348/4150 train_time:200264ms step_avg:148.56ms
+step:1349/4150 train_time:200496ms step_avg:148.63ms
+step:1350/4150 train_time:200731ms step_avg:148.69ms
+step:1351/4150 train_time:200963ms step_avg:148.75ms
+step:1352/4150 train_time:201195ms step_avg:148.81ms
+step:1353/4150 train_time:201427ms step_avg:148.87ms
+step:1354/4150 train_time:201664ms step_avg:148.94ms
+step:1355/4150 train_time:201894ms step_avg:149.00ms
+step:1356/4150 train_time:202131ms step_avg:149.06ms
+step:1357/4150 train_time:202365ms step_avg:149.13ms
+step:1358/4150 train_time:202598ms step_avg:149.19ms
+step:1359/4150 train_time:202832ms step_avg:149.25ms
+step:1360/4150 train_time:203066ms step_avg:149.31ms
+step:1361/4150 train_time:203297ms step_avg:149.37ms
+step:1362/4150 train_time:203534ms step_avg:149.44ms
+step:1363/4150 train_time:203767ms step_avg:149.50ms
+step:1364/4150 train_time:204002ms step_avg:149.56ms
+step:1365/4150 train_time:204232ms step_avg:149.62ms
+step:1366/4150 train_time:204468ms step_avg:149.68ms
+step:1367/4150 train_time:204698ms step_avg:149.74ms
+step:1368/4150 train_time:204931ms step_avg:149.80ms
+step:1369/4150 train_time:205162ms step_avg:149.86ms
+step:1370/4150 train_time:205396ms step_avg:149.92ms
+step:1371/4150 train_time:205629ms step_avg:149.98ms
+step:1372/4150 train_time:205864ms step_avg:150.05ms
+step:1373/4150 train_time:206094ms step_avg:150.11ms
+step:1374/4150 train_time:206327ms step_avg:150.17ms
+step:1375/4150 train_time:206558ms step_avg:150.22ms
+step:1376/4150 train_time:206793ms step_avg:150.29ms
+step:1377/4150 train_time:207026ms step_avg:150.35ms
+step:1378/4150 train_time:207260ms step_avg:150.41ms
+step:1379/4150 train_time:207495ms step_avg:150.47ms
+step:1380/4150 train_time:207729ms step_avg:150.53ms
+step:1381/4150 train_time:207960ms step_avg:150.59ms
+step:1382/4150 train_time:208195ms step_avg:150.65ms
+step:1383/4150 train_time:208426ms step_avg:150.71ms
+step:1384/4150 train_time:208664ms step_avg:150.77ms
+step:1385/4150 train_time:208896ms step_avg:150.83ms
+step:1386/4150 train_time:209132ms step_avg:150.89ms
+step:1387/4150 train_time:209363ms step_avg:150.95ms
+step:1388/4150 train_time:209598ms step_avg:151.01ms
+step:1389/4150 train_time:209827ms step_avg:151.06ms
+step:1390/4150 train_time:210064ms step_avg:151.12ms
+step:1391/4150 train_time:210295ms step_avg:151.18ms
+step:1392/4150 train_time:210529ms step_avg:151.24ms
+step:1393/4150 train_time:210761ms step_avg:151.30ms
+step:1394/4150 train_time:210996ms step_avg:151.36ms
+step:1395/4150 train_time:211227ms step_avg:151.42ms
+step:1396/4150 train_time:211461ms step_avg:151.48ms
+step:1397/4150 train_time:211696ms step_avg:151.54ms
+step:1398/4150 train_time:211930ms step_avg:151.59ms
+step:1399/4150 train_time:212160ms step_avg:151.65ms
+step:1400/4150 train_time:212395ms step_avg:151.71ms
+step:1401/4150 train_time:212627ms step_avg:151.77ms
+step:1402/4150 train_time:212860ms step_avg:151.83ms
+step:1403/4150 train_time:213092ms step_avg:151.88ms
+step:1404/4150 train_time:213328ms step_avg:151.94ms
+step:1405/4150 train_time:213559ms step_avg:152.00ms
+step:1406/4150 train_time:213795ms step_avg:152.06ms
+step:1407/4150 train_time:214029ms step_avg:152.12ms
+step:1408/4150 train_time:214266ms step_avg:152.18ms
+step:1409/4150 train_time:214497ms step_avg:152.23ms
+step:1410/4150 train_time:214732ms step_avg:152.29ms
+step:1411/4150 train_time:214965ms step_avg:152.35ms
+step:1412/4150 train_time:215200ms step_avg:152.41ms
+step:1413/4150 train_time:215431ms step_avg:152.46ms
+step:1414/4150 train_time:215664ms step_avg:152.52ms
+step:1415/4150 train_time:215895ms step_avg:152.58ms
+step:1416/4150 train_time:216130ms step_avg:152.63ms
+step:1417/4150 train_time:216361ms step_avg:152.69ms
+step:1418/4150 train_time:216596ms step_avg:152.75ms
+step:1419/4150 train_time:216829ms step_avg:152.80ms
+step:1420/4150 train_time:217063ms step_avg:152.86ms
+step:1421/4150 train_time:217294ms step_avg:152.92ms
+step:1422/4150 train_time:217529ms step_avg:152.97ms
+step:1423/4150 train_time:217760ms step_avg:153.03ms
+step:1424/4150 train_time:217995ms step_avg:153.09ms
+step:1425/4150 train_time:218229ms step_avg:153.14ms
+step:1426/4150 train_time:218465ms step_avg:153.20ms
+step:1427/4150 train_time:218696ms step_avg:153.26ms
+step:1428/4150 train_time:218931ms step_avg:153.31ms
+step:1429/4150 train_time:219161ms step_avg:153.37ms
+step:1430/4150 train_time:219396ms step_avg:153.42ms
+step:1431/4150 train_time:219630ms step_avg:153.48ms
+step:1432/4150 train_time:219866ms step_avg:153.54ms
+step:1433/4150 train_time:220097ms step_avg:153.59ms
+step:1434/4150 train_time:220332ms step_avg:153.65ms
+step:1435/4150 train_time:220566ms step_avg:153.70ms
+step:1436/4150 train_time:220800ms step_avg:153.76ms
+step:1437/4150 train_time:221031ms step_avg:153.81ms
+step:1438/4150 train_time:221267ms step_avg:153.87ms
+step:1439/4150 train_time:221500ms step_avg:153.93ms
+step:1440/4150 train_time:221736ms step_avg:153.98ms
+step:1441/4150 train_time:221969ms step_avg:154.04ms
+step:1442/4150 train_time:222204ms step_avg:154.09ms
+step:1443/4150 train_time:222436ms step_avg:154.15ms
+step:1444/4150 train_time:222673ms step_avg:154.21ms
+step:1445/4150 train_time:222907ms step_avg:154.26ms
+step:1446/4150 train_time:223142ms step_avg:154.32ms
+step:1447/4150 train_time:223373ms step_avg:154.37ms
+step:1448/4150 train_time:223608ms step_avg:154.43ms
+step:1449/4150 train_time:223839ms step_avg:154.48ms
+step:1450/4150 train_time:224074ms step_avg:154.53ms
+step:1451/4150 train_time:224305ms step_avg:154.59ms
+step:1452/4150 train_time:224542ms step_avg:154.64ms
+step:1453/4150 train_time:224776ms step_avg:154.70ms
+step:1454/4150 train_time:225014ms step_avg:154.75ms
+step:1455/4150 train_time:225248ms step_avg:154.81ms
+step:1456/4150 train_time:225485ms step_avg:154.87ms
+step:1457/4150 train_time:225718ms step_avg:154.92ms
+step:1458/4150 train_time:225955ms step_avg:154.98ms
+step:1459/4150 train_time:226189ms step_avg:155.03ms
+step:1460/4150 train_time:226423ms step_avg:155.08ms
+step:1461/4150 train_time:226657ms step_avg:155.14ms
+step:1462/4150 train_time:226892ms step_avg:155.19ms
+step:1463/4150 train_time:227127ms step_avg:155.25ms
+step:1464/4150 train_time:227361ms step_avg:155.30ms
+step:1465/4150 train_time:227591ms step_avg:155.35ms
+step:1466/4150 train_time:227826ms step_avg:155.41ms
+step:1467/4150 train_time:228059ms step_avg:155.46ms
+step:1468/4150 train_time:228294ms step_avg:155.51ms
+step:1469/4150 train_time:228524ms step_avg:155.56ms
+step:1470/4150 train_time:228758ms step_avg:155.62ms
+step:1471/4150 train_time:228991ms step_avg:155.67ms
+step:1472/4150 train_time:229230ms step_avg:155.73ms
+step:1473/4150 train_time:229462ms step_avg:155.78ms
+step:1474/4150 train_time:229695ms step_avg:155.83ms
+step:1475/4150 train_time:229927ms step_avg:155.88ms
+step:1476/4150 train_time:230166ms step_avg:155.94ms
+step:1477/4150 train_time:230398ms step_avg:155.99ms
+step:1478/4150 train_time:230631ms step_avg:156.04ms
+step:1479/4150 train_time:230864ms step_avg:156.09ms
+step:1480/4150 train_time:231098ms step_avg:156.15ms
+step:1481/4150 train_time:231334ms step_avg:156.20ms
+step:1482/4150 train_time:231572ms step_avg:156.26ms
+step:1483/4150 train_time:231805ms step_avg:156.31ms
+step:1484/4150 train_time:232041ms step_avg:156.36ms
+step:1485/4150 train_time:232275ms step_avg:156.41ms
+step:1486/4150 train_time:232512ms step_avg:156.47ms
+step:1487/4150 train_time:232742ms step_avg:156.52ms
+step:1488/4150 train_time:232975ms step_avg:156.57ms
+step:1489/4150 train_time:233207ms step_avg:156.62ms
+step:1490/4150 train_time:233442ms step_avg:156.67ms
+step:1491/4150 train_time:233674ms step_avg:156.72ms
+step:1492/4150 train_time:233908ms step_avg:156.77ms
+step:1493/4150 train_time:234139ms step_avg:156.82ms
+step:1494/4150 train_time:234375ms step_avg:156.88ms
+step:1495/4150 train_time:234607ms step_avg:156.93ms
+step:1496/4150 train_time:234846ms step_avg:156.98ms
+step:1497/4150 train_time:235078ms step_avg:157.03ms
+step:1498/4150 train_time:235312ms step_avg:157.08ms
+step:1499/4150 train_time:235547ms step_avg:157.14ms
+step:1500/4150 train_time:235785ms step_avg:157.19ms
+step:1500/4150 val_loss:3.2818 train_time:235998ms step_avg:157.33ms
+step:1501/4150 train_time:236022ms step_avg:157.24ms
+step:1502/4150 train_time:236261ms step_avg:157.30ms
+step:1503/4150 train_time:236500ms step_avg:157.35ms
+step:1504/4150 train_time:236733ms step_avg:157.40ms
+step:1505/4150 train_time:236962ms step_avg:157.45ms
+step:1506/4150 train_time:237198ms step_avg:157.50ms
+step:1507/4150 train_time:237436ms step_avg:157.56ms
+step:1508/4150 train_time:237668ms step_avg:157.60ms
+step:1509/4150 train_time:237897ms step_avg:157.65ms
+step:1510/4150 train_time:238130ms step_avg:157.70ms
+step:1511/4150 train_time:238369ms step_avg:157.76ms
+step:1512/4150 train_time:238604ms step_avg:157.81ms
+step:1513/4150 train_time:238835ms step_avg:157.86ms
+step:1514/4150 train_time:239070ms step_avg:157.91ms
+step:1515/4150 train_time:239306ms step_avg:157.96ms
+step:1516/4150 train_time:239542ms step_avg:158.01ms
+step:1517/4150 train_time:239770ms step_avg:158.06ms
+step:1518/4150 train_time:240003ms step_avg:158.10ms
+step:1519/4150 train_time:240236ms step_avg:158.15ms
+step:1520/4150 train_time:240473ms step_avg:158.21ms
+step:1521/4150 train_time:240703ms step_avg:158.25ms
+step:1522/4150 train_time:240937ms step_avg:158.30ms
+step:1523/4150 train_time:241170ms step_avg:158.35ms
+step:1524/4150 train_time:241407ms step_avg:158.40ms
+step:1525/4150 train_time:241640ms step_avg:158.45ms
+step:1526/4150 train_time:241878ms step_avg:158.50ms
+step:1527/4150 train_time:242109ms step_avg:158.55ms
+step:1528/4150 train_time:242344ms step_avg:158.60ms
+step:1529/4150 train_time:242580ms step_avg:158.65ms
+step:1530/4150 train_time:242815ms step_avg:158.70ms
+step:1531/4150 train_time:243045ms step_avg:158.75ms
+step:1532/4150 train_time:243282ms step_avg:158.80ms
+step:1533/4150 train_time:243513ms step_avg:158.85ms
+step:1534/4150 train_time:243749ms step_avg:158.90ms
+step:1535/4150 train_time:243980ms step_avg:158.94ms
+step:1536/4150 train_time:244215ms step_avg:158.99ms
+step:1537/4150 train_time:244449ms step_avg:159.04ms
+step:1538/4150 train_time:244684ms step_avg:159.09ms
+step:1539/4150 train_time:244917ms step_avg:159.14ms
+step:1540/4150 train_time:245152ms step_avg:159.19ms
+step:1541/4150 train_time:245385ms step_avg:159.24ms
+step:1542/4150 train_time:245619ms step_avg:159.29ms
+step:1543/4150 train_time:245850ms step_avg:159.33ms
+step:1544/4150 train_time:246085ms step_avg:159.38ms
+step:1545/4150 train_time:246319ms step_avg:159.43ms
+step:1546/4150 train_time:246554ms step_avg:159.48ms
+step:1547/4150 train_time:246785ms step_avg:159.52ms
+step:1548/4150 train_time:247022ms step_avg:159.57ms
+step:1549/4150 train_time:247254ms step_avg:159.62ms
+step:1550/4150 train_time:247489ms step_avg:159.67ms
+step:1551/4150 train_time:247720ms step_avg:159.72ms
+step:1552/4150 train_time:247954ms step_avg:159.76ms
+step:1553/4150 train_time:248185ms step_avg:159.81ms
+step:1554/4150 train_time:248424ms step_avg:159.86ms
+step:1555/4150 train_time:248659ms step_avg:159.91ms
+step:1556/4150 train_time:248892ms step_avg:159.96ms
+step:1557/4150 train_time:249125ms step_avg:160.00ms
+step:1558/4150 train_time:249361ms step_avg:160.05ms
+step:1559/4150 train_time:249595ms step_avg:160.10ms
+step:1560/4150 train_time:249828ms step_avg:160.15ms
+step:1561/4150 train_time:250062ms step_avg:160.19ms
+step:1562/4150 train_time:250297ms step_avg:160.24ms
+step:1563/4150 train_time:250531ms step_avg:160.29ms
+step:1564/4150 train_time:250767ms step_avg:160.34ms
+step:1565/4150 train_time:251001ms step_avg:160.38ms
+step:1566/4150 train_time:251238ms step_avg:160.43ms
+step:1567/4150 train_time:251469ms step_avg:160.48ms
+step:1568/4150 train_time:251703ms step_avg:160.53ms
+step:1569/4150 train_time:251934ms step_avg:160.57ms
+step:1570/4150 train_time:252169ms step_avg:160.62ms
+step:1571/4150 train_time:252402ms step_avg:160.66ms
+step:1572/4150 train_time:252637ms step_avg:160.71ms
+step:1573/4150 train_time:252867ms step_avg:160.75ms
+step:1574/4150 train_time:253102ms step_avg:160.80ms
+step:1575/4150 train_time:253336ms step_avg:160.85ms
+step:1576/4150 train_time:253571ms step_avg:160.90ms
+step:1577/4150 train_time:253803ms step_avg:160.94ms
+step:1578/4150 train_time:254037ms step_avg:160.99ms
+step:1579/4150 train_time:254270ms step_avg:161.03ms
+step:1580/4150 train_time:254506ms step_avg:161.08ms
+step:1581/4150 train_time:254739ms step_avg:161.13ms
+step:1582/4150 train_time:254976ms step_avg:161.17ms
+step:1583/4150 train_time:255209ms step_avg:161.22ms
+step:1584/4150 train_time:255444ms step_avg:161.27ms
+step:1585/4150 train_time:255679ms step_avg:161.31ms
+step:1586/4150 train_time:255914ms step_avg:161.36ms
+step:1587/4150 train_time:256145ms step_avg:161.40ms
+step:1588/4150 train_time:256380ms step_avg:161.45ms
+step:1589/4150 train_time:256612ms step_avg:161.49ms
+step:1590/4150 train_time:256847ms step_avg:161.54ms
+step:1591/4150 train_time:257078ms step_avg:161.58ms
+step:1592/4150 train_time:257313ms step_avg:161.63ms
+step:1593/4150 train_time:257545ms step_avg:161.67ms
+step:1594/4150 train_time:257779ms step_avg:161.72ms
+step:1595/4150 train_time:258011ms step_avg:161.76ms
+step:1596/4150 train_time:258245ms step_avg:161.81ms
+step:1597/4150 train_time:258477ms step_avg:161.85ms
+step:1598/4150 train_time:258712ms step_avg:161.90ms
+step:1599/4150 train_time:258946ms step_avg:161.94ms
+step:1600/4150 train_time:259180ms step_avg:161.99ms
+step:1601/4150 train_time:259412ms step_avg:162.03ms
+step:1602/4150 train_time:259648ms step_avg:162.08ms
+step:1603/4150 train_time:259882ms step_avg:162.12ms
+step:1604/4150 train_time:260116ms step_avg:162.17ms
+step:1605/4150 train_time:260347ms step_avg:162.21ms
+step:1606/4150 train_time:260583ms step_avg:162.26ms
+step:1607/4150 train_time:260816ms step_avg:162.30ms
+step:1608/4150 train_time:261051ms step_avg:162.35ms
+step:1609/4150 train_time:261282ms step_avg:162.39ms
+step:1610/4150 train_time:261516ms step_avg:162.43ms
+step:1611/4150 train_time:261748ms step_avg:162.48ms
+step:1612/4150 train_time:261986ms step_avg:162.52ms
+step:1613/4150 train_time:262219ms step_avg:162.57ms
+step:1614/4150 train_time:262456ms step_avg:162.61ms
+step:1615/4150 train_time:262687ms step_avg:162.65ms
+step:1616/4150 train_time:262924ms step_avg:162.70ms
+step:1617/4150 train_time:263154ms step_avg:162.74ms
+step:1618/4150 train_time:263388ms step_avg:162.79ms
+step:1619/4150 train_time:263619ms step_avg:162.83ms
+step:1620/4150 train_time:263853ms step_avg:162.87ms
+step:1621/4150 train_time:264084ms step_avg:162.91ms
+step:1622/4150 train_time:264321ms step_avg:162.96ms
+step:1623/4150 train_time:264554ms step_avg:163.00ms
+step:1624/4150 train_time:264789ms step_avg:163.05ms
+step:1625/4150 train_time:265022ms step_avg:163.09ms
+step:1626/4150 train_time:265258ms step_avg:163.14ms
+step:1627/4150 train_time:265491ms step_avg:163.18ms
+step:1628/4150 train_time:265725ms step_avg:163.22ms
+step:1629/4150 train_time:265959ms step_avg:163.26ms
+step:1630/4150 train_time:266193ms step_avg:163.31ms
+step:1631/4150 train_time:266424ms step_avg:163.35ms
+step:1632/4150 train_time:266660ms step_avg:163.39ms
+step:1633/4150 train_time:266892ms step_avg:163.44ms
+step:1634/4150 train_time:267127ms step_avg:163.48ms
+step:1635/4150 train_time:267360ms step_avg:163.52ms
+step:1636/4150 train_time:267596ms step_avg:163.57ms
+step:1637/4150 train_time:267828ms step_avg:163.61ms
+step:1638/4150 train_time:268065ms step_avg:163.65ms
+step:1639/4150 train_time:268300ms step_avg:163.70ms
+step:1640/4150 train_time:268537ms step_avg:163.74ms
+step:1641/4150 train_time:268771ms step_avg:163.78ms
+step:1642/4150 train_time:269006ms step_avg:163.83ms
+step:1643/4150 train_time:269238ms step_avg:163.87ms
+step:1644/4150 train_time:269473ms step_avg:163.91ms
+step:1645/4150 train_time:269706ms step_avg:163.95ms
+step:1646/4150 train_time:269941ms step_avg:164.00ms
+step:1647/4150 train_time:270172ms step_avg:164.04ms
+step:1648/4150 train_time:270407ms step_avg:164.08ms
+step:1649/4150 train_time:270639ms step_avg:164.12ms
+step:1650/4150 train_time:270875ms step_avg:164.17ms
+step:1651/4150 train_time:271106ms step_avg:164.21ms
+step:1652/4150 train_time:271338ms step_avg:164.25ms
+step:1653/4150 train_time:271570ms step_avg:164.29ms
+step:1654/4150 train_time:271805ms step_avg:164.33ms
+step:1655/4150 train_time:272038ms step_avg:164.37ms
+step:1656/4150 train_time:272275ms step_avg:164.42ms
+step:1657/4150 train_time:272509ms step_avg:164.46ms
+step:1658/4150 train_time:272742ms step_avg:164.50ms
+step:1659/4150 train_time:272973ms step_avg:164.54ms
+step:1660/4150 train_time:273209ms step_avg:164.58ms
+step:1661/4150 train_time:273446ms step_avg:164.63ms
+step:1662/4150 train_time:273682ms step_avg:164.67ms
+step:1663/4150 train_time:273912ms step_avg:164.71ms
+step:1664/4150 train_time:274146ms step_avg:164.75ms
+step:1665/4150 train_time:274379ms step_avg:164.79ms
+step:1666/4150 train_time:274614ms step_avg:164.83ms
+step:1667/4150 train_time:274847ms step_avg:164.88ms
+step:1668/4150 train_time:275081ms step_avg:164.92ms
+step:1669/4150 train_time:275312ms step_avg:164.96ms
+step:1670/4150 train_time:275548ms step_avg:165.00ms
+step:1671/4150 train_time:275778ms step_avg:165.04ms
+step:1672/4150 train_time:276013ms step_avg:165.08ms
+step:1673/4150 train_time:276245ms step_avg:165.12ms
+step:1674/4150 train_time:276484ms step_avg:165.16ms
+step:1675/4150 train_time:276715ms step_avg:165.20ms
+step:1676/4150 train_time:276950ms step_avg:165.24ms
+step:1677/4150 train_time:277179ms step_avg:165.28ms
+step:1678/4150 train_time:277416ms step_avg:165.33ms
+step:1679/4150 train_time:277649ms step_avg:165.37ms
+step:1680/4150 train_time:277885ms step_avg:165.41ms
+step:1681/4150 train_time:278119ms step_avg:165.45ms
+step:1682/4150 train_time:278356ms step_avg:165.49ms
+step:1683/4150 train_time:278589ms step_avg:165.53ms
+step:1684/4150 train_time:278823ms step_avg:165.57ms
+step:1685/4150 train_time:279056ms step_avg:165.61ms
+step:1686/4150 train_time:279292ms step_avg:165.65ms
+step:1687/4150 train_time:279525ms step_avg:165.69ms
+step:1688/4150 train_time:279758ms step_avg:165.73ms
+step:1689/4150 train_time:279989ms step_avg:165.77ms
+step:1690/4150 train_time:280224ms step_avg:165.81ms
+step:1691/4150 train_time:280462ms step_avg:165.86ms
+step:1692/4150 train_time:280697ms step_avg:165.90ms
+step:1693/4150 train_time:280929ms step_avg:165.94ms
+step:1694/4150 train_time:281165ms step_avg:165.98ms
+step:1695/4150 train_time:281399ms step_avg:166.02ms
+step:1696/4150 train_time:281633ms step_avg:166.06ms
+step:1697/4150 train_time:281863ms step_avg:166.09ms
+step:1698/4150 train_time:282101ms step_avg:166.14ms
+step:1699/4150 train_time:282335ms step_avg:166.18ms
+step:1700/4150 train_time:282571ms step_avg:166.22ms
+step:1701/4150 train_time:282804ms step_avg:166.26ms
+step:1702/4150 train_time:283039ms step_avg:166.30ms
+step:1703/4150 train_time:283271ms step_avg:166.34ms
+step:1704/4150 train_time:283508ms step_avg:166.38ms
+step:1705/4150 train_time:283741ms step_avg:166.42ms
+step:1706/4150 train_time:283977ms step_avg:166.46ms
+step:1707/4150 train_time:284207ms step_avg:166.49ms
+step:1708/4150 train_time:284441ms step_avg:166.53ms
+step:1709/4150 train_time:284674ms step_avg:166.57ms
+step:1710/4150 train_time:284908ms step_avg:166.61ms
+step:1711/4150 train_time:285139ms step_avg:166.65ms
+step:1712/4150 train_time:285373ms step_avg:166.69ms
+step:1713/4150 train_time:285607ms step_avg:166.73ms
+step:1714/4150 train_time:285841ms step_avg:166.77ms
+step:1715/4150 train_time:286072ms step_avg:166.81ms
+step:1716/4150 train_time:286306ms step_avg:166.85ms
+step:1717/4150 train_time:286539ms step_avg:166.88ms
+step:1718/4150 train_time:286778ms step_avg:166.93ms
+step:1719/4150 train_time:287011ms step_avg:166.96ms
+step:1720/4150 train_time:287246ms step_avg:167.00ms
+step:1721/4150 train_time:287484ms step_avg:167.04ms
+step:1722/4150 train_time:287721ms step_avg:167.09ms
+step:1723/4150 train_time:287954ms step_avg:167.12ms
+step:1724/4150 train_time:288188ms step_avg:167.16ms
+step:1725/4150 train_time:288426ms step_avg:167.20ms
+step:1726/4150 train_time:288664ms step_avg:167.24ms
+step:1727/4150 train_time:288898ms step_avg:167.28ms
+step:1728/4150 train_time:289136ms step_avg:167.32ms
+step:1729/4150 train_time:289367ms step_avg:167.36ms
+step:1730/4150 train_time:289602ms step_avg:167.40ms
+step:1731/4150 train_time:289834ms step_avg:167.44ms
+step:1732/4150 train_time:290070ms step_avg:167.48ms
+step:1733/4150 train_time:290301ms step_avg:167.51ms
+step:1734/4150 train_time:290537ms step_avg:167.55ms
+step:1735/4150 train_time:290768ms step_avg:167.59ms
+step:1736/4150 train_time:291003ms step_avg:167.63ms
+step:1737/4150 train_time:291237ms step_avg:167.67ms
+step:1738/4150 train_time:291474ms step_avg:167.71ms
+step:1739/4150 train_time:291707ms step_avg:167.74ms
+step:1740/4150 train_time:291942ms step_avg:167.78ms
+step:1741/4150 train_time:292173ms step_avg:167.82ms
+step:1742/4150 train_time:292410ms step_avg:167.86ms
+step:1743/4150 train_time:292642ms step_avg:167.90ms
+step:1744/4150 train_time:292876ms step_avg:167.93ms
+step:1745/4150 train_time:293106ms step_avg:167.97ms
+step:1746/4150 train_time:293345ms step_avg:168.01ms
+step:1747/4150 train_time:293577ms step_avg:168.05ms
+step:1748/4150 train_time:293813ms step_avg:168.09ms
+step:1749/4150 train_time:294044ms step_avg:168.12ms
+step:1750/4150 train_time:294283ms step_avg:168.16ms
+step:1750/4150 val_loss:3.2283 train_time:294496ms step_avg:168.28ms
+step:1751/4150 train_time:294518ms step_avg:168.20ms
+step:1752/4150 train_time:294758ms step_avg:168.24ms
+step:1753/4150 train_time:294990ms step_avg:168.28ms
+step:1754/4150 train_time:295224ms step_avg:168.31ms
+step:1755/4150 train_time:295455ms step_avg:168.35ms
+step:1756/4150 train_time:295692ms step_avg:168.39ms
+step:1757/4150 train_time:295932ms step_avg:168.43ms
+step:1758/4150 train_time:296168ms step_avg:168.47ms
+step:1759/4150 train_time:296400ms step_avg:168.50ms
+step:1760/4150 train_time:296635ms step_avg:168.54ms
+step:1761/4150 train_time:296869ms step_avg:168.58ms
+step:1762/4150 train_time:297104ms step_avg:168.62ms
+step:1763/4150 train_time:297333ms step_avg:168.65ms
+step:1764/4150 train_time:297572ms step_avg:168.69ms
+step:1765/4150 train_time:297806ms step_avg:168.73ms
+step:1766/4150 train_time:298045ms step_avg:168.77ms
+step:1767/4150 train_time:298274ms step_avg:168.80ms
+step:1768/4150 train_time:298508ms step_avg:168.84ms
+step:1769/4150 train_time:298744ms step_avg:168.88ms
+step:1770/4150 train_time:298983ms step_avg:168.92ms
+step:1771/4150 train_time:299214ms step_avg:168.95ms
+step:1772/4150 train_time:299447ms step_avg:168.99ms
+step:1773/4150 train_time:299680ms step_avg:169.02ms
+step:1774/4150 train_time:299916ms step_avg:169.06ms
+step:1775/4150 train_time:300150ms step_avg:169.10ms
+step:1776/4150 train_time:300386ms step_avg:169.14ms
+step:1777/4150 train_time:300618ms step_avg:169.17ms
+step:1778/4150 train_time:300853ms step_avg:169.21ms
+step:1779/4150 train_time:301085ms step_avg:169.24ms
+step:1780/4150 train_time:301325ms step_avg:169.28ms
+step:1781/4150 train_time:301555ms step_avg:169.32ms
+step:1782/4150 train_time:301792ms step_avg:169.36ms
+step:1783/4150 train_time:302028ms step_avg:169.39ms
+step:1784/4150 train_time:302266ms step_avg:169.43ms
+step:1785/4150 train_time:302497ms step_avg:169.47ms
+step:1786/4150 train_time:302732ms step_avg:169.50ms
+step:1787/4150 train_time:302965ms step_avg:169.54ms
+step:1788/4150 train_time:303204ms step_avg:169.58ms
+step:1789/4150 train_time:303436ms step_avg:169.61ms
+step:1790/4150 train_time:303672ms step_avg:169.65ms
+step:1791/4150 train_time:303907ms step_avg:169.69ms
+step:1792/4150 train_time:304142ms step_avg:169.72ms
+step:1793/4150 train_time:304375ms step_avg:169.76ms
+step:1794/4150 train_time:304611ms step_avg:169.79ms
+step:1795/4150 train_time:304845ms step_avg:169.83ms
+step:1796/4150 train_time:305086ms step_avg:169.87ms
+step:1797/4150 train_time:305316ms step_avg:169.90ms
+step:1798/4150 train_time:305551ms step_avg:169.94ms
+step:1799/4150 train_time:305785ms step_avg:169.97ms
+step:1800/4150 train_time:306024ms step_avg:170.01ms
+step:1801/4150 train_time:306255ms step_avg:170.05ms
+step:1802/4150 train_time:306492ms step_avg:170.08ms
+step:1803/4150 train_time:306725ms step_avg:170.12ms
+step:1804/4150 train_time:306960ms step_avg:170.16ms
+step:1805/4150 train_time:307194ms step_avg:170.19ms
+step:1806/4150 train_time:307428ms step_avg:170.23ms
+step:1807/4150 train_time:307660ms step_avg:170.26ms
+step:1808/4150 train_time:307895ms step_avg:170.30ms
+step:1809/4150 train_time:308130ms step_avg:170.33ms
+step:1810/4150 train_time:308365ms step_avg:170.37ms
+step:1811/4150 train_time:308599ms step_avg:170.40ms
+step:1812/4150 train_time:308835ms step_avg:170.44ms
+step:1813/4150 train_time:309069ms step_avg:170.47ms
+step:1814/4150 train_time:309306ms step_avg:170.51ms
+step:1815/4150 train_time:309537ms step_avg:170.54ms
+step:1816/4150 train_time:309775ms step_avg:170.58ms
+step:1817/4150 train_time:310010ms step_avg:170.62ms
+step:1818/4150 train_time:310245ms step_avg:170.65ms
+step:1819/4150 train_time:310478ms step_avg:170.69ms
+step:1820/4150 train_time:310713ms step_avg:170.72ms
+step:1821/4150 train_time:310948ms step_avg:170.76ms
+step:1822/4150 train_time:311187ms step_avg:170.79ms
+step:1823/4150 train_time:311420ms step_avg:170.83ms
+step:1824/4150 train_time:311656ms step_avg:170.86ms
+step:1825/4150 train_time:311892ms step_avg:170.90ms
+step:1826/4150 train_time:312127ms step_avg:170.93ms
+step:1827/4150 train_time:312362ms step_avg:170.97ms
+step:1828/4150 train_time:312598ms step_avg:171.01ms
+step:1829/4150 train_time:312829ms step_avg:171.04ms
+step:1830/4150 train_time:313066ms step_avg:171.07ms
+step:1831/4150 train_time:313299ms step_avg:171.11ms
+step:1832/4150 train_time:313534ms step_avg:171.14ms
+step:1833/4150 train_time:313766ms step_avg:171.18ms
+step:1834/4150 train_time:314006ms step_avg:171.21ms
+step:1835/4150 train_time:314239ms step_avg:171.25ms
+step:1836/4150 train_time:314475ms step_avg:171.28ms
+step:1837/4150 train_time:314708ms step_avg:171.32ms
+step:1838/4150 train_time:314944ms step_avg:171.35ms
+step:1839/4150 train_time:315177ms step_avg:171.39ms
+step:1840/4150 train_time:315412ms step_avg:171.42ms
+step:1841/4150 train_time:315646ms step_avg:171.45ms
+step:1842/4150 train_time:315883ms step_avg:171.49ms
+step:1843/4150 train_time:316117ms step_avg:171.52ms
+step:1844/4150 train_time:316352ms step_avg:171.56ms
+step:1845/4150 train_time:316585ms step_avg:171.59ms
+step:1846/4150 train_time:316826ms step_avg:171.63ms
+step:1847/4150 train_time:317057ms step_avg:171.66ms
+step:1848/4150 train_time:317292ms step_avg:171.69ms
+step:1849/4150 train_time:317527ms step_avg:171.73ms
+step:1850/4150 train_time:317763ms step_avg:171.76ms
+step:1851/4150 train_time:317994ms step_avg:171.80ms
+step:1852/4150 train_time:318232ms step_avg:171.83ms
+step:1853/4150 train_time:318465ms step_avg:171.86ms
+step:1854/4150 train_time:318701ms step_avg:171.90ms
+step:1855/4150 train_time:318935ms step_avg:171.93ms
+step:1856/4150 train_time:319174ms step_avg:171.97ms
+step:1857/4150 train_time:319407ms step_avg:172.00ms
+step:1858/4150 train_time:319641ms step_avg:172.04ms
+step:1859/4150 train_time:319874ms step_avg:172.07ms
+step:1860/4150 train_time:320110ms step_avg:172.10ms
+step:1861/4150 train_time:320343ms step_avg:172.13ms
+step:1862/4150 train_time:320578ms step_avg:172.17ms
+step:1863/4150 train_time:320811ms step_avg:172.20ms
+step:1864/4150 train_time:321047ms step_avg:172.24ms
+step:1865/4150 train_time:321281ms step_avg:172.27ms
+step:1866/4150 train_time:321517ms step_avg:172.30ms
+step:1867/4150 train_time:321751ms step_avg:172.34ms
+step:1868/4150 train_time:321985ms step_avg:172.37ms
+step:1869/4150 train_time:322217ms step_avg:172.40ms
+step:1870/4150 train_time:322452ms step_avg:172.43ms
+step:1871/4150 train_time:322685ms step_avg:172.47ms
+step:1872/4150 train_time:322921ms step_avg:172.50ms
+step:1873/4150 train_time:323153ms step_avg:172.53ms
+step:1874/4150 train_time:323387ms step_avg:172.57ms
+step:1875/4150 train_time:323619ms step_avg:172.60ms
+step:1876/4150 train_time:323854ms step_avg:172.63ms
+step:1877/4150 train_time:324090ms step_avg:172.66ms
+step:1878/4150 train_time:324328ms step_avg:172.70ms
+step:1879/4150 train_time:324560ms step_avg:172.73ms
+step:1880/4150 train_time:324795ms step_avg:172.76ms
+step:1881/4150 train_time:325029ms step_avg:172.80ms
+step:1882/4150 train_time:325268ms step_avg:172.83ms
+step:1883/4150 train_time:325500ms step_avg:172.86ms
+step:1884/4150 train_time:325737ms step_avg:172.90ms
+step:1885/4150 train_time:325972ms step_avg:172.93ms
+step:1886/4150 train_time:326209ms step_avg:172.96ms
+step:1887/4150 train_time:326443ms step_avg:173.00ms
+step:1888/4150 train_time:326678ms step_avg:173.03ms
+step:1889/4150 train_time:326911ms step_avg:173.06ms
+step:1890/4150 train_time:327146ms step_avg:173.09ms
+step:1891/4150 train_time:327380ms step_avg:173.13ms
+step:1892/4150 train_time:327616ms step_avg:173.16ms
+step:1893/4150 train_time:327849ms step_avg:173.19ms
+step:1894/4150 train_time:328089ms step_avg:173.23ms
+step:1895/4150 train_time:328322ms step_avg:173.26ms
+step:1896/4150 train_time:328554ms step_avg:173.29ms
+step:1897/4150 train_time:328788ms step_avg:173.32ms
+step:1898/4150 train_time:329028ms step_avg:173.35ms
+step:1899/4150 train_time:329261ms step_avg:173.39ms
+step:1900/4150 train_time:329497ms step_avg:173.42ms
+step:1901/4150 train_time:329730ms step_avg:173.45ms
+step:1902/4150 train_time:329969ms step_avg:173.49ms
+step:1903/4150 train_time:330203ms step_avg:173.52ms
+step:1904/4150 train_time:330436ms step_avg:173.55ms
+step:1905/4150 train_time:330667ms step_avg:173.58ms
+step:1906/4150 train_time:330906ms step_avg:173.61ms
+step:1907/4150 train_time:331137ms step_avg:173.64ms
+step:1908/4150 train_time:331372ms step_avg:173.68ms
+step:1909/4150 train_time:331605ms step_avg:173.71ms
+step:1910/4150 train_time:331841ms step_avg:173.74ms
+step:1911/4150 train_time:332073ms step_avg:173.77ms
+step:1912/4150 train_time:332312ms step_avg:173.80ms
+step:1913/4150 train_time:332545ms step_avg:173.83ms
+step:1914/4150 train_time:332780ms step_avg:173.87ms
+step:1915/4150 train_time:333017ms step_avg:173.90ms
+step:1916/4150 train_time:333252ms step_avg:173.93ms
+step:1917/4150 train_time:333484ms step_avg:173.96ms
+step:1918/4150 train_time:333723ms step_avg:174.00ms
+step:1919/4150 train_time:333956ms step_avg:174.03ms
+step:1920/4150 train_time:334192ms step_avg:174.06ms
+step:1921/4150 train_time:334430ms step_avg:174.09ms
+step:1922/4150 train_time:334665ms step_avg:174.12ms
+step:1923/4150 train_time:334897ms step_avg:174.15ms
+step:1924/4150 train_time:335132ms step_avg:174.19ms
+step:1925/4150 train_time:335367ms step_avg:174.22ms
+step:1926/4150 train_time:335603ms step_avg:174.25ms
+step:1927/4150 train_time:335832ms step_avg:174.28ms
+step:1928/4150 train_time:336069ms step_avg:174.31ms
+step:1929/4150 train_time:336304ms step_avg:174.34ms
+step:1930/4150 train_time:336542ms step_avg:174.37ms
+step:1931/4150 train_time:336775ms step_avg:174.40ms
+step:1932/4150 train_time:337010ms step_avg:174.44ms
+step:1933/4150 train_time:337243ms step_avg:174.47ms
+step:1934/4150 train_time:337479ms step_avg:174.50ms
+step:1935/4150 train_time:337710ms step_avg:174.53ms
+step:1936/4150 train_time:337946ms step_avg:174.56ms
+step:1937/4150 train_time:338179ms step_avg:174.59ms
+step:1938/4150 train_time:338413ms step_avg:174.62ms
+step:1939/4150 train_time:338645ms step_avg:174.65ms
+step:1940/4150 train_time:338882ms step_avg:174.68ms
+step:1941/4150 train_time:339112ms step_avg:174.71ms
+step:1942/4150 train_time:339349ms step_avg:174.74ms
+step:1943/4150 train_time:339582ms step_avg:174.77ms
+step:1944/4150 train_time:339815ms step_avg:174.80ms
+step:1945/4150 train_time:340046ms step_avg:174.83ms
+step:1946/4150 train_time:340282ms step_avg:174.86ms
+step:1947/4150 train_time:340513ms step_avg:174.89ms
+step:1948/4150 train_time:340751ms step_avg:174.92ms
+step:1949/4150 train_time:340983ms step_avg:174.95ms
+step:1950/4150 train_time:341217ms step_avg:174.98ms
+step:1951/4150 train_time:341453ms step_avg:175.01ms
+step:1952/4150 train_time:341687ms step_avg:175.04ms
+step:1953/4150 train_time:341920ms step_avg:175.07ms
+step:1954/4150 train_time:342155ms step_avg:175.11ms
+step:1955/4150 train_time:342387ms step_avg:175.13ms
+step:1956/4150 train_time:342623ms step_avg:175.16ms
+step:1957/4150 train_time:342856ms step_avg:175.19ms
+step:1958/4150 train_time:343093ms step_avg:175.23ms
+step:1959/4150 train_time:343325ms step_avg:175.26ms
+step:1960/4150 train_time:343564ms step_avg:175.29ms
+step:1961/4150 train_time:343795ms step_avg:175.32ms
+step:1962/4150 train_time:344033ms step_avg:175.35ms
+step:1963/4150 train_time:344268ms step_avg:175.38ms
+step:1964/4150 train_time:344506ms step_avg:175.41ms
+step:1965/4150 train_time:344738ms step_avg:175.44ms
+step:1966/4150 train_time:344973ms step_avg:175.47ms
+step:1967/4150 train_time:345207ms step_avg:175.50ms
+step:1968/4150 train_time:345446ms step_avg:175.53ms
+step:1969/4150 train_time:345676ms step_avg:175.56ms
+step:1970/4150 train_time:345915ms step_avg:175.59ms
+step:1971/4150 train_time:346148ms step_avg:175.62ms
+step:1972/4150 train_time:346384ms step_avg:175.65ms
+step:1973/4150 train_time:346617ms step_avg:175.68ms
+step:1974/4150 train_time:346852ms step_avg:175.71ms
+step:1975/4150 train_time:347086ms step_avg:175.74ms
+step:1976/4150 train_time:347322ms step_avg:175.77ms
+step:1977/4150 train_time:347554ms step_avg:175.80ms
+step:1978/4150 train_time:347788ms step_avg:175.83ms
+step:1979/4150 train_time:348022ms step_avg:175.86ms
+step:1980/4150 train_time:348258ms step_avg:175.89ms
+step:1981/4150 train_time:348491ms step_avg:175.92ms
+step:1982/4150 train_time:348726ms step_avg:175.95ms
+step:1983/4150 train_time:348958ms step_avg:175.97ms
+step:1984/4150 train_time:349192ms step_avg:176.00ms
+step:1985/4150 train_time:349424ms step_avg:176.03ms
+step:1986/4150 train_time:349661ms step_avg:176.06ms
+step:1987/4150 train_time:349892ms step_avg:176.09ms
+step:1988/4150 train_time:350128ms step_avg:176.12ms
+step:1989/4150 train_time:350364ms step_avg:176.15ms
+step:1990/4150 train_time:350602ms step_avg:176.18ms
+step:1991/4150 train_time:350832ms step_avg:176.21ms
+step:1992/4150 train_time:351068ms step_avg:176.24ms
+step:1993/4150 train_time:351303ms step_avg:176.27ms
+step:1994/4150 train_time:351539ms step_avg:176.30ms
+step:1995/4150 train_time:351772ms step_avg:176.33ms
+step:1996/4150 train_time:352005ms step_avg:176.36ms
+step:1997/4150 train_time:352237ms step_avg:176.38ms
+step:1998/4150 train_time:352473ms step_avg:176.41ms
+step:1999/4150 train_time:352706ms step_avg:176.44ms
+step:2000/4150 train_time:352940ms step_avg:176.47ms
+step:2000/4150 val_loss:3.1826 train_time:353153ms step_avg:176.58ms
+step:2001/4150 train_time:353176ms step_avg:176.50ms
+step:2002/4150 train_time:353417ms step_avg:176.53ms
+step:2003/4150 train_time:353652ms step_avg:176.56ms
+step:2004/4150 train_time:353885ms step_avg:176.59ms
+step:2005/4150 train_time:354115ms step_avg:176.62ms
+step:2006/4150 train_time:354349ms step_avg:176.64ms
+step:2007/4150 train_time:354584ms step_avg:176.67ms
+step:2008/4150 train_time:354821ms step_avg:176.70ms
+step:2009/4150 train_time:355054ms step_avg:176.73ms
+step:2010/4150 train_time:355289ms step_avg:176.76ms
+step:2011/4150 train_time:355525ms step_avg:176.79ms
+step:2012/4150 train_time:355760ms step_avg:176.82ms
+step:2013/4150 train_time:355992ms step_avg:176.85ms
+step:2014/4150 train_time:356227ms step_avg:176.88ms
+step:2015/4150 train_time:356463ms step_avg:176.90ms
+step:2016/4150 train_time:356700ms step_avg:176.93ms
+step:2017/4150 train_time:356935ms step_avg:176.96ms
+step:2018/4150 train_time:357169ms step_avg:176.99ms
+step:2019/4150 train_time:357402ms step_avg:177.02ms
+step:2020/4150 train_time:357640ms step_avg:177.05ms
+step:2021/4150 train_time:357873ms step_avg:177.08ms
+step:2022/4150 train_time:358110ms step_avg:177.11ms
+step:2023/4150 train_time:358342ms step_avg:177.13ms
+step:2024/4150 train_time:358578ms step_avg:177.16ms
+step:2025/4150 train_time:358814ms step_avg:177.19ms
+step:2026/4150 train_time:359051ms step_avg:177.22ms
+step:2027/4150 train_time:359283ms step_avg:177.25ms
+step:2028/4150 train_time:359519ms step_avg:177.28ms
+step:2029/4150 train_time:359753ms step_avg:177.31ms
+step:2030/4150 train_time:359989ms step_avg:177.33ms
+step:2031/4150 train_time:360221ms step_avg:177.36ms
+step:2032/4150 train_time:360457ms step_avg:177.39ms
+step:2033/4150 train_time:360694ms step_avg:177.42ms
+step:2034/4150 train_time:360933ms step_avg:177.45ms
+step:2035/4150 train_time:361166ms step_avg:177.48ms
+step:2036/4150 train_time:361401ms step_avg:177.51ms
+step:2037/4150 train_time:361635ms step_avg:177.53ms
+step:2038/4150 train_time:361871ms step_avg:177.56ms
+step:2039/4150 train_time:362104ms step_avg:177.59ms
+step:2040/4150 train_time:362340ms step_avg:177.62ms
+step:2041/4150 train_time:362574ms step_avg:177.65ms
+step:2042/4150 train_time:362811ms step_avg:177.67ms
+step:2043/4150 train_time:363042ms step_avg:177.70ms
+step:2044/4150 train_time:363277ms step_avg:177.73ms
+step:2045/4150 train_time:363509ms step_avg:177.75ms
+step:2046/4150 train_time:363744ms step_avg:177.78ms
+step:2047/4150 train_time:363976ms step_avg:177.81ms
+step:2048/4150 train_time:364212ms step_avg:177.84ms
+step:2049/4150 train_time:364445ms step_avg:177.86ms
+step:2050/4150 train_time:364679ms step_avg:177.89ms
+step:2051/4150 train_time:364914ms step_avg:177.92ms
+step:2052/4150 train_time:365149ms step_avg:177.95ms
+step:2053/4150 train_time:365384ms step_avg:177.98ms
+step:2054/4150 train_time:365620ms step_avg:178.00ms
+step:2055/4150 train_time:365856ms step_avg:178.03ms
+step:2056/4150 train_time:366090ms step_avg:178.06ms
+step:2057/4150 train_time:366323ms step_avg:178.09ms
+step:2058/4150 train_time:366557ms step_avg:178.11ms
+step:2059/4150 train_time:366792ms step_avg:178.14ms
+step:2060/4150 train_time:367030ms step_avg:178.17ms
+step:2061/4150 train_time:367261ms step_avg:178.20ms
+step:2062/4150 train_time:367497ms step_avg:178.22ms
+step:2063/4150 train_time:367728ms step_avg:178.25ms
+step:2064/4150 train_time:367963ms step_avg:178.28ms
+step:2065/4150 train_time:368197ms step_avg:178.30ms
+step:2066/4150 train_time:368436ms step_avg:178.33ms
+step:2067/4150 train_time:368666ms step_avg:178.36ms
+step:2068/4150 train_time:368903ms step_avg:178.39ms
+step:2069/4150 train_time:369138ms step_avg:178.41ms
+step:2070/4150 train_time:369376ms step_avg:178.44ms
+step:2071/4150 train_time:369607ms step_avg:178.47ms
+step:2072/4150 train_time:369845ms step_avg:178.50ms
+step:2073/4150 train_time:370079ms step_avg:178.52ms
+step:2074/4150 train_time:370317ms step_avg:178.55ms
+step:2075/4150 train_time:370548ms step_avg:178.58ms
+step:2076/4150 train_time:370784ms step_avg:178.61ms
+step:2077/4150 train_time:371021ms step_avg:178.63ms
+step:2078/4150 train_time:371257ms step_avg:178.66ms
+step:2079/4150 train_time:371492ms step_avg:178.69ms
+step:2080/4150 train_time:371728ms step_avg:178.72ms
+step:2081/4150 train_time:371960ms step_avg:178.74ms
+step:2082/4150 train_time:372196ms step_avg:178.77ms
+step:2083/4150 train_time:372430ms step_avg:178.80ms
+step:2084/4150 train_time:372666ms step_avg:178.82ms
+step:2085/4150 train_time:372899ms step_avg:178.85ms
+step:2086/4150 train_time:373136ms step_avg:178.88ms
+step:2087/4150 train_time:373369ms step_avg:178.90ms
+step:2088/4150 train_time:373603ms step_avg:178.93ms
+step:2089/4150 train_time:373835ms step_avg:178.95ms
+step:2090/4150 train_time:374072ms step_avg:178.98ms
+step:2091/4150 train_time:374306ms step_avg:179.01ms
+step:2092/4150 train_time:374542ms step_avg:179.04ms
+step:2093/4150 train_time:374775ms step_avg:179.06ms
+step:2094/4150 train_time:375015ms step_avg:179.09ms
+step:2095/4150 train_time:375246ms step_avg:179.12ms
+step:2096/4150 train_time:375482ms step_avg:179.14ms
+step:2097/4150 train_time:375715ms step_avg:179.17ms
+step:2098/4150 train_time:375950ms step_avg:179.19ms
+step:2099/4150 train_time:376183ms step_avg:179.22ms
+step:2100/4150 train_time:376419ms step_avg:179.25ms
+step:2101/4150 train_time:376653ms step_avg:179.27ms
+step:2102/4150 train_time:376889ms step_avg:179.30ms
+step:2103/4150 train_time:377123ms step_avg:179.33ms
+step:2104/4150 train_time:377359ms step_avg:179.35ms
+step:2105/4150 train_time:377593ms step_avg:179.38ms
+step:2106/4150 train_time:377832ms step_avg:179.41ms
+step:2107/4150 train_time:378064ms step_avg:179.43ms
+step:2108/4150 train_time:378304ms step_avg:179.46ms
+step:2109/4150 train_time:378539ms step_avg:179.49ms
+step:2110/4150 train_time:378776ms step_avg:179.51ms
+step:2111/4150 train_time:379008ms step_avg:179.54ms
+step:2112/4150 train_time:379244ms step_avg:179.57ms
+step:2113/4150 train_time:379478ms step_avg:179.59ms
+step:2114/4150 train_time:379715ms step_avg:179.62ms
+step:2115/4150 train_time:379946ms step_avg:179.64ms
+step:2116/4150 train_time:380182ms step_avg:179.67ms
+step:2117/4150 train_time:380417ms step_avg:179.70ms
+step:2118/4150 train_time:380656ms step_avg:179.72ms
+step:2119/4150 train_time:380889ms step_avg:179.75ms
+step:2120/4150 train_time:381124ms step_avg:179.78ms
+step:2121/4150 train_time:381357ms step_avg:179.80ms
+step:2122/4150 train_time:381593ms step_avg:179.83ms
+step:2123/4150 train_time:381825ms step_avg:179.85ms
+step:2124/4150 train_time:382061ms step_avg:179.88ms
+step:2125/4150 train_time:382293ms step_avg:179.90ms
+step:2126/4150 train_time:382534ms step_avg:179.93ms
+step:2127/4150 train_time:382768ms step_avg:179.96ms
+step:2128/4150 train_time:383004ms step_avg:179.98ms
+step:2129/4150 train_time:383235ms step_avg:180.01ms
+step:2130/4150 train_time:383472ms step_avg:180.03ms
+step:2131/4150 train_time:383706ms step_avg:180.06ms
+step:2132/4150 train_time:383942ms step_avg:180.09ms
+step:2133/4150 train_time:384175ms step_avg:180.11ms
+step:2134/4150 train_time:384413ms step_avg:180.14ms
+step:2135/4150 train_time:384649ms step_avg:180.16ms
+step:2136/4150 train_time:384884ms step_avg:180.19ms
+step:2137/4150 train_time:385120ms step_avg:180.22ms
+step:2138/4150 train_time:385355ms step_avg:180.24ms
+step:2139/4150 train_time:385587ms step_avg:180.27ms
+step:2140/4150 train_time:385823ms step_avg:180.29ms
+step:2141/4150 train_time:386060ms step_avg:180.32ms
+step:2142/4150 train_time:386297ms step_avg:180.34ms
+step:2143/4150 train_time:386529ms step_avg:180.37ms
+step:2144/4150 train_time:386763ms step_avg:180.39ms
+step:2145/4150 train_time:386997ms step_avg:180.42ms
+step:2146/4150 train_time:387236ms step_avg:180.45ms
+step:2147/4150 train_time:387471ms step_avg:180.47ms
+step:2148/4150 train_time:387708ms step_avg:180.50ms
+step:2149/4150 train_time:387941ms step_avg:180.52ms
+step:2150/4150 train_time:388178ms step_avg:180.55ms
+step:2151/4150 train_time:388413ms step_avg:180.57ms
+step:2152/4150 train_time:388650ms step_avg:180.60ms
+step:2153/4150 train_time:388883ms step_avg:180.62ms
+step:2154/4150 train_time:389119ms step_avg:180.65ms
+step:2155/4150 train_time:389353ms step_avg:180.67ms
+step:2156/4150 train_time:389592ms step_avg:180.70ms
+step:2157/4150 train_time:389826ms step_avg:180.73ms
+step:2158/4150 train_time:390061ms step_avg:180.75ms
+step:2159/4150 train_time:390297ms step_avg:180.78ms
+step:2160/4150 train_time:390537ms step_avg:180.80ms
+step:2161/4150 train_time:390773ms step_avg:180.83ms
+step:2162/4150 train_time:391007ms step_avg:180.85ms
+step:2163/4150 train_time:391238ms step_avg:180.88ms
+step:2164/4150 train_time:391476ms step_avg:180.90ms
+step:2165/4150 train_time:391708ms step_avg:180.93ms
+step:2166/4150 train_time:391943ms step_avg:180.95ms
+step:2167/4150 train_time:392174ms step_avg:180.98ms
+step:2168/4150 train_time:392411ms step_avg:181.00ms
+step:2169/4150 train_time:392646ms step_avg:181.03ms
+step:2170/4150 train_time:392882ms step_avg:181.05ms
+step:2171/4150 train_time:393119ms step_avg:181.08ms
+step:2172/4150 train_time:393357ms step_avg:181.10ms
+step:2173/4150 train_time:393593ms step_avg:181.13ms
+step:2174/4150 train_time:393835ms step_avg:181.16ms
+step:2175/4150 train_time:394066ms step_avg:181.18ms
+step:2176/4150 train_time:394301ms step_avg:181.20ms
+step:2177/4150 train_time:394534ms step_avg:181.23ms
+step:2178/4150 train_time:394772ms step_avg:181.25ms
+step:2179/4150 train_time:395005ms step_avg:181.28ms
+step:2180/4150 train_time:395242ms step_avg:181.30ms
+step:2181/4150 train_time:395475ms step_avg:181.33ms
+step:2182/4150 train_time:395715ms step_avg:181.35ms
+step:2183/4150 train_time:395946ms step_avg:181.38ms
+step:2184/4150 train_time:396183ms step_avg:181.40ms
+step:2185/4150 train_time:396416ms step_avg:181.43ms
+step:2186/4150 train_time:396653ms step_avg:181.45ms
+step:2187/4150 train_time:396886ms step_avg:181.48ms
+step:2188/4150 train_time:397121ms step_avg:181.50ms
+step:2189/4150 train_time:397352ms step_avg:181.52ms
+step:2190/4150 train_time:397589ms step_avg:181.55ms
+step:2191/4150 train_time:397825ms step_avg:181.57ms
+step:2192/4150 train_time:398062ms step_avg:181.60ms
+step:2193/4150 train_time:398298ms step_avg:181.62ms
+step:2194/4150 train_time:398536ms step_avg:181.65ms
+step:2195/4150 train_time:398772ms step_avg:181.67ms
+step:2196/4150 train_time:399008ms step_avg:181.70ms
+step:2197/4150 train_time:399241ms step_avg:181.72ms
+step:2198/4150 train_time:399476ms step_avg:181.75ms
+step:2199/4150 train_time:399709ms step_avg:181.77ms
+step:2200/4150 train_time:399944ms step_avg:181.79ms
+step:2201/4150 train_time:400180ms step_avg:181.82ms
+step:2202/4150 train_time:400416ms step_avg:181.84ms
+step:2203/4150 train_time:400648ms step_avg:181.86ms
+step:2204/4150 train_time:400883ms step_avg:181.89ms
+step:2205/4150 train_time:401116ms step_avg:181.91ms
+step:2206/4150 train_time:401356ms step_avg:181.94ms
+step:2207/4150 train_time:401591ms step_avg:181.96ms
+step:2208/4150 train_time:401826ms step_avg:181.99ms
+step:2209/4150 train_time:402058ms step_avg:182.01ms
+step:2210/4150 train_time:402295ms step_avg:182.03ms
+step:2211/4150 train_time:402528ms step_avg:182.06ms
+step:2212/4150 train_time:402764ms step_avg:182.08ms
+step:2213/4150 train_time:403000ms step_avg:182.11ms
+step:2214/4150 train_time:403237ms step_avg:182.13ms
+step:2215/4150 train_time:403471ms step_avg:182.15ms
+step:2216/4150 train_time:403706ms step_avg:182.18ms
+step:2217/4150 train_time:403938ms step_avg:182.20ms
+step:2218/4150 train_time:404176ms step_avg:182.23ms
+step:2219/4150 train_time:404412ms step_avg:182.25ms
+step:2220/4150 train_time:404651ms step_avg:182.28ms
+step:2221/4150 train_time:404885ms step_avg:182.30ms
+step:2222/4150 train_time:405123ms step_avg:182.32ms
+step:2223/4150 train_time:405359ms step_avg:182.35ms
+step:2224/4150 train_time:405597ms step_avg:182.37ms
+step:2225/4150 train_time:405830ms step_avg:182.40ms
+step:2226/4150 train_time:406063ms step_avg:182.42ms
+step:2227/4150 train_time:406298ms step_avg:182.44ms
+step:2228/4150 train_time:406536ms step_avg:182.47ms
+step:2229/4150 train_time:406769ms step_avg:182.49ms
+step:2230/4150 train_time:407006ms step_avg:182.51ms
+step:2231/4150 train_time:407237ms step_avg:182.54ms
+step:2232/4150 train_time:407477ms step_avg:182.56ms
+step:2233/4150 train_time:407713ms step_avg:182.59ms
+step:2234/4150 train_time:407950ms step_avg:182.61ms
+step:2235/4150 train_time:408184ms step_avg:182.63ms
+step:2236/4150 train_time:408420ms step_avg:182.66ms
+step:2237/4150 train_time:408657ms step_avg:182.68ms
+step:2238/4150 train_time:408894ms step_avg:182.71ms
+step:2239/4150 train_time:409126ms step_avg:182.73ms
+step:2240/4150 train_time:409359ms step_avg:182.75ms
+step:2241/4150 train_time:409593ms step_avg:182.77ms
+step:2242/4150 train_time:409831ms step_avg:182.80ms
+step:2243/4150 train_time:410061ms step_avg:182.82ms
+step:2244/4150 train_time:410297ms step_avg:182.84ms
+step:2245/4150 train_time:410527ms step_avg:182.86ms
+step:2246/4150 train_time:410763ms step_avg:182.89ms
+step:2247/4150 train_time:410999ms step_avg:182.91ms
+step:2248/4150 train_time:411237ms step_avg:182.93ms
+step:2249/4150 train_time:411472ms step_avg:182.96ms
+step:2250/4150 train_time:411709ms step_avg:182.98ms
+step:2250/4150 val_loss:3.1422 train_time:411925ms step_avg:183.08ms
+step:2251/4150 train_time:411948ms step_avg:183.01ms
+step:2252/4150 train_time:412188ms step_avg:183.03ms
+step:2253/4150 train_time:412426ms step_avg:183.06ms
+step:2254/4150 train_time:412661ms step_avg:183.08ms
+step:2255/4150 train_time:412894ms step_avg:183.10ms
+step:2256/4150 train_time:413130ms step_avg:183.12ms
+step:2257/4150 train_time:413368ms step_avg:183.15ms
+step:2258/4150 train_time:413605ms step_avg:183.17ms
+step:2259/4150 train_time:413837ms step_avg:183.19ms
+step:2260/4150 train_time:414073ms step_avg:183.22ms
+step:2261/4150 train_time:414310ms step_avg:183.24ms
+step:2262/4150 train_time:414548ms step_avg:183.27ms
+step:2263/4150 train_time:414778ms step_avg:183.29ms
+step:2264/4150 train_time:415015ms step_avg:183.31ms
+step:2265/4150 train_time:415249ms step_avg:183.33ms
+step:2266/4150 train_time:415486ms step_avg:183.36ms
+step:2267/4150 train_time:415719ms step_avg:183.38ms
+step:2268/4150 train_time:415954ms step_avg:183.40ms
+step:2269/4150 train_time:416189ms step_avg:183.42ms
+step:2270/4150 train_time:416425ms step_avg:183.45ms
+step:2271/4150 train_time:416657ms step_avg:183.47ms
+step:2272/4150 train_time:416891ms step_avg:183.49ms
+step:2273/4150 train_time:417123ms step_avg:183.51ms
+step:2274/4150 train_time:417363ms step_avg:183.54ms
+step:2275/4150 train_time:417597ms step_avg:183.56ms
+step:2276/4150 train_time:417836ms step_avg:183.58ms
+step:2277/4150 train_time:418067ms step_avg:183.60ms
+step:2278/4150 train_time:418301ms step_avg:183.63ms
+step:2279/4150 train_time:418536ms step_avg:183.65ms
+step:2280/4150 train_time:418772ms step_avg:183.67ms
+step:2281/4150 train_time:419006ms step_avg:183.69ms
+step:2282/4150 train_time:419241ms step_avg:183.72ms
+step:2283/4150 train_time:419480ms step_avg:183.74ms
+step:2284/4150 train_time:419716ms step_avg:183.76ms
+step:2285/4150 train_time:419946ms step_avg:183.78ms
+step:2286/4150 train_time:420181ms step_avg:183.81ms
+step:2287/4150 train_time:420414ms step_avg:183.83ms
+step:2288/4150 train_time:420652ms step_avg:183.85ms
+step:2289/4150 train_time:420884ms step_avg:183.87ms
+step:2290/4150 train_time:421124ms step_avg:183.90ms
+step:2291/4150 train_time:421356ms step_avg:183.92ms
+step:2292/4150 train_time:421595ms step_avg:183.94ms
+step:2293/4150 train_time:421828ms step_avg:183.96ms
+step:2294/4150 train_time:422064ms step_avg:183.99ms
+step:2295/4150 train_time:422302ms step_avg:184.01ms
+step:2296/4150 train_time:422539ms step_avg:184.03ms
+step:2297/4150 train_time:422770ms step_avg:184.05ms
+step:2298/4150 train_time:423007ms step_avg:184.08ms
+step:2299/4150 train_time:423242ms step_avg:184.10ms
+step:2300/4150 train_time:423479ms step_avg:184.12ms
+step:2301/4150 train_time:423713ms step_avg:184.14ms
+step:2302/4150 train_time:423948ms step_avg:184.16ms
+step:2303/4150 train_time:424184ms step_avg:184.19ms
+step:2304/4150 train_time:424425ms step_avg:184.21ms
+step:2305/4150 train_time:424661ms step_avg:184.23ms
+step:2306/4150 train_time:424896ms step_avg:184.26ms
+step:2307/4150 train_time:425128ms step_avg:184.28ms
+step:2308/4150 train_time:425366ms step_avg:184.30ms
+step:2309/4150 train_time:425605ms step_avg:184.32ms
+step:2310/4150 train_time:425839ms step_avg:184.35ms
+step:2311/4150 train_time:426072ms step_avg:184.37ms
+step:2312/4150 train_time:426307ms step_avg:184.39ms
+step:2313/4150 train_time:426545ms step_avg:184.41ms
+step:2314/4150 train_time:426782ms step_avg:184.43ms
+step:2315/4150 train_time:427016ms step_avg:184.46ms
+step:2316/4150 train_time:427251ms step_avg:184.48ms
+step:2317/4150 train_time:427485ms step_avg:184.50ms
+step:2318/4150 train_time:427721ms step_avg:184.52ms
+step:2319/4150 train_time:427957ms step_avg:184.54ms
+step:2320/4150 train_time:428192ms step_avg:184.57ms
+step:2321/4150 train_time:428425ms step_avg:184.59ms
+step:2322/4150 train_time:428666ms step_avg:184.61ms
+step:2323/4150 train_time:428904ms step_avg:184.63ms
+step:2324/4150 train_time:429139ms step_avg:184.66ms
+step:2325/4150 train_time:429373ms step_avg:184.68ms
+step:2326/4150 train_time:429610ms step_avg:184.70ms
+step:2327/4150 train_time:429844ms step_avg:184.72ms
+step:2328/4150 train_time:430080ms step_avg:184.74ms
+step:2329/4150 train_time:430312ms step_avg:184.76ms
+step:2330/4150 train_time:430548ms step_avg:184.78ms
+step:2331/4150 train_time:430781ms step_avg:184.81ms
+step:2332/4150 train_time:431019ms step_avg:184.83ms
+step:2333/4150 train_time:431254ms step_avg:184.85ms
+step:2334/4150 train_time:431488ms step_avg:184.87ms
+step:2335/4150 train_time:431721ms step_avg:184.89ms
+step:2336/4150 train_time:431958ms step_avg:184.91ms
+step:2337/4150 train_time:432190ms step_avg:184.93ms
+step:2338/4150 train_time:432425ms step_avg:184.96ms
+step:2339/4150 train_time:432657ms step_avg:184.98ms
+step:2340/4150 train_time:432894ms step_avg:185.00ms
+step:2341/4150 train_time:433128ms step_avg:185.02ms
+step:2342/4150 train_time:433362ms step_avg:185.04ms
+step:2343/4150 train_time:433596ms step_avg:185.06ms
+step:2344/4150 train_time:433833ms step_avg:185.08ms
+step:2345/4150 train_time:434064ms step_avg:185.10ms
+step:2346/4150 train_time:434302ms step_avg:185.12ms
+step:2347/4150 train_time:434536ms step_avg:185.15ms
+step:2348/4150 train_time:434773ms step_avg:185.17ms
+step:2349/4150 train_time:435005ms step_avg:185.19ms
+step:2350/4150 train_time:435246ms step_avg:185.21ms
+step:2351/4150 train_time:435480ms step_avg:185.23ms
+step:2352/4150 train_time:435717ms step_avg:185.25ms
+step:2353/4150 train_time:435953ms step_avg:185.28ms
+step:2354/4150 train_time:436191ms step_avg:185.30ms
+step:2355/4150 train_time:436424ms step_avg:185.32ms
+step:2356/4150 train_time:436661ms step_avg:185.34ms
+step:2357/4150 train_time:436897ms step_avg:185.36ms
+step:2358/4150 train_time:437132ms step_avg:185.38ms
+step:2359/4150 train_time:437365ms step_avg:185.40ms
+step:2360/4150 train_time:437600ms step_avg:185.42ms
+step:2361/4150 train_time:437834ms step_avg:185.44ms
+step:2362/4150 train_time:438068ms step_avg:185.46ms
+step:2363/4150 train_time:438304ms step_avg:185.49ms
+step:2364/4150 train_time:438542ms step_avg:185.51ms
+step:2365/4150 train_time:438777ms step_avg:185.53ms
+step:2366/4150 train_time:439014ms step_avg:185.55ms
+step:2367/4150 train_time:439247ms step_avg:185.57ms
+step:2368/4150 train_time:439483ms step_avg:185.59ms
+step:2369/4150 train_time:439719ms step_avg:185.61ms
+step:2370/4150 train_time:439957ms step_avg:185.64ms
+step:2371/4150 train_time:440190ms step_avg:185.66ms
+step:2372/4150 train_time:440426ms step_avg:185.68ms
+step:2373/4150 train_time:440659ms step_avg:185.70ms
+step:2374/4150 train_time:440897ms step_avg:185.72ms
+step:2375/4150 train_time:441129ms step_avg:185.74ms
+step:2376/4150 train_time:441366ms step_avg:185.76ms
+step:2377/4150 train_time:441597ms step_avg:185.78ms
+step:2378/4150 train_time:441837ms step_avg:185.80ms
+step:2379/4150 train_time:442070ms step_avg:185.82ms
+step:2380/4150 train_time:442305ms step_avg:185.84ms
+step:2381/4150 train_time:442540ms step_avg:185.86ms
+step:2382/4150 train_time:442782ms step_avg:185.89ms
+step:2383/4150 train_time:443018ms step_avg:185.91ms
+step:2384/4150 train_time:443253ms step_avg:185.93ms
+step:2385/4150 train_time:443484ms step_avg:185.95ms
+step:2386/4150 train_time:443721ms step_avg:185.97ms
+step:2387/4150 train_time:443956ms step_avg:185.99ms
+step:2388/4150 train_time:444193ms step_avg:186.01ms
+step:2389/4150 train_time:444423ms step_avg:186.03ms
+step:2390/4150 train_time:444662ms step_avg:186.05ms
+step:2391/4150 train_time:444896ms step_avg:186.07ms
+step:2392/4150 train_time:445131ms step_avg:186.09ms
+step:2393/4150 train_time:445362ms step_avg:186.11ms
+step:2394/4150 train_time:445600ms step_avg:186.13ms
+step:2395/4150 train_time:445832ms step_avg:186.15ms
+step:2396/4150 train_time:446069ms step_avg:186.17ms
+step:2397/4150 train_time:446301ms step_avg:186.19ms
+step:2398/4150 train_time:446540ms step_avg:186.21ms
+step:2399/4150 train_time:446772ms step_avg:186.23ms
+step:2400/4150 train_time:447007ms step_avg:186.25ms
+step:2401/4150 train_time:447239ms step_avg:186.27ms
+step:2402/4150 train_time:447474ms step_avg:186.29ms
+step:2403/4150 train_time:447706ms step_avg:186.31ms
+step:2404/4150 train_time:447943ms step_avg:186.33ms
+step:2405/4150 train_time:448177ms step_avg:186.35ms
+step:2406/4150 train_time:448412ms step_avg:186.37ms
+step:2407/4150 train_time:448644ms step_avg:186.39ms
+step:2408/4150 train_time:448881ms step_avg:186.41ms
+step:2409/4150 train_time:449116ms step_avg:186.43ms
+step:2410/4150 train_time:449355ms step_avg:186.45ms
+step:2411/4150 train_time:449590ms step_avg:186.47ms
+step:2412/4150 train_time:449828ms step_avg:186.50ms
+step:2413/4150 train_time:450063ms step_avg:186.52ms
+step:2414/4150 train_time:450299ms step_avg:186.54ms
+step:2415/4150 train_time:450530ms step_avg:186.56ms
+step:2416/4150 train_time:450767ms step_avg:186.58ms
+step:2417/4150 train_time:451006ms step_avg:186.60ms
+step:2418/4150 train_time:451246ms step_avg:186.62ms
+step:2419/4150 train_time:451479ms step_avg:186.64ms
+step:2420/4150 train_time:451714ms step_avg:186.66ms
+step:2421/4150 train_time:451949ms step_avg:186.68ms
+step:2422/4150 train_time:452189ms step_avg:186.70ms
+step:2423/4150 train_time:452423ms step_avg:186.72ms
+step:2424/4150 train_time:452657ms step_avg:186.74ms
+step:2425/4150 train_time:452893ms step_avg:186.76ms
+step:2426/4150 train_time:453127ms step_avg:186.78ms
+step:2427/4150 train_time:453362ms step_avg:186.80ms
+step:2428/4150 train_time:453600ms step_avg:186.82ms
+step:2429/4150 train_time:453836ms step_avg:186.84ms
+step:2430/4150 train_time:454072ms step_avg:186.86ms
+step:2431/4150 train_time:454308ms step_avg:186.88ms
+step:2432/4150 train_time:454546ms step_avg:186.90ms
+step:2433/4150 train_time:454780ms step_avg:186.92ms
+step:2434/4150 train_time:455016ms step_avg:186.94ms
+step:2435/4150 train_time:455249ms step_avg:186.96ms
+step:2436/4150 train_time:455484ms step_avg:186.98ms
+step:2437/4150 train_time:455719ms step_avg:187.00ms
+step:2438/4150 train_time:455957ms step_avg:187.02ms
+step:2439/4150 train_time:456190ms step_avg:187.04ms
+step:2440/4150 train_time:456426ms step_avg:187.06ms
+step:2441/4150 train_time:456659ms step_avg:187.08ms
+step:2442/4150 train_time:456899ms step_avg:187.10ms
+step:2443/4150 train_time:457132ms step_avg:187.12ms
+step:2444/4150 train_time:457367ms step_avg:187.14ms
+step:2445/4150 train_time:457601ms step_avg:187.16ms
+step:2446/4150 train_time:457837ms step_avg:187.18ms
+step:2447/4150 train_time:458070ms step_avg:187.20ms
+step:2448/4150 train_time:458306ms step_avg:187.22ms
+step:2449/4150 train_time:458541ms step_avg:187.24ms
+step:2450/4150 train_time:458782ms step_avg:187.26ms
+step:2451/4150 train_time:459018ms step_avg:187.28ms
+step:2452/4150 train_time:459255ms step_avg:187.30ms
+step:2453/4150 train_time:459488ms step_avg:187.32ms
+step:2454/4150 train_time:459727ms step_avg:187.34ms
+step:2455/4150 train_time:459961ms step_avg:187.36ms
+step:2456/4150 train_time:460202ms step_avg:187.38ms
+step:2457/4150 train_time:460438ms step_avg:187.40ms
+step:2458/4150 train_time:460674ms step_avg:187.42ms
+step:2459/4150 train_time:460910ms step_avg:187.44ms
+step:2460/4150 train_time:461146ms step_avg:187.46ms
+step:2461/4150 train_time:461379ms step_avg:187.48ms
+step:2462/4150 train_time:461619ms step_avg:187.50ms
+step:2463/4150 train_time:461854ms step_avg:187.52ms
+step:2464/4150 train_time:462091ms step_avg:187.54ms
+step:2465/4150 train_time:462325ms step_avg:187.56ms
+step:2466/4150 train_time:462566ms step_avg:187.58ms
+step:2467/4150 train_time:462802ms step_avg:187.60ms
+step:2468/4150 train_time:463040ms step_avg:187.62ms
+step:2469/4150 train_time:463274ms step_avg:187.64ms
+step:2470/4150 train_time:463511ms step_avg:187.66ms
+step:2471/4150 train_time:463749ms step_avg:187.68ms
+step:2472/4150 train_time:463984ms step_avg:187.70ms
+step:2473/4150 train_time:464217ms step_avg:187.71ms
+step:2474/4150 train_time:464452ms step_avg:187.73ms
+step:2475/4150 train_time:464689ms step_avg:187.75ms
+step:2476/4150 train_time:464929ms step_avg:187.77ms
+step:2477/4150 train_time:465164ms step_avg:187.79ms
+step:2478/4150 train_time:465402ms step_avg:187.81ms
+step:2479/4150 train_time:465634ms step_avg:187.83ms
+step:2480/4150 train_time:465871ms step_avg:187.85ms
+step:2481/4150 train_time:466102ms step_avg:187.87ms
+step:2482/4150 train_time:466337ms step_avg:187.89ms
+step:2483/4150 train_time:466570ms step_avg:187.91ms
+step:2484/4150 train_time:466807ms step_avg:187.93ms
+step:2485/4150 train_time:467042ms step_avg:187.94ms
+step:2486/4150 train_time:467281ms step_avg:187.96ms
+step:2487/4150 train_time:467515ms step_avg:187.98ms
+step:2488/4150 train_time:467754ms step_avg:188.00ms
+step:2489/4150 train_time:467987ms step_avg:188.02ms
+step:2490/4150 train_time:468223ms step_avg:188.04ms
+step:2491/4150 train_time:468456ms step_avg:188.06ms
+step:2492/4150 train_time:468693ms step_avg:188.08ms
+step:2493/4150 train_time:468930ms step_avg:188.10ms
+step:2494/4150 train_time:469168ms step_avg:188.12ms
+step:2495/4150 train_time:469402ms step_avg:188.14ms
+step:2496/4150 train_time:469637ms step_avg:188.16ms
+step:2497/4150 train_time:469869ms step_avg:188.17ms
+step:2498/4150 train_time:470107ms step_avg:188.19ms
+step:2499/4150 train_time:470341ms step_avg:188.21ms
+step:2500/4150 train_time:470577ms step_avg:188.23ms
+step:2500/4150 val_loss:3.1053 train_time:470793ms step_avg:188.32ms
+step:2501/4150 train_time:470815ms step_avg:188.25ms
+step:2502/4150 train_time:471053ms step_avg:188.27ms
+step:2503/4150 train_time:471292ms step_avg:188.29ms
+step:2504/4150 train_time:471524ms step_avg:188.31ms
+step:2505/4150 train_time:471755ms step_avg:188.33ms
+step:2506/4150 train_time:471993ms step_avg:188.35ms
+step:2507/4150 train_time:472231ms step_avg:188.36ms
+step:2508/4150 train_time:472468ms step_avg:188.38ms
+step:2509/4150 train_time:472698ms step_avg:188.40ms
+step:2510/4150 train_time:472935ms step_avg:188.42ms
+step:2511/4150 train_time:473171ms step_avg:188.44ms
+step:2512/4150 train_time:473409ms step_avg:188.46ms
+step:2513/4150 train_time:473639ms step_avg:188.48ms
+step:2514/4150 train_time:473876ms step_avg:188.49ms
+step:2515/4150 train_time:474115ms step_avg:188.51ms
+step:2516/4150 train_time:474352ms step_avg:188.53ms
+step:2517/4150 train_time:474584ms step_avg:188.55ms
+step:2518/4150 train_time:474820ms step_avg:188.57ms
+step:2519/4150 train_time:475056ms step_avg:188.59ms
+step:2520/4150 train_time:475296ms step_avg:188.61ms
+step:2521/4150 train_time:475531ms step_avg:188.63ms
+step:2522/4150 train_time:475769ms step_avg:188.65ms
+step:2523/4150 train_time:476002ms step_avg:188.67ms
+step:2524/4150 train_time:476238ms step_avg:188.68ms
+step:2525/4150 train_time:476472ms step_avg:188.70ms
+step:2526/4150 train_time:476708ms step_avg:188.72ms
+step:2527/4150 train_time:476941ms step_avg:188.74ms
+step:2528/4150 train_time:477179ms step_avg:188.76ms
+step:2529/4150 train_time:477414ms step_avg:188.78ms
+step:2530/4150 train_time:477653ms step_avg:188.80ms
+step:2531/4150 train_time:477884ms step_avg:188.81ms
+step:2532/4150 train_time:478120ms step_avg:188.83ms
+step:2533/4150 train_time:478357ms step_avg:188.85ms
+step:2534/4150 train_time:478596ms step_avg:188.87ms
+step:2535/4150 train_time:478831ms step_avg:188.89ms
+step:2536/4150 train_time:479067ms step_avg:188.91ms
+step:2537/4150 train_time:479300ms step_avg:188.92ms
+step:2538/4150 train_time:479536ms step_avg:188.94ms
+step:2539/4150 train_time:479768ms step_avg:188.96ms
+step:2540/4150 train_time:480004ms step_avg:188.98ms
+step:2541/4150 train_time:480235ms step_avg:188.99ms
+step:2542/4150 train_time:480472ms step_avg:189.01ms
+step:2543/4150 train_time:480703ms step_avg:189.03ms
+step:2544/4150 train_time:480939ms step_avg:189.05ms
+step:2545/4150 train_time:481171ms step_avg:189.07ms
+step:2546/4150 train_time:481413ms step_avg:189.09ms
+step:2547/4150 train_time:481647ms step_avg:189.10ms
+step:2548/4150 train_time:481885ms step_avg:189.12ms
+step:2549/4150 train_time:482121ms step_avg:189.14ms
+step:2550/4150 train_time:482357ms step_avg:189.16ms
+step:2551/4150 train_time:482591ms step_avg:189.18ms
+step:2552/4150 train_time:482831ms step_avg:189.20ms
+step:2553/4150 train_time:483063ms step_avg:189.21ms
+step:2554/4150 train_time:483302ms step_avg:189.23ms
+step:2555/4150 train_time:483536ms step_avg:189.25ms
+step:2556/4150 train_time:483773ms step_avg:189.27ms
+step:2557/4150 train_time:484006ms step_avg:189.29ms
+step:2558/4150 train_time:484242ms step_avg:189.30ms
+step:2559/4150 train_time:484479ms step_avg:189.32ms
+step:2560/4150 train_time:484716ms step_avg:189.34ms
+step:2561/4150 train_time:484950ms step_avg:189.36ms
+step:2562/4150 train_time:485185ms step_avg:189.38ms
+step:2563/4150 train_time:485418ms step_avg:189.39ms
+step:2564/4150 train_time:485656ms step_avg:189.41ms
+step:2565/4150 train_time:485893ms step_avg:189.43ms
+step:2566/4150 train_time:486129ms step_avg:189.45ms
+step:2567/4150 train_time:486364ms step_avg:189.47ms
+step:2568/4150 train_time:486602ms step_avg:189.49ms
+step:2569/4150 train_time:486837ms step_avg:189.50ms
+step:2570/4150 train_time:487075ms step_avg:189.52ms
+step:2571/4150 train_time:487309ms step_avg:189.54ms
+step:2572/4150 train_time:487546ms step_avg:189.56ms
+step:2573/4150 train_time:487780ms step_avg:189.58ms
+step:2574/4150 train_time:488018ms step_avg:189.60ms
+step:2575/4150 train_time:488254ms step_avg:189.61ms
+step:2576/4150 train_time:488492ms step_avg:189.63ms
+step:2577/4150 train_time:488724ms step_avg:189.65ms
+step:2578/4150 train_time:488964ms step_avg:189.67ms
+step:2579/4150 train_time:489199ms step_avg:189.69ms
+step:2580/4150 train_time:489435ms step_avg:189.70ms
+step:2581/4150 train_time:489671ms step_avg:189.72ms
+step:2582/4150 train_time:489908ms step_avg:189.74ms
+step:2583/4150 train_time:490138ms step_avg:189.76ms
+step:2584/4150 train_time:490374ms step_avg:189.77ms
+step:2585/4150 train_time:490608ms step_avg:189.79ms
+step:2586/4150 train_time:490845ms step_avg:189.81ms
+step:2587/4150 train_time:491078ms step_avg:189.83ms
+step:2588/4150 train_time:491313ms step_avg:189.84ms
+step:2589/4150 train_time:491547ms step_avg:189.86ms
+step:2590/4150 train_time:491784ms step_avg:189.88ms
+step:2591/4150 train_time:492020ms step_avg:189.90ms
+step:2592/4150 train_time:492257ms step_avg:189.91ms
+step:2593/4150 train_time:492492ms step_avg:189.93ms
+step:2594/4150 train_time:492731ms step_avg:189.95ms
+step:2595/4150 train_time:492965ms step_avg:189.97ms
+step:2596/4150 train_time:493203ms step_avg:189.99ms
+step:2597/4150 train_time:493437ms step_avg:190.00ms
+step:2598/4150 train_time:493675ms step_avg:190.02ms
+step:2599/4150 train_time:493908ms step_avg:190.04ms
+step:2600/4150 train_time:494145ms step_avg:190.06ms
+step:2601/4150 train_time:494378ms step_avg:190.07ms
+step:2602/4150 train_time:494614ms step_avg:190.09ms
+step:2603/4150 train_time:494852ms step_avg:190.11ms
+step:2604/4150 train_time:495087ms step_avg:190.13ms
+step:2605/4150 train_time:495318ms step_avg:190.14ms
+step:2606/4150 train_time:495556ms step_avg:190.16ms
+step:2607/4150 train_time:495793ms step_avg:190.18ms
+step:2608/4150 train_time:496030ms step_avg:190.20ms
+step:2609/4150 train_time:496260ms step_avg:190.21ms
+step:2610/4150 train_time:496495ms step_avg:190.23ms
+step:2611/4150 train_time:496728ms step_avg:190.24ms
+step:2612/4150 train_time:496965ms step_avg:190.26ms
+step:2613/4150 train_time:497200ms step_avg:190.28ms
+step:2614/4150 train_time:497434ms step_avg:190.30ms
+step:2615/4150 train_time:497667ms step_avg:190.31ms
+step:2616/4150 train_time:497905ms step_avg:190.33ms
+step:2617/4150 train_time:498137ms step_avg:190.35ms
+step:2618/4150 train_time:498375ms step_avg:190.36ms
+step:2619/4150 train_time:498609ms step_avg:190.38ms
+step:2620/4150 train_time:498846ms step_avg:190.40ms
+step:2621/4150 train_time:499077ms step_avg:190.41ms
+step:2622/4150 train_time:499316ms step_avg:190.43ms
+step:2623/4150 train_time:499550ms step_avg:190.45ms
+step:2624/4150 train_time:499792ms step_avg:190.47ms
+step:2625/4150 train_time:500027ms step_avg:190.49ms
+step:2626/4150 train_time:500263ms step_avg:190.50ms
+step:2627/4150 train_time:500498ms step_avg:190.52ms
+step:2628/4150 train_time:500736ms step_avg:190.54ms
+step:2629/4150 train_time:500971ms step_avg:190.56ms
+step:2630/4150 train_time:501206ms step_avg:190.57ms
+step:2631/4150 train_time:501438ms step_avg:190.59ms
+step:2632/4150 train_time:501678ms step_avg:190.61ms
+step:2633/4150 train_time:501910ms step_avg:190.62ms
+step:2634/4150 train_time:502146ms step_avg:190.64ms
+step:2635/4150 train_time:502377ms step_avg:190.66ms
+step:2636/4150 train_time:502618ms step_avg:190.67ms
+step:2637/4150 train_time:502851ms step_avg:190.69ms
+step:2638/4150 train_time:503090ms step_avg:190.71ms
+step:2639/4150 train_time:503323ms step_avg:190.72ms
+step:2640/4150 train_time:503562ms step_avg:190.74ms
+step:2641/4150 train_time:503798ms step_avg:190.76ms
+step:2642/4150 train_time:504036ms step_avg:190.78ms
+step:2643/4150 train_time:504269ms step_avg:190.79ms
+step:2644/4150 train_time:504505ms step_avg:190.81ms
+step:2645/4150 train_time:504741ms step_avg:190.83ms
+step:2646/4150 train_time:504981ms step_avg:190.85ms
+step:2647/4150 train_time:505216ms step_avg:190.86ms
+step:2648/4150 train_time:505453ms step_avg:190.88ms
+step:2649/4150 train_time:505687ms step_avg:190.90ms
+step:2650/4150 train_time:505923ms step_avg:190.91ms
+step:2651/4150 train_time:506158ms step_avg:190.93ms
+step:2652/4150 train_time:506396ms step_avg:190.95ms
+step:2653/4150 train_time:506637ms step_avg:190.97ms
+step:2654/4150 train_time:506873ms step_avg:190.98ms
+step:2655/4150 train_time:507104ms step_avg:191.00ms
+step:2656/4150 train_time:507343ms step_avg:191.02ms
+step:2657/4150 train_time:507579ms step_avg:191.03ms
+step:2658/4150 train_time:507818ms step_avg:191.05ms
+step:2659/4150 train_time:508050ms step_avg:191.07ms
+step:2660/4150 train_time:508287ms step_avg:191.09ms
+step:2661/4150 train_time:508521ms step_avg:191.10ms
+step:2662/4150 train_time:508761ms step_avg:191.12ms
+step:2663/4150 train_time:508997ms step_avg:191.14ms
+step:2664/4150 train_time:509234ms step_avg:191.15ms
+step:2665/4150 train_time:509466ms step_avg:191.17ms
+step:2666/4150 train_time:509703ms step_avg:191.19ms
+step:2667/4150 train_time:509938ms step_avg:191.20ms
+step:2668/4150 train_time:510175ms step_avg:191.22ms
+step:2669/4150 train_time:510410ms step_avg:191.24ms
+step:2670/4150 train_time:510645ms step_avg:191.25ms
+step:2671/4150 train_time:510881ms step_avg:191.27ms
+step:2672/4150 train_time:511121ms step_avg:191.29ms
+step:2673/4150 train_time:511356ms step_avg:191.30ms
+step:2674/4150 train_time:511592ms step_avg:191.32ms
+step:2675/4150 train_time:511824ms step_avg:191.34ms
+step:2676/4150 train_time:512061ms step_avg:191.35ms
+step:2677/4150 train_time:512294ms step_avg:191.37ms
+step:2678/4150 train_time:512528ms step_avg:191.38ms
+step:2679/4150 train_time:512760ms step_avg:191.40ms
+step:2680/4150 train_time:512999ms step_avg:191.42ms
+step:2681/4150 train_time:513235ms step_avg:191.43ms
+step:2682/4150 train_time:513473ms step_avg:191.45ms
+step:2683/4150 train_time:513703ms step_avg:191.47ms
+step:2684/4150 train_time:513942ms step_avg:191.48ms
+step:2685/4150 train_time:514178ms step_avg:191.50ms
+step:2686/4150 train_time:514416ms step_avg:191.52ms
+step:2687/4150 train_time:514650ms step_avg:191.53ms
+step:2688/4150 train_time:514887ms step_avg:191.55ms
+step:2689/4150 train_time:515123ms step_avg:191.57ms
+step:2690/4150 train_time:515360ms step_avg:191.58ms
+step:2691/4150 train_time:515592ms step_avg:191.60ms
+step:2692/4150 train_time:515829ms step_avg:191.62ms
+step:2693/4150 train_time:516064ms step_avg:191.63ms
+step:2694/4150 train_time:516303ms step_avg:191.65ms
+step:2695/4150 train_time:516537ms step_avg:191.67ms
+step:2696/4150 train_time:516774ms step_avg:191.68ms
+step:2697/4150 train_time:517009ms step_avg:191.70ms
+step:2698/4150 train_time:517249ms step_avg:191.72ms
+step:2699/4150 train_time:517485ms step_avg:191.73ms
+step:2700/4150 train_time:517720ms step_avg:191.75ms
+step:2701/4150 train_time:517951ms step_avg:191.76ms
+step:2702/4150 train_time:518193ms step_avg:191.78ms
+step:2703/4150 train_time:518429ms step_avg:191.80ms
+step:2704/4150 train_time:518667ms step_avg:191.81ms
+step:2705/4150 train_time:518900ms step_avg:191.83ms
+step:2706/4150 train_time:519138ms step_avg:191.85ms
+step:2707/4150 train_time:519376ms step_avg:191.86ms
+step:2708/4150 train_time:519613ms step_avg:191.88ms
+step:2709/4150 train_time:519844ms step_avg:191.90ms
+step:2710/4150 train_time:520081ms step_avg:191.91ms
+step:2711/4150 train_time:520313ms step_avg:191.93ms
+step:2712/4150 train_time:520549ms step_avg:191.94ms
+step:2713/4150 train_time:520781ms step_avg:191.96ms
+step:2714/4150 train_time:521017ms step_avg:191.97ms
+step:2715/4150 train_time:521251ms step_avg:191.99ms
+step:2716/4150 train_time:521489ms step_avg:192.01ms
+step:2717/4150 train_time:521720ms step_avg:192.02ms
+step:2718/4150 train_time:521955ms step_avg:192.04ms
+step:2719/4150 train_time:522188ms step_avg:192.05ms
+step:2720/4150 train_time:522424ms step_avg:192.07ms
+step:2721/4150 train_time:522658ms step_avg:192.08ms
+step:2722/4150 train_time:522893ms step_avg:192.10ms
+step:2723/4150 train_time:523126ms step_avg:192.11ms
+step:2724/4150 train_time:523363ms step_avg:192.13ms
+step:2725/4150 train_time:523598ms step_avg:192.15ms
+step:2726/4150 train_time:523836ms step_avg:192.16ms
+step:2727/4150 train_time:524069ms step_avg:192.18ms
+step:2728/4150 train_time:524308ms step_avg:192.19ms
+step:2729/4150 train_time:524542ms step_avg:192.21ms
+step:2730/4150 train_time:524781ms step_avg:192.23ms
+step:2731/4150 train_time:525017ms step_avg:192.24ms
+step:2732/4150 train_time:525252ms step_avg:192.26ms
+step:2733/4150 train_time:525486ms step_avg:192.27ms
+step:2734/4150 train_time:525723ms step_avg:192.29ms
+step:2735/4150 train_time:525954ms step_avg:192.31ms
+step:2736/4150 train_time:526189ms step_avg:192.32ms
+step:2737/4150 train_time:526423ms step_avg:192.34ms
+step:2738/4150 train_time:526658ms step_avg:192.35ms
+step:2739/4150 train_time:526896ms step_avg:192.37ms
+step:2740/4150 train_time:527136ms step_avg:192.39ms
+step:2741/4150 train_time:527372ms step_avg:192.40ms
+step:2742/4150 train_time:527610ms step_avg:192.42ms
+step:2743/4150 train_time:527844ms step_avg:192.43ms
+step:2744/4150 train_time:528080ms step_avg:192.45ms
+step:2745/4150 train_time:528314ms step_avg:192.46ms
+step:2746/4150 train_time:528552ms step_avg:192.48ms
+step:2747/4150 train_time:528785ms step_avg:192.50ms
+step:2748/4150 train_time:529022ms step_avg:192.51ms
+step:2749/4150 train_time:529259ms step_avg:192.53ms
+step:2750/4150 train_time:529498ms step_avg:192.54ms
+step:2750/4150 val_loss:3.0726 train_time:529718ms step_avg:192.62ms
+step:2751/4150 train_time:529742ms step_avg:192.56ms
+step:2752/4150 train_time:529981ms step_avg:192.58ms
+step:2753/4150 train_time:530218ms step_avg:192.60ms
+step:2754/4150 train_time:530452ms step_avg:192.61ms
+step:2755/4150 train_time:530684ms step_avg:192.63ms
+step:2756/4150 train_time:530922ms step_avg:192.64ms
+step:2757/4150 train_time:531159ms step_avg:192.66ms
+step:2758/4150 train_time:531397ms step_avg:192.67ms
+step:2759/4150 train_time:531630ms step_avg:192.69ms
+step:2760/4150 train_time:531868ms step_avg:192.71ms
+step:2761/4150 train_time:532106ms step_avg:192.72ms
+step:2762/4150 train_time:532343ms step_avg:192.74ms
+step:2763/4150 train_time:532575ms step_avg:192.75ms
+step:2764/4150 train_time:532812ms step_avg:192.77ms
+step:2765/4150 train_time:533048ms step_avg:192.78ms
+step:2766/4150 train_time:533287ms step_avg:192.80ms
+step:2767/4150 train_time:533520ms step_avg:192.82ms
+step:2768/4150 train_time:533756ms step_avg:192.83ms
+step:2769/4150 train_time:533991ms step_avg:192.85ms
+step:2770/4150 train_time:534231ms step_avg:192.86ms
+step:2771/4150 train_time:534465ms step_avg:192.88ms
+step:2772/4150 train_time:534701ms step_avg:192.89ms
+step:2773/4150 train_time:534934ms step_avg:192.91ms
+step:2774/4150 train_time:535171ms step_avg:192.92ms
+step:2775/4150 train_time:535406ms step_avg:192.94ms
+step:2776/4150 train_time:535647ms step_avg:192.96ms
+step:2777/4150 train_time:535883ms step_avg:192.97ms
+step:2778/4150 train_time:536121ms step_avg:192.99ms
+step:2779/4150 train_time:536356ms step_avg:193.00ms
+step:2780/4150 train_time:536593ms step_avg:193.02ms
+step:2781/4150 train_time:536831ms step_avg:193.04ms
+step:2782/4150 train_time:537065ms step_avg:193.05ms
+step:2783/4150 train_time:537300ms step_avg:193.06ms
+step:2784/4150 train_time:537538ms step_avg:193.08ms
+step:2785/4150 train_time:537772ms step_avg:193.10ms
+step:2786/4150 train_time:538009ms step_avg:193.11ms
+step:2787/4150 train_time:538244ms step_avg:193.13ms
+step:2788/4150 train_time:538484ms step_avg:193.14ms
+step:2789/4150 train_time:538717ms step_avg:193.16ms
+step:2790/4150 train_time:538954ms step_avg:193.17ms
+step:2791/4150 train_time:539190ms step_avg:193.19ms
+step:2792/4150 train_time:539425ms step_avg:193.20ms
+step:2793/4150 train_time:539659ms step_avg:193.22ms
+step:2794/4150 train_time:539896ms step_avg:193.23ms
+step:2795/4150 train_time:540133ms step_avg:193.25ms
+step:2796/4150 train_time:540372ms step_avg:193.27ms
+step:2797/4150 train_time:540605ms step_avg:193.28ms
+step:2798/4150 train_time:540841ms step_avg:193.30ms
+step:2799/4150 train_time:541081ms step_avg:193.31ms
+step:2800/4150 train_time:541317ms step_avg:193.33ms
+step:2801/4150 train_time:541550ms step_avg:193.34ms
+step:2802/4150 train_time:541787ms step_avg:193.36ms
+step:2803/4150 train_time:542021ms step_avg:193.37ms
+step:2804/4150 train_time:542256ms step_avg:193.39ms
+step:2805/4150 train_time:542490ms step_avg:193.40ms
+step:2806/4150 train_time:542727ms step_avg:193.42ms
+step:2807/4150 train_time:542960ms step_avg:193.43ms
+step:2808/4150 train_time:543198ms step_avg:193.45ms
+step:2809/4150 train_time:543431ms step_avg:193.46ms
+step:2810/4150 train_time:543673ms step_avg:193.48ms
+step:2811/4150 train_time:543907ms step_avg:193.49ms
+step:2812/4150 train_time:544143ms step_avg:193.51ms
+step:2813/4150 train_time:544377ms step_avg:193.52ms
+step:2814/4150 train_time:544615ms step_avg:193.54ms
+step:2815/4150 train_time:544854ms step_avg:193.55ms
+step:2816/4150 train_time:545093ms step_avg:193.57ms
+step:2817/4150 train_time:545328ms step_avg:193.58ms
+step:2818/4150 train_time:545566ms step_avg:193.60ms
+step:2819/4150 train_time:545799ms step_avg:193.61ms
+step:2820/4150 train_time:546037ms step_avg:193.63ms
+step:2821/4150 train_time:546271ms step_avg:193.64ms
+step:2822/4150 train_time:546510ms step_avg:193.66ms
+step:2823/4150 train_time:546743ms step_avg:193.67ms
+step:2824/4150 train_time:546981ms step_avg:193.69ms
+step:2825/4150 train_time:547219ms step_avg:193.71ms
+step:2826/4150 train_time:547456ms step_avg:193.72ms
+step:2827/4150 train_time:547692ms step_avg:193.74ms
+step:2828/4150 train_time:547930ms step_avg:193.75ms
+step:2829/4150 train_time:548164ms step_avg:193.77ms
+step:2830/4150 train_time:548404ms step_avg:193.78ms
+step:2831/4150 train_time:548640ms step_avg:193.80ms
+step:2832/4150 train_time:548878ms step_avg:193.81ms
+step:2833/4150 train_time:549114ms step_avg:193.83ms
+step:2834/4150 train_time:549350ms step_avg:193.84ms
+step:2835/4150 train_time:549586ms step_avg:193.86ms
+step:2836/4150 train_time:549824ms step_avg:193.87ms
+step:2837/4150 train_time:550058ms step_avg:193.89ms
+step:2838/4150 train_time:550297ms step_avg:193.90ms
+step:2839/4150 train_time:550533ms step_avg:193.92ms
+step:2840/4150 train_time:550773ms step_avg:193.93ms
+step:2841/4150 train_time:551008ms step_avg:193.95ms
+step:2842/4150 train_time:551243ms step_avg:193.96ms
+step:2843/4150 train_time:551478ms step_avg:193.98ms
+step:2844/4150 train_time:551717ms step_avg:193.99ms
+step:2845/4150 train_time:551953ms step_avg:194.01ms
+step:2846/4150 train_time:552189ms step_avg:194.02ms
+step:2847/4150 train_time:552423ms step_avg:194.04ms
+step:2848/4150 train_time:552662ms step_avg:194.05ms
+step:2849/4150 train_time:552896ms step_avg:194.07ms
+step:2850/4150 train_time:553135ms step_avg:194.08ms
+step:2851/4150 train_time:553367ms step_avg:194.10ms
+step:2852/4150 train_time:553605ms step_avg:194.11ms
+step:2853/4150 train_time:553838ms step_avg:194.12ms
+step:2854/4150 train_time:554075ms step_avg:194.14ms
+step:2855/4150 train_time:554312ms step_avg:194.15ms
+step:2856/4150 train_time:554550ms step_avg:194.17ms
+step:2857/4150 train_time:554787ms step_avg:194.19ms
+step:2858/4150 train_time:555023ms step_avg:194.20ms
+step:2859/4150 train_time:555256ms step_avg:194.21ms
+step:2860/4150 train_time:555496ms step_avg:194.23ms
+step:2861/4150 train_time:555731ms step_avg:194.24ms
+step:2862/4150 train_time:555969ms step_avg:194.26ms
+step:2863/4150 train_time:556203ms step_avg:194.27ms
+step:2864/4150 train_time:556437ms step_avg:194.29ms
+step:2865/4150 train_time:556672ms step_avg:194.30ms
+step:2866/4150 train_time:556911ms step_avg:194.32ms
+step:2867/4150 train_time:557145ms step_avg:194.33ms
+step:2868/4150 train_time:557381ms step_avg:194.34ms
+step:2869/4150 train_time:557615ms step_avg:194.36ms
+step:2870/4150 train_time:557854ms step_avg:194.37ms
+step:2871/4150 train_time:558091ms step_avg:194.39ms
+step:2872/4150 train_time:558328ms step_avg:194.40ms
+step:2873/4150 train_time:558561ms step_avg:194.42ms
+step:2874/4150 train_time:558798ms step_avg:194.43ms
+step:2875/4150 train_time:559034ms step_avg:194.45ms
+step:2876/4150 train_time:559271ms step_avg:194.46ms
+step:2877/4150 train_time:559506ms step_avg:194.48ms
+step:2878/4150 train_time:559746ms step_avg:194.49ms
+step:2879/4150 train_time:559978ms step_avg:194.50ms
+step:2880/4150 train_time:560217ms step_avg:194.52ms
+step:2881/4150 train_time:560451ms step_avg:194.53ms
+step:2882/4150 train_time:560689ms step_avg:194.55ms
+step:2883/4150 train_time:560923ms step_avg:194.56ms
+step:2884/4150 train_time:561161ms step_avg:194.58ms
+step:2885/4150 train_time:561394ms step_avg:194.59ms
+step:2886/4150 train_time:561633ms step_avg:194.61ms
+step:2887/4150 train_time:561869ms step_avg:194.62ms
+step:2888/4150 train_time:562108ms step_avg:194.64ms
+step:2889/4150 train_time:562340ms step_avg:194.65ms
+step:2890/4150 train_time:562579ms step_avg:194.66ms
+step:2891/4150 train_time:562815ms step_avg:194.68ms
+step:2892/4150 train_time:563056ms step_avg:194.69ms
+step:2893/4150 train_time:563290ms step_avg:194.71ms
+step:2894/4150 train_time:563526ms step_avg:194.72ms
+step:2895/4150 train_time:563759ms step_avg:194.74ms
+step:2896/4150 train_time:563997ms step_avg:194.75ms
+step:2897/4150 train_time:564236ms step_avg:194.77ms
+step:2898/4150 train_time:564472ms step_avg:194.78ms
+step:2899/4150 train_time:564708ms step_avg:194.79ms
+step:2900/4150 train_time:564944ms step_avg:194.81ms
+step:2901/4150 train_time:565180ms step_avg:194.82ms
+step:2902/4150 train_time:565417ms step_avg:194.84ms
+step:2903/4150 train_time:565652ms step_avg:194.85ms
+step:2904/4150 train_time:565889ms step_avg:194.87ms
+step:2905/4150 train_time:566124ms step_avg:194.88ms
+step:2906/4150 train_time:566361ms step_avg:194.89ms
+step:2907/4150 train_time:566592ms step_avg:194.91ms
+step:2908/4150 train_time:566830ms step_avg:194.92ms
+step:2909/4150 train_time:567071ms step_avg:194.94ms
+step:2910/4150 train_time:567310ms step_avg:194.95ms
+step:2911/4150 train_time:567545ms step_avg:194.97ms
+step:2912/4150 train_time:567782ms step_avg:194.98ms
+step:2913/4150 train_time:568015ms step_avg:194.99ms
+step:2914/4150 train_time:568254ms step_avg:195.01ms
+step:2915/4150 train_time:568490ms step_avg:195.02ms
+step:2916/4150 train_time:568726ms step_avg:195.04ms
+step:2917/4150 train_time:568958ms step_avg:195.05ms
+step:2918/4150 train_time:569197ms step_avg:195.06ms
+step:2919/4150 train_time:569433ms step_avg:195.08ms
+step:2920/4150 train_time:569669ms step_avg:195.09ms
+step:2921/4150 train_time:569903ms step_avg:195.11ms
+step:2922/4150 train_time:570139ms step_avg:195.12ms
+step:2923/4150 train_time:570374ms step_avg:195.13ms
+step:2924/4150 train_time:570613ms step_avg:195.15ms
+step:2925/4150 train_time:570849ms step_avg:195.16ms
+step:2926/4150 train_time:571084ms step_avg:195.18ms
+step:2927/4150 train_time:571317ms step_avg:195.19ms
+step:2928/4150 train_time:571554ms step_avg:195.20ms
+step:2929/4150 train_time:571793ms step_avg:195.22ms
+step:2930/4150 train_time:572028ms step_avg:195.23ms
+step:2931/4150 train_time:572263ms step_avg:195.25ms
+step:2932/4150 train_time:572501ms step_avg:195.26ms
+step:2933/4150 train_time:572735ms step_avg:195.27ms
+step:2934/4150 train_time:572976ms step_avg:195.29ms
+step:2935/4150 train_time:573212ms step_avg:195.30ms
+step:2936/4150 train_time:573452ms step_avg:195.32ms
+step:2937/4150 train_time:573685ms step_avg:195.33ms
+step:2938/4150 train_time:573923ms step_avg:195.34ms
+step:2939/4150 train_time:574159ms step_avg:195.36ms
+step:2940/4150 train_time:574396ms step_avg:195.37ms
+step:2941/4150 train_time:574635ms step_avg:195.39ms
+step:2942/4150 train_time:574871ms step_avg:195.40ms
+step:2943/4150 train_time:575108ms step_avg:195.42ms
+step:2944/4150 train_time:575346ms step_avg:195.43ms
+step:2945/4150 train_time:575578ms step_avg:195.44ms
+step:2946/4150 train_time:575818ms step_avg:195.46ms
+step:2947/4150 train_time:576051ms step_avg:195.47ms
+step:2948/4150 train_time:576287ms step_avg:195.48ms
+step:2949/4150 train_time:576519ms step_avg:195.50ms
+step:2950/4150 train_time:576756ms step_avg:195.51ms
+step:2951/4150 train_time:576991ms step_avg:195.52ms
+step:2952/4150 train_time:577228ms step_avg:195.54ms
+step:2953/4150 train_time:577462ms step_avg:195.55ms
+step:2954/4150 train_time:577700ms step_avg:195.57ms
+step:2955/4150 train_time:577937ms step_avg:195.58ms
+step:2956/4150 train_time:578175ms step_avg:195.59ms
+step:2957/4150 train_time:578410ms step_avg:195.61ms
+step:2958/4150 train_time:578646ms step_avg:195.62ms
+step:2959/4150 train_time:578884ms step_avg:195.63ms
+step:2960/4150 train_time:579123ms step_avg:195.65ms
+step:2961/4150 train_time:579356ms step_avg:195.66ms
+step:2962/4150 train_time:579594ms step_avg:195.68ms
+step:2963/4150 train_time:579826ms step_avg:195.69ms
+step:2964/4150 train_time:580067ms step_avg:195.70ms
+step:2965/4150 train_time:580300ms step_avg:195.72ms
+step:2966/4150 train_time:580535ms step_avg:195.73ms
+step:2967/4150 train_time:580773ms step_avg:195.74ms
+step:2968/4150 train_time:581013ms step_avg:195.76ms
+step:2969/4150 train_time:581251ms step_avg:195.77ms
+step:2970/4150 train_time:581492ms step_avg:195.79ms
+step:2971/4150 train_time:581728ms step_avg:195.80ms
+step:2972/4150 train_time:581966ms step_avg:195.82ms
+step:2973/4150 train_time:582199ms step_avg:195.83ms
+step:2974/4150 train_time:582434ms step_avg:195.84ms
+step:2975/4150 train_time:582670ms step_avg:195.86ms
+step:2976/4150 train_time:582910ms step_avg:195.87ms
+step:2977/4150 train_time:583146ms step_avg:195.88ms
+step:2978/4150 train_time:583380ms step_avg:195.90ms
+step:2979/4150 train_time:583615ms step_avg:195.91ms
+step:2980/4150 train_time:583854ms step_avg:195.92ms
+step:2981/4150 train_time:584090ms step_avg:195.94ms
+step:2982/4150 train_time:584328ms step_avg:195.95ms
+step:2983/4150 train_time:584561ms step_avg:195.96ms
+step:2984/4150 train_time:584800ms step_avg:195.98ms
+step:2985/4150 train_time:585037ms step_avg:195.99ms
+step:2986/4150 train_time:585275ms step_avg:196.01ms
+step:2987/4150 train_time:585510ms step_avg:196.02ms
+step:2988/4150 train_time:585751ms step_avg:196.03ms
+step:2989/4150 train_time:585986ms step_avg:196.05ms
+step:2990/4150 train_time:586223ms step_avg:196.06ms
+step:2991/4150 train_time:586456ms step_avg:196.07ms
+step:2992/4150 train_time:586696ms step_avg:196.09ms
+step:2993/4150 train_time:586928ms step_avg:196.10ms
+step:2994/4150 train_time:587167ms step_avg:196.11ms
+step:2995/4150 train_time:587401ms step_avg:196.13ms
+step:2996/4150 train_time:587635ms step_avg:196.14ms
+step:2997/4150 train_time:587868ms step_avg:196.15ms
+step:2998/4150 train_time:588107ms step_avg:196.17ms
+step:2999/4150 train_time:588342ms step_avg:196.18ms
+step:3000/4150 train_time:588578ms step_avg:196.19ms
+step:3000/4150 val_loss:3.0406 train_time:588794ms step_avg:196.26ms
+step:3001/4150 train_time:588816ms step_avg:196.21ms
+step:3002/4150 train_time:589057ms step_avg:196.22ms
+step:3003/4150 train_time:589293ms step_avg:196.23ms
+step:3004/4150 train_time:589527ms step_avg:196.25ms
+step:3005/4150 train_time:589762ms step_avg:196.26ms
+step:3006/4150 train_time:590000ms step_avg:196.27ms
+step:3007/4150 train_time:590237ms step_avg:196.29ms
+step:3008/4150 train_time:590478ms step_avg:196.30ms
+step:3009/4150 train_time:590709ms step_avg:196.31ms
+step:3010/4150 train_time:590946ms step_avg:196.33ms
+step:3011/4150 train_time:591181ms step_avg:196.34ms
+step:3012/4150 train_time:591420ms step_avg:196.35ms
+step:3013/4150 train_time:591653ms step_avg:196.37ms
+step:3014/4150 train_time:591890ms step_avg:196.38ms
+step:3015/4150 train_time:592127ms step_avg:196.39ms
+step:3016/4150 train_time:592366ms step_avg:196.41ms
+step:3017/4150 train_time:592600ms step_avg:196.42ms
+step:3018/4150 train_time:592835ms step_avg:196.43ms
+step:3019/4150 train_time:593070ms step_avg:196.45ms
+step:3020/4150 train_time:593309ms step_avg:196.46ms
+step:3021/4150 train_time:593547ms step_avg:196.47ms
+step:3022/4150 train_time:593783ms step_avg:196.49ms
+step:3023/4150 train_time:594019ms step_avg:196.50ms
+step:3024/4150 train_time:594257ms step_avg:196.51ms
+step:3025/4150 train_time:594491ms step_avg:196.53ms
+step:3026/4150 train_time:594726ms step_avg:196.54ms
+step:3027/4150 train_time:594961ms step_avg:196.55ms
+step:3028/4150 train_time:595198ms step_avg:196.56ms
+step:3029/4150 train_time:595432ms step_avg:196.58ms
+step:3030/4150 train_time:595670ms step_avg:196.59ms
+step:3031/4150 train_time:595902ms step_avg:196.60ms
+step:3032/4150 train_time:596140ms step_avg:196.62ms
+step:3033/4150 train_time:596374ms step_avg:196.63ms
+step:3034/4150 train_time:596613ms step_avg:196.64ms
+step:3035/4150 train_time:596849ms step_avg:196.66ms
+step:3036/4150 train_time:597083ms step_avg:196.67ms
+step:3037/4150 train_time:597318ms step_avg:196.68ms
+step:3038/4150 train_time:597556ms step_avg:196.69ms
+step:3039/4150 train_time:597793ms step_avg:196.71ms
+step:3040/4150 train_time:598030ms step_avg:196.72ms
+step:3041/4150 train_time:598269ms step_avg:196.73ms
+step:3042/4150 train_time:598506ms step_avg:196.75ms
+step:3043/4150 train_time:598739ms step_avg:196.76ms
+step:3044/4150 train_time:598976ms step_avg:196.77ms
+step:3045/4150 train_time:599212ms step_avg:196.79ms
+step:3046/4150 train_time:599450ms step_avg:196.80ms
+step:3047/4150 train_time:599685ms step_avg:196.81ms
+step:3048/4150 train_time:599924ms step_avg:196.83ms
+step:3049/4150 train_time:600158ms step_avg:196.84ms
+step:3050/4150 train_time:600397ms step_avg:196.85ms
+step:3051/4150 train_time:600629ms step_avg:196.86ms
+step:3052/4150 train_time:600867ms step_avg:196.88ms
+step:3053/4150 train_time:601104ms step_avg:196.89ms
+step:3054/4150 train_time:601339ms step_avg:196.90ms
+step:3055/4150 train_time:601572ms step_avg:196.91ms
+step:3056/4150 train_time:601809ms step_avg:196.93ms
+step:3057/4150 train_time:602045ms step_avg:196.94ms
+step:3058/4150 train_time:602282ms step_avg:196.95ms
+step:3059/4150 train_time:602516ms step_avg:196.97ms
+step:3060/4150 train_time:602756ms step_avg:196.98ms
+step:3061/4150 train_time:602991ms step_avg:196.99ms
+step:3062/4150 train_time:603227ms step_avg:197.00ms
+step:3063/4150 train_time:603464ms step_avg:197.02ms
+step:3064/4150 train_time:603705ms step_avg:197.03ms
+step:3065/4150 train_time:603939ms step_avg:197.04ms
+step:3066/4150 train_time:604178ms step_avg:197.06ms
+step:3067/4150 train_time:604412ms step_avg:197.07ms
+step:3068/4150 train_time:604647ms step_avg:197.08ms
+step:3069/4150 train_time:604881ms step_avg:197.09ms
+step:3070/4150 train_time:605119ms step_avg:197.11ms
+step:3071/4150 train_time:605356ms step_avg:197.12ms
+step:3072/4150 train_time:605592ms step_avg:197.13ms
+step:3073/4150 train_time:605825ms step_avg:197.14ms
+step:3074/4150 train_time:606063ms step_avg:197.16ms
+step:3075/4150 train_time:606303ms step_avg:197.17ms
+step:3076/4150 train_time:606539ms step_avg:197.18ms
+step:3077/4150 train_time:606771ms step_avg:197.20ms
+step:3078/4150 train_time:607009ms step_avg:197.21ms
+step:3079/4150 train_time:607245ms step_avg:197.22ms
+step:3080/4150 train_time:607480ms step_avg:197.23ms
+step:3081/4150 train_time:607714ms step_avg:197.25ms
+step:3082/4150 train_time:607950ms step_avg:197.26ms
+step:3083/4150 train_time:608186ms step_avg:197.27ms
+step:3084/4150 train_time:608427ms step_avg:197.28ms
+step:3085/4150 train_time:608660ms step_avg:197.30ms
+step:3086/4150 train_time:608899ms step_avg:197.31ms
+step:3087/4150 train_time:609132ms step_avg:197.32ms
+step:3088/4150 train_time:609370ms step_avg:197.33ms
+step:3089/4150 train_time:609604ms step_avg:197.35ms
+step:3090/4150 train_time:609840ms step_avg:197.36ms
+step:3091/4150 train_time:610075ms step_avg:197.37ms
+step:3092/4150 train_time:610314ms step_avg:197.38ms
+step:3093/4150 train_time:610551ms step_avg:197.40ms
+step:3094/4150 train_time:610787ms step_avg:197.41ms
+step:3095/4150 train_time:611019ms step_avg:197.42ms
+step:3096/4150 train_time:611256ms step_avg:197.43ms
+step:3097/4150 train_time:611492ms step_avg:197.45ms
+step:3098/4150 train_time:611729ms step_avg:197.46ms
+step:3099/4150 train_time:611965ms step_avg:197.47ms
+step:3100/4150 train_time:612202ms step_avg:197.48ms
+step:3101/4150 train_time:612436ms step_avg:197.50ms
+step:3102/4150 train_time:612673ms step_avg:197.51ms
+step:3103/4150 train_time:612907ms step_avg:197.52ms
+step:3104/4150 train_time:613144ms step_avg:197.53ms
+step:3105/4150 train_time:613379ms step_avg:197.55ms
+step:3106/4150 train_time:613617ms step_avg:197.56ms
+step:3107/4150 train_time:613851ms step_avg:197.57ms
+step:3108/4150 train_time:614090ms step_avg:197.58ms
+step:3109/4150 train_time:614325ms step_avg:197.60ms
+step:3110/4150 train_time:614565ms step_avg:197.61ms
+step:3111/4150 train_time:614799ms step_avg:197.62ms
+step:3112/4150 train_time:615034ms step_avg:197.63ms
+step:3113/4150 train_time:615270ms step_avg:197.65ms
+step:3114/4150 train_time:615510ms step_avg:197.66ms
+step:3115/4150 train_time:615748ms step_avg:197.67ms
+step:3116/4150 train_time:615986ms step_avg:197.68ms
+step:3117/4150 train_time:616220ms step_avg:197.70ms
+step:3118/4150 train_time:616457ms step_avg:197.71ms
+step:3119/4150 train_time:616692ms step_avg:197.72ms
+step:3120/4150 train_time:616934ms step_avg:197.74ms
+step:3121/4150 train_time:617170ms step_avg:197.75ms
+step:3122/4150 train_time:617406ms step_avg:197.76ms
+step:3123/4150 train_time:617639ms step_avg:197.77ms
+step:3124/4150 train_time:617876ms step_avg:197.78ms
+step:3125/4150 train_time:618108ms step_avg:197.79ms
+step:3126/4150 train_time:618345ms step_avg:197.81ms
+step:3127/4150 train_time:618580ms step_avg:197.82ms
+step:3128/4150 train_time:618818ms step_avg:197.83ms
+step:3129/4150 train_time:619051ms step_avg:197.84ms
+step:3130/4150 train_time:619289ms step_avg:197.86ms
+step:3131/4150 train_time:619523ms step_avg:197.87ms
+step:3132/4150 train_time:619758ms step_avg:197.88ms
+step:3133/4150 train_time:619994ms step_avg:197.89ms
+step:3134/4150 train_time:620231ms step_avg:197.90ms
+step:3135/4150 train_time:620466ms step_avg:197.92ms
+step:3136/4150 train_time:620704ms step_avg:197.93ms
+step:3137/4150 train_time:620942ms step_avg:197.94ms
+step:3138/4150 train_time:621182ms step_avg:197.95ms
+step:3139/4150 train_time:621418ms step_avg:197.97ms
+step:3140/4150 train_time:621658ms step_avg:197.98ms
+step:3141/4150 train_time:621892ms step_avg:197.99ms
+step:3142/4150 train_time:622129ms step_avg:198.00ms
+step:3143/4150 train_time:622361ms step_avg:198.01ms
+step:3144/4150 train_time:622605ms step_avg:198.03ms
+step:3145/4150 train_time:622840ms step_avg:198.04ms
+step:3146/4150 train_time:623079ms step_avg:198.05ms
+step:3147/4150 train_time:623313ms step_avg:198.07ms
+step:3148/4150 train_time:623548ms step_avg:198.08ms
+step:3149/4150 train_time:623782ms step_avg:198.09ms
+step:3150/4150 train_time:624024ms step_avg:198.10ms
+step:3151/4150 train_time:624258ms step_avg:198.11ms
+step:3152/4150 train_time:624494ms step_avg:198.13ms
+step:3153/4150 train_time:624729ms step_avg:198.14ms
+step:3154/4150 train_time:624967ms step_avg:198.15ms
+step:3155/4150 train_time:625205ms step_avg:198.16ms
+step:3156/4150 train_time:625442ms step_avg:198.18ms
+step:3157/4150 train_time:625678ms step_avg:198.19ms
+step:3158/4150 train_time:625921ms step_avg:198.20ms
+step:3159/4150 train_time:626155ms step_avg:198.21ms
+step:3160/4150 train_time:626397ms step_avg:198.23ms
+step:3161/4150 train_time:626631ms step_avg:198.24ms
+step:3162/4150 train_time:626868ms step_avg:198.25ms
+step:3163/4150 train_time:627105ms step_avg:198.26ms
+step:3164/4150 train_time:627346ms step_avg:198.28ms
+step:3165/4150 train_time:627581ms step_avg:198.29ms
+step:3166/4150 train_time:627816ms step_avg:198.30ms
+step:3167/4150 train_time:628050ms step_avg:198.31ms
+step:3168/4150 train_time:628289ms step_avg:198.32ms
+step:3169/4150 train_time:628522ms step_avg:198.33ms
+step:3170/4150 train_time:628758ms step_avg:198.35ms
+step:3171/4150 train_time:628993ms step_avg:198.36ms
+step:3172/4150 train_time:629230ms step_avg:198.37ms
+step:3173/4150 train_time:629467ms step_avg:198.38ms
+step:3174/4150 train_time:629705ms step_avg:198.39ms
+step:3175/4150 train_time:629941ms step_avg:198.41ms
+step:3176/4150 train_time:630179ms step_avg:198.42ms
+step:3177/4150 train_time:630415ms step_avg:198.43ms
+step:3178/4150 train_time:630650ms step_avg:198.44ms
+step:3179/4150 train_time:630885ms step_avg:198.45ms
+step:3180/4150 train_time:631123ms step_avg:198.47ms
+step:3181/4150 train_time:631356ms step_avg:198.48ms
+step:3182/4150 train_time:631592ms step_avg:198.49ms
+step:3183/4150 train_time:631827ms step_avg:198.50ms
+step:3184/4150 train_time:632062ms step_avg:198.51ms
+step:3185/4150 train_time:632296ms step_avg:198.52ms
+step:3186/4150 train_time:632534ms step_avg:198.54ms
+step:3187/4150 train_time:632769ms step_avg:198.55ms
+step:3188/4150 train_time:633006ms step_avg:198.56ms
+step:3189/4150 train_time:633241ms step_avg:198.57ms
+step:3190/4150 train_time:633479ms step_avg:198.58ms
+step:3191/4150 train_time:633713ms step_avg:198.59ms
+step:3192/4150 train_time:633948ms step_avg:198.61ms
+step:3193/4150 train_time:634184ms step_avg:198.62ms
+step:3194/4150 train_time:634421ms step_avg:198.63ms
+step:3195/4150 train_time:634656ms step_avg:198.64ms
+step:3196/4150 train_time:634891ms step_avg:198.65ms
+step:3197/4150 train_time:635123ms step_avg:198.66ms
+step:3198/4150 train_time:635360ms step_avg:198.67ms
+step:3199/4150 train_time:635598ms step_avg:198.69ms
+step:3200/4150 train_time:635833ms step_avg:198.70ms
+step:3201/4150 train_time:636068ms step_avg:198.71ms
+step:3202/4150 train_time:636306ms step_avg:198.72ms
+step:3203/4150 train_time:636540ms step_avg:198.73ms
+step:3204/4150 train_time:636778ms step_avg:198.74ms
+step:3205/4150 train_time:637015ms step_avg:198.76ms
+step:3206/4150 train_time:637252ms step_avg:198.77ms
+step:3207/4150 train_time:637486ms step_avg:198.78ms
+step:3208/4150 train_time:637723ms step_avg:198.79ms
+step:3209/4150 train_time:637957ms step_avg:198.80ms
+step:3210/4150 train_time:638193ms step_avg:198.81ms
+step:3211/4150 train_time:638428ms step_avg:198.83ms
+step:3212/4150 train_time:638666ms step_avg:198.84ms
+step:3213/4150 train_time:638900ms step_avg:198.85ms
+step:3214/4150 train_time:639135ms step_avg:198.86ms
+step:3215/4150 train_time:639367ms step_avg:198.87ms
+step:3216/4150 train_time:639604ms step_avg:198.88ms
+step:3217/4150 train_time:639844ms step_avg:198.89ms
+step:3218/4150 train_time:640080ms step_avg:198.91ms
+step:3219/4150 train_time:640315ms step_avg:198.92ms
+step:3220/4150 train_time:640551ms step_avg:198.93ms
+step:3221/4150 train_time:640785ms step_avg:198.94ms
+step:3222/4150 train_time:641020ms step_avg:198.95ms
+step:3223/4150 train_time:641254ms step_avg:198.96ms
+step:3224/4150 train_time:641491ms step_avg:198.97ms
+step:3225/4150 train_time:641726ms step_avg:198.98ms
+step:3226/4150 train_time:641964ms step_avg:199.00ms
+step:3227/4150 train_time:642199ms step_avg:199.01ms
+step:3228/4150 train_time:642437ms step_avg:199.02ms
+step:3229/4150 train_time:642671ms step_avg:199.03ms
+step:3230/4150 train_time:642906ms step_avg:199.04ms
+step:3231/4150 train_time:643141ms step_avg:199.05ms
+step:3232/4150 train_time:643381ms step_avg:199.07ms
+step:3233/4150 train_time:643614ms step_avg:199.08ms
+step:3234/4150 train_time:643850ms step_avg:199.09ms
+step:3235/4150 train_time:644083ms step_avg:199.10ms
+step:3236/4150 train_time:644320ms step_avg:199.11ms
+step:3237/4150 train_time:644554ms step_avg:199.12ms
+step:3238/4150 train_time:644790ms step_avg:199.13ms
+step:3239/4150 train_time:645027ms step_avg:199.14ms
+step:3240/4150 train_time:645264ms step_avg:199.16ms
+step:3241/4150 train_time:645499ms step_avg:199.17ms
+step:3242/4150 train_time:645739ms step_avg:199.18ms
+step:3243/4150 train_time:645971ms step_avg:199.19ms
+step:3244/4150 train_time:646208ms step_avg:199.20ms
+step:3245/4150 train_time:646442ms step_avg:199.21ms
+step:3246/4150 train_time:646681ms step_avg:199.22ms
+step:3247/4150 train_time:646918ms step_avg:199.24ms
+step:3248/4150 train_time:647159ms step_avg:199.25ms
+step:3249/4150 train_time:647392ms step_avg:199.26ms
+step:3250/4150 train_time:647628ms step_avg:199.27ms
+step:3250/4150 val_loss:3.0090 train_time:647842ms step_avg:199.34ms
+step:3251/4150 train_time:647864ms step_avg:199.28ms
+step:3252/4150 train_time:648103ms step_avg:199.29ms
+step:3253/4150 train_time:648339ms step_avg:199.30ms
+step:3254/4150 train_time:648574ms step_avg:199.32ms
+step:3255/4150 train_time:648806ms step_avg:199.33ms
+step:3256/4150 train_time:649045ms step_avg:199.34ms
+step:3257/4150 train_time:649283ms step_avg:199.35ms
+step:3258/4150 train_time:649518ms step_avg:199.36ms
+step:3259/4150 train_time:649750ms step_avg:199.37ms
+step:3260/4150 train_time:649990ms step_avg:199.38ms
+step:3261/4150 train_time:650225ms step_avg:199.39ms
+step:3262/4150 train_time:650462ms step_avg:199.41ms
+step:3263/4150 train_time:650697ms step_avg:199.42ms
+step:3264/4150 train_time:650935ms step_avg:199.43ms
+step:3265/4150 train_time:651171ms step_avg:199.44ms
+step:3266/4150 train_time:651413ms step_avg:199.45ms
+step:3267/4150 train_time:651647ms step_avg:199.46ms
+step:3268/4150 train_time:651883ms step_avg:199.47ms
+step:3269/4150 train_time:652114ms step_avg:199.48ms
+step:3270/4150 train_time:652352ms step_avg:199.50ms
+step:3271/4150 train_time:652588ms step_avg:199.51ms
+step:3272/4150 train_time:652827ms step_avg:199.52ms
+step:3273/4150 train_time:653060ms step_avg:199.53ms
+step:3274/4150 train_time:653298ms step_avg:199.54ms
+step:3275/4150 train_time:653533ms step_avg:199.55ms
+step:3276/4150 train_time:653776ms step_avg:199.57ms
+step:3277/4150 train_time:654012ms step_avg:199.58ms
+step:3278/4150 train_time:654248ms step_avg:199.59ms
+step:3279/4150 train_time:654484ms step_avg:199.60ms
+step:3280/4150 train_time:654720ms step_avg:199.61ms
+step:3281/4150 train_time:654954ms step_avg:199.62ms
+step:3282/4150 train_time:655194ms step_avg:199.63ms
+step:3283/4150 train_time:655427ms step_avg:199.64ms
+step:3284/4150 train_time:655667ms step_avg:199.65ms
+step:3285/4150 train_time:655901ms step_avg:199.67ms
+step:3286/4150 train_time:656139ms step_avg:199.68ms
+step:3287/4150 train_time:656376ms step_avg:199.69ms
+step:3288/4150 train_time:656613ms step_avg:199.70ms
+step:3289/4150 train_time:656848ms step_avg:199.71ms
+step:3290/4150 train_time:657085ms step_avg:199.72ms
+step:3291/4150 train_time:657322ms step_avg:199.73ms
+step:3292/4150 train_time:657559ms step_avg:199.74ms
+step:3293/4150 train_time:657794ms step_avg:199.76ms
+step:3294/4150 train_time:658032ms step_avg:199.77ms
+step:3295/4150 train_time:658272ms step_avg:199.78ms
+step:3296/4150 train_time:658507ms step_avg:199.79ms
+step:3297/4150 train_time:658742ms step_avg:199.80ms
+step:3298/4150 train_time:658980ms step_avg:199.81ms
+step:3299/4150 train_time:659215ms step_avg:199.82ms
+step:3300/4150 train_time:659451ms step_avg:199.83ms
+step:3301/4150 train_time:659684ms step_avg:199.84ms
+step:3302/4150 train_time:659920ms step_avg:199.85ms
+step:3303/4150 train_time:660155ms step_avg:199.87ms
+step:3304/4150 train_time:660394ms step_avg:199.88ms
+step:3305/4150 train_time:660626ms step_avg:199.89ms
+step:3306/4150 train_time:660862ms step_avg:199.90ms
+step:3307/4150 train_time:661099ms step_avg:199.91ms
+step:3308/4150 train_time:661339ms step_avg:199.92ms
+step:3309/4150 train_time:661575ms step_avg:199.93ms
+step:3310/4150 train_time:661810ms step_avg:199.94ms
+step:3311/4150 train_time:662045ms step_avg:199.95ms
+step:3312/4150 train_time:662282ms step_avg:199.96ms
+step:3313/4150 train_time:662516ms step_avg:199.97ms
+step:3314/4150 train_time:662754ms step_avg:199.99ms
+step:3315/4150 train_time:662993ms step_avg:200.00ms
+step:3316/4150 train_time:663230ms step_avg:200.01ms
+step:3317/4150 train_time:663465ms step_avg:200.02ms
+step:3318/4150 train_time:663701ms step_avg:200.03ms
+step:3319/4150 train_time:663939ms step_avg:200.04ms
+step:3320/4150 train_time:664178ms step_avg:200.05ms
+step:3321/4150 train_time:664415ms step_avg:200.06ms
+step:3322/4150 train_time:664650ms step_avg:200.08ms
+step:3323/4150 train_time:664886ms step_avg:200.09ms
+step:3324/4150 train_time:665122ms step_avg:200.10ms
+step:3325/4150 train_time:665357ms step_avg:200.11ms
+step:3326/4150 train_time:665596ms step_avg:200.12ms
+step:3327/4150 train_time:665829ms step_avg:200.13ms
+step:3328/4150 train_time:666067ms step_avg:200.14ms
+step:3329/4150 train_time:666302ms step_avg:200.15ms
+step:3330/4150 train_time:666540ms step_avg:200.16ms
+step:3331/4150 train_time:666774ms step_avg:200.17ms
+step:3332/4150 train_time:667014ms step_avg:200.18ms
+step:3333/4150 train_time:667250ms step_avg:200.19ms
+step:3334/4150 train_time:667489ms step_avg:200.21ms
+step:3335/4150 train_time:667723ms step_avg:200.22ms
+step:3336/4150 train_time:667960ms step_avg:200.23ms
+step:3337/4150 train_time:668193ms step_avg:200.24ms
+step:3338/4150 train_time:668430ms step_avg:200.25ms
+step:3339/4150 train_time:668662ms step_avg:200.26ms
+step:3340/4150 train_time:668897ms step_avg:200.27ms
+step:3341/4150 train_time:669137ms step_avg:200.28ms
+step:3342/4150 train_time:669374ms step_avg:200.29ms
+step:3343/4150 train_time:669610ms step_avg:200.30ms
+step:3344/4150 train_time:669847ms step_avg:200.31ms
+step:3345/4150 train_time:670081ms step_avg:200.32ms
+step:3346/4150 train_time:670320ms step_avg:200.33ms
+step:3347/4150 train_time:670553ms step_avg:200.34ms
+step:3348/4150 train_time:670792ms step_avg:200.36ms
+step:3349/4150 train_time:671028ms step_avg:200.37ms
+step:3350/4150 train_time:671266ms step_avg:200.38ms
+step:3351/4150 train_time:671498ms step_avg:200.39ms
+step:3352/4150 train_time:671735ms step_avg:200.40ms
+step:3353/4150 train_time:671971ms step_avg:200.41ms
+step:3354/4150 train_time:672209ms step_avg:200.42ms
+step:3355/4150 train_time:672440ms step_avg:200.43ms
+step:3356/4150 train_time:672679ms step_avg:200.44ms
+step:3357/4150 train_time:672915ms step_avg:200.45ms
+step:3358/4150 train_time:673152ms step_avg:200.46ms
+step:3359/4150 train_time:673387ms step_avg:200.47ms
+step:3360/4150 train_time:673624ms step_avg:200.48ms
+step:3361/4150 train_time:673859ms step_avg:200.49ms
+step:3362/4150 train_time:674101ms step_avg:200.51ms
+step:3363/4150 train_time:674334ms step_avg:200.52ms
+step:3364/4150 train_time:674574ms step_avg:200.53ms
+step:3365/4150 train_time:674811ms step_avg:200.54ms
+step:3366/4150 train_time:675050ms step_avg:200.55ms
+step:3367/4150 train_time:675283ms step_avg:200.56ms
+step:3368/4150 train_time:675518ms step_avg:200.57ms
+step:3369/4150 train_time:675755ms step_avg:200.58ms
+step:3370/4150 train_time:675995ms step_avg:200.59ms
+step:3371/4150 train_time:676228ms step_avg:200.60ms
+step:3372/4150 train_time:676465ms step_avg:200.61ms
+step:3373/4150 train_time:676697ms step_avg:200.62ms
+step:3374/4150 train_time:676935ms step_avg:200.63ms
+step:3375/4150 train_time:677170ms step_avg:200.64ms
+step:3376/4150 train_time:677410ms step_avg:200.65ms
+step:3377/4150 train_time:677644ms step_avg:200.66ms
+step:3378/4150 train_time:677881ms step_avg:200.68ms
+step:3379/4150 train_time:678117ms step_avg:200.69ms
+step:3380/4150 train_time:678352ms step_avg:200.70ms
+step:3381/4150 train_time:678586ms step_avg:200.71ms
+step:3382/4150 train_time:678824ms step_avg:200.72ms
+step:3383/4150 train_time:679057ms step_avg:200.73ms
+step:3384/4150 train_time:679293ms step_avg:200.74ms
+step:3385/4150 train_time:679535ms step_avg:200.75ms
+step:3386/4150 train_time:679773ms step_avg:200.76ms
+step:3387/4150 train_time:680006ms step_avg:200.77ms
+step:3388/4150 train_time:680244ms step_avg:200.78ms
+step:3389/4150 train_time:680478ms step_avg:200.79ms
+step:3390/4150 train_time:680714ms step_avg:200.80ms
+step:3391/4150 train_time:680948ms step_avg:200.81ms
+step:3392/4150 train_time:681188ms step_avg:200.82ms
+step:3393/4150 train_time:681422ms step_avg:200.83ms
+step:3394/4150 train_time:681660ms step_avg:200.84ms
+step:3395/4150 train_time:681895ms step_avg:200.85ms
+step:3396/4150 train_time:682133ms step_avg:200.86ms
+step:3397/4150 train_time:682368ms step_avg:200.87ms
+step:3398/4150 train_time:682606ms step_avg:200.88ms
+step:3399/4150 train_time:682837ms step_avg:200.89ms
+step:3400/4150 train_time:683077ms step_avg:200.91ms
+step:3401/4150 train_time:683314ms step_avg:200.92ms
+step:3402/4150 train_time:683556ms step_avg:200.93ms
+step:3403/4150 train_time:683789ms step_avg:200.94ms
+step:3404/4150 train_time:684027ms step_avg:200.95ms
+step:3405/4150 train_time:684259ms step_avg:200.96ms
+step:3406/4150 train_time:684498ms step_avg:200.97ms
+step:3407/4150 train_time:684729ms step_avg:200.98ms
+step:3408/4150 train_time:684968ms step_avg:200.99ms
+step:3409/4150 train_time:685200ms step_avg:201.00ms
+step:3410/4150 train_time:685441ms step_avg:201.01ms
+step:3411/4150 train_time:685676ms step_avg:201.02ms
+step:3412/4150 train_time:685914ms step_avg:201.03ms
+step:3413/4150 train_time:686148ms step_avg:201.04ms
+step:3414/4150 train_time:686388ms step_avg:201.05ms
+step:3415/4150 train_time:686621ms step_avg:201.06ms
+step:3416/4150 train_time:686857ms step_avg:201.07ms
+step:3417/4150 train_time:687091ms step_avg:201.08ms
+step:3418/4150 train_time:687329ms step_avg:201.09ms
+step:3419/4150 train_time:687564ms step_avg:201.10ms
+step:3420/4150 train_time:687799ms step_avg:201.11ms
+step:3421/4150 train_time:688037ms step_avg:201.12ms
+step:3422/4150 train_time:688275ms step_avg:201.13ms
+step:3423/4150 train_time:688510ms step_avg:201.14ms
+step:3424/4150 train_time:688747ms step_avg:201.15ms
+step:3425/4150 train_time:688981ms step_avg:201.16ms
+step:3426/4150 train_time:689220ms step_avg:201.17ms
+step:3427/4150 train_time:689454ms step_avg:201.18ms
+step:3428/4150 train_time:689690ms step_avg:201.19ms
+step:3429/4150 train_time:689923ms step_avg:201.20ms
+step:3430/4150 train_time:690161ms step_avg:201.21ms
+step:3431/4150 train_time:690399ms step_avg:201.22ms
+step:3432/4150 train_time:690635ms step_avg:201.23ms
+step:3433/4150 train_time:690869ms step_avg:201.24ms
+step:3434/4150 train_time:691106ms step_avg:201.25ms
+step:3435/4150 train_time:691342ms step_avg:201.26ms
+step:3436/4150 train_time:691580ms step_avg:201.27ms
+step:3437/4150 train_time:691815ms step_avg:201.28ms
+step:3438/4150 train_time:692057ms step_avg:201.30ms
+step:3439/4150 train_time:692290ms step_avg:201.31ms
+step:3440/4150 train_time:692533ms step_avg:201.32ms
+step:3441/4150 train_time:692770ms step_avg:201.33ms
+step:3442/4150 train_time:693007ms step_avg:201.34ms
+step:3443/4150 train_time:693240ms step_avg:201.35ms
+step:3444/4150 train_time:693478ms step_avg:201.36ms
+step:3445/4150 train_time:693714ms step_avg:201.37ms
+step:3446/4150 train_time:693951ms step_avg:201.38ms
+step:3447/4150 train_time:694186ms step_avg:201.39ms
+step:3448/4150 train_time:694421ms step_avg:201.40ms
+step:3449/4150 train_time:694657ms step_avg:201.41ms
+step:3450/4150 train_time:694892ms step_avg:201.42ms
+step:3451/4150 train_time:695125ms step_avg:201.43ms
+step:3452/4150 train_time:695362ms step_avg:201.44ms
+step:3453/4150 train_time:695598ms step_avg:201.45ms
+step:3454/4150 train_time:695837ms step_avg:201.46ms
+step:3455/4150 train_time:696075ms step_avg:201.47ms
+step:3456/4150 train_time:696313ms step_avg:201.48ms
+step:3457/4150 train_time:696548ms step_avg:201.49ms
+step:3458/4150 train_time:696786ms step_avg:201.50ms
+step:3459/4150 train_time:697021ms step_avg:201.51ms
+step:3460/4150 train_time:697259ms step_avg:201.52ms
+step:3461/4150 train_time:697490ms step_avg:201.53ms
+step:3462/4150 train_time:697730ms step_avg:201.54ms
+step:3463/4150 train_time:697963ms step_avg:201.55ms
+step:3464/4150 train_time:698200ms step_avg:201.56ms
+step:3465/4150 train_time:698436ms step_avg:201.57ms
+step:3466/4150 train_time:698675ms step_avg:201.58ms
+step:3467/4150 train_time:698910ms step_avg:201.59ms
+step:3468/4150 train_time:699146ms step_avg:201.60ms
+step:3469/4150 train_time:699380ms step_avg:201.61ms
+step:3470/4150 train_time:699616ms step_avg:201.62ms
+step:3471/4150 train_time:699849ms step_avg:201.63ms
+step:3472/4150 train_time:700088ms step_avg:201.64ms
+step:3473/4150 train_time:700320ms step_avg:201.65ms
+step:3474/4150 train_time:700555ms step_avg:201.66ms
+step:3475/4150 train_time:700788ms step_avg:201.67ms
+step:3476/4150 train_time:701024ms step_avg:201.68ms
+step:3477/4150 train_time:701258ms step_avg:201.68ms
+step:3478/4150 train_time:701494ms step_avg:201.69ms
+step:3479/4150 train_time:701728ms step_avg:201.70ms
+step:3480/4150 train_time:701968ms step_avg:201.72ms
+step:3481/4150 train_time:702202ms step_avg:201.72ms
+step:3482/4150 train_time:702438ms step_avg:201.73ms
+step:3483/4150 train_time:702673ms step_avg:201.74ms
+step:3484/4150 train_time:702908ms step_avg:201.75ms
+step:3485/4150 train_time:703144ms step_avg:201.76ms
+step:3486/4150 train_time:703381ms step_avg:201.77ms
+step:3487/4150 train_time:703617ms step_avg:201.78ms
+step:3488/4150 train_time:703855ms step_avg:201.79ms
+step:3489/4150 train_time:704091ms step_avg:201.80ms
+step:3490/4150 train_time:704328ms step_avg:201.81ms
+step:3491/4150 train_time:704564ms step_avg:201.82ms
+step:3492/4150 train_time:704799ms step_avg:201.83ms
+step:3493/4150 train_time:705032ms step_avg:201.84ms
+step:3494/4150 train_time:705270ms step_avg:201.85ms
+step:3495/4150 train_time:705505ms step_avg:201.86ms
+step:3496/4150 train_time:705745ms step_avg:201.87ms
+step:3497/4150 train_time:705978ms step_avg:201.88ms
+step:3498/4150 train_time:706214ms step_avg:201.89ms
+step:3499/4150 train_time:706448ms step_avg:201.90ms
+step:3500/4150 train_time:706687ms step_avg:201.91ms
+step:3500/4150 val_loss:2.9773 train_time:706901ms step_avg:201.97ms
+step:3501/4150 train_time:706923ms step_avg:201.92ms
+step:3502/4150 train_time:707163ms step_avg:201.93ms
+step:3503/4150 train_time:707399ms step_avg:201.94ms
+step:3504/4150 train_time:707631ms step_avg:201.95ms
+step:3505/4150 train_time:707861ms step_avg:201.96ms
+step:3506/4150 train_time:708103ms step_avg:201.97ms
+step:3507/4150 train_time:708338ms step_avg:201.98ms
+step:3508/4150 train_time:708577ms step_avg:201.99ms
+step:3509/4150 train_time:708809ms step_avg:202.00ms
+step:3510/4150 train_time:709048ms step_avg:202.01ms
+step:3511/4150 train_time:709287ms step_avg:202.02ms
+step:3512/4150 train_time:709523ms step_avg:202.03ms
+step:3513/4150 train_time:709758ms step_avg:202.04ms
+step:3514/4150 train_time:709996ms step_avg:202.05ms
+step:3515/4150 train_time:710230ms step_avg:202.06ms
+step:3516/4150 train_time:710466ms step_avg:202.07ms
+step:3517/4150 train_time:710702ms step_avg:202.08ms
+step:3518/4150 train_time:710940ms step_avg:202.09ms
+step:3519/4150 train_time:711174ms step_avg:202.10ms
+step:3520/4150 train_time:711413ms step_avg:202.11ms
+step:3521/4150 train_time:711647ms step_avg:202.11ms
+step:3522/4150 train_time:711882ms step_avg:202.12ms
+step:3523/4150 train_time:712123ms step_avg:202.14ms
+step:3524/4150 train_time:712359ms step_avg:202.14ms
+step:3525/4150 train_time:712590ms step_avg:202.15ms
+step:3526/4150 train_time:712825ms step_avg:202.16ms
+step:3527/4150 train_time:713061ms step_avg:202.17ms
+step:3528/4150 train_time:713298ms step_avg:202.18ms
+step:3529/4150 train_time:713532ms step_avg:202.19ms
+step:3530/4150 train_time:713769ms step_avg:202.20ms
+step:3531/4150 train_time:714002ms step_avg:202.21ms
+step:3532/4150 train_time:714240ms step_avg:202.22ms
+step:3533/4150 train_time:714474ms step_avg:202.23ms
+step:3534/4150 train_time:714712ms step_avg:202.24ms
+step:3535/4150 train_time:714944ms step_avg:202.25ms
+step:3536/4150 train_time:715187ms step_avg:202.26ms
+step:3537/4150 train_time:715422ms step_avg:202.27ms
+step:3538/4150 train_time:715661ms step_avg:202.28ms
+step:3539/4150 train_time:715896ms step_avg:202.29ms
+step:3540/4150 train_time:716134ms step_avg:202.30ms
+step:3541/4150 train_time:716368ms step_avg:202.31ms
+step:3542/4150 train_time:716605ms step_avg:202.32ms
+step:3543/4150 train_time:716840ms step_avg:202.33ms
+step:3544/4150 train_time:717079ms step_avg:202.34ms
+step:3545/4150 train_time:717313ms step_avg:202.35ms
+step:3546/4150 train_time:717553ms step_avg:202.36ms
+step:3547/4150 train_time:717788ms step_avg:202.36ms
+step:3548/4150 train_time:718026ms step_avg:202.37ms
+step:3549/4150 train_time:718260ms step_avg:202.38ms
+step:3550/4150 train_time:718495ms step_avg:202.39ms
+step:3551/4150 train_time:718730ms step_avg:202.40ms
+step:3552/4150 train_time:718966ms step_avg:202.41ms
+step:3553/4150 train_time:719201ms step_avg:202.42ms
+step:3554/4150 train_time:719440ms step_avg:202.43ms
+step:3555/4150 train_time:719676ms step_avg:202.44ms
+step:3556/4150 train_time:719913ms step_avg:202.45ms
+step:3557/4150 train_time:720146ms step_avg:202.46ms
+step:3558/4150 train_time:720387ms step_avg:202.47ms
+step:3559/4150 train_time:720622ms step_avg:202.48ms
+step:3560/4150 train_time:720860ms step_avg:202.49ms
+step:3561/4150 train_time:721093ms step_avg:202.50ms
+step:3562/4150 train_time:721332ms step_avg:202.51ms
+step:3563/4150 train_time:721569ms step_avg:202.52ms
+step:3564/4150 train_time:721805ms step_avg:202.53ms
+step:3565/4150 train_time:722041ms step_avg:202.54ms
+step:3566/4150 train_time:722279ms step_avg:202.55ms
+step:3567/4150 train_time:722515ms step_avg:202.56ms
+step:3568/4150 train_time:722751ms step_avg:202.56ms
+step:3569/4150 train_time:722985ms step_avg:202.57ms
+step:3570/4150 train_time:723222ms step_avg:202.58ms
+step:3571/4150 train_time:723456ms step_avg:202.59ms
+step:3572/4150 train_time:723692ms step_avg:202.60ms
+step:3573/4150 train_time:723925ms step_avg:202.61ms
+step:3574/4150 train_time:724163ms step_avg:202.62ms
+step:3575/4150 train_time:724397ms step_avg:202.63ms
+step:3576/4150 train_time:724634ms step_avg:202.64ms
+step:3577/4150 train_time:724871ms step_avg:202.65ms
+step:3578/4150 train_time:725106ms step_avg:202.66ms
+step:3579/4150 train_time:725342ms step_avg:202.67ms
+step:3580/4150 train_time:725581ms step_avg:202.68ms
+step:3581/4150 train_time:725818ms step_avg:202.69ms
+step:3582/4150 train_time:726055ms step_avg:202.70ms
+step:3583/4150 train_time:726289ms step_avg:202.70ms
+step:3584/4150 train_time:726527ms step_avg:202.71ms
+step:3585/4150 train_time:726764ms step_avg:202.72ms
+step:3586/4150 train_time:727000ms step_avg:202.73ms
+step:3587/4150 train_time:727232ms step_avg:202.74ms
+step:3588/4150 train_time:727470ms step_avg:202.75ms
+step:3589/4150 train_time:727707ms step_avg:202.76ms
+step:3590/4150 train_time:727945ms step_avg:202.77ms
+step:3591/4150 train_time:728181ms step_avg:202.78ms
+step:3592/4150 train_time:728421ms step_avg:202.79ms
+step:3593/4150 train_time:728656ms step_avg:202.80ms
+step:3594/4150 train_time:728894ms step_avg:202.81ms
+step:3595/4150 train_time:729128ms step_avg:202.82ms
+step:3596/4150 train_time:729366ms step_avg:202.83ms
+step:3597/4150 train_time:729601ms step_avg:202.84ms
+step:3598/4150 train_time:729841ms step_avg:202.85ms
+step:3599/4150 train_time:730072ms step_avg:202.85ms
+step:3600/4150 train_time:730308ms step_avg:202.86ms
+step:3601/4150 train_time:730544ms step_avg:202.87ms
+step:3602/4150 train_time:730782ms step_avg:202.88ms
+step:3603/4150 train_time:731018ms step_avg:202.89ms
+step:3604/4150 train_time:731257ms step_avg:202.90ms
+step:3605/4150 train_time:731490ms step_avg:202.91ms
+step:3606/4150 train_time:731728ms step_avg:202.92ms
+step:3607/4150 train_time:731963ms step_avg:202.93ms
+step:3608/4150 train_time:732203ms step_avg:202.94ms
+step:3609/4150 train_time:732435ms step_avg:202.95ms
+step:3610/4150 train_time:732676ms step_avg:202.96ms
+step:3611/4150 train_time:732909ms step_avg:202.97ms
+step:3612/4150 train_time:733146ms step_avg:202.98ms
+step:3613/4150 train_time:733381ms step_avg:202.98ms
+step:3614/4150 train_time:733620ms step_avg:202.99ms
+step:3615/4150 train_time:733852ms step_avg:203.00ms
+step:3616/4150 train_time:734089ms step_avg:203.01ms
+step:3617/4150 train_time:734326ms step_avg:203.02ms
+step:3618/4150 train_time:734563ms step_avg:203.03ms
+step:3619/4150 train_time:734802ms step_avg:203.04ms
+step:3620/4150 train_time:735038ms step_avg:203.05ms
+step:3621/4150 train_time:735272ms step_avg:203.06ms
+step:3622/4150 train_time:735511ms step_avg:203.07ms
+step:3623/4150 train_time:735746ms step_avg:203.08ms
+step:3624/4150 train_time:735985ms step_avg:203.09ms
+step:3625/4150 train_time:736218ms step_avg:203.09ms
+step:3626/4150 train_time:736454ms step_avg:203.10ms
+step:3627/4150 train_time:736688ms step_avg:203.11ms
+step:3628/4150 train_time:736925ms step_avg:203.12ms
+step:3629/4150 train_time:737160ms step_avg:203.13ms
+step:3630/4150 train_time:737396ms step_avg:203.14ms
+step:3631/4150 train_time:737629ms step_avg:203.15ms
+step:3632/4150 train_time:737866ms step_avg:203.16ms
+step:3633/4150 train_time:738098ms step_avg:203.16ms
+step:3634/4150 train_time:738336ms step_avg:203.17ms
+step:3635/4150 train_time:738570ms step_avg:203.18ms
+step:3636/4150 train_time:738806ms step_avg:203.19ms
+step:3637/4150 train_time:739040ms step_avg:203.20ms
+step:3638/4150 train_time:739279ms step_avg:203.21ms
+step:3639/4150 train_time:739513ms step_avg:203.22ms
+step:3640/4150 train_time:739750ms step_avg:203.23ms
+step:3641/4150 train_time:739982ms step_avg:203.24ms
+step:3642/4150 train_time:740223ms step_avg:203.25ms
+step:3643/4150 train_time:740456ms step_avg:203.25ms
+step:3644/4150 train_time:740695ms step_avg:203.26ms
+step:3645/4150 train_time:740931ms step_avg:203.27ms
+step:3646/4150 train_time:741171ms step_avg:203.28ms
+step:3647/4150 train_time:741404ms step_avg:203.29ms
+step:3648/4150 train_time:741641ms step_avg:203.30ms
+step:3649/4150 train_time:741876ms step_avg:203.31ms
+step:3650/4150 train_time:742114ms step_avg:203.32ms
+step:3651/4150 train_time:742347ms step_avg:203.33ms
+step:3652/4150 train_time:742586ms step_avg:203.34ms
+step:3653/4150 train_time:742820ms step_avg:203.35ms
+step:3654/4150 train_time:743059ms step_avg:203.35ms
+step:3655/4150 train_time:743292ms step_avg:203.36ms
+step:3656/4150 train_time:743532ms step_avg:203.37ms
+step:3657/4150 train_time:743767ms step_avg:203.38ms
+step:3658/4150 train_time:744005ms step_avg:203.39ms
+step:3659/4150 train_time:744238ms step_avg:203.40ms
+step:3660/4150 train_time:744475ms step_avg:203.41ms
+step:3661/4150 train_time:744708ms step_avg:203.42ms
+step:3662/4150 train_time:744946ms step_avg:203.43ms
+step:3663/4150 train_time:745180ms step_avg:203.43ms
+step:3664/4150 train_time:745420ms step_avg:203.44ms
+step:3665/4150 train_time:745656ms step_avg:203.45ms
+step:3666/4150 train_time:745894ms step_avg:203.46ms
+step:3667/4150 train_time:746128ms step_avg:203.47ms
+step:3668/4150 train_time:746365ms step_avg:203.48ms
+step:3669/4150 train_time:746604ms step_avg:203.49ms
+step:3670/4150 train_time:746841ms step_avg:203.50ms
+step:3671/4150 train_time:747075ms step_avg:203.51ms
+step:3672/4150 train_time:747311ms step_avg:203.52ms
+step:3673/4150 train_time:747544ms step_avg:203.52ms
+step:3674/4150 train_time:747785ms step_avg:203.53ms
+step:3675/4150 train_time:748023ms step_avg:203.54ms
+step:3676/4150 train_time:748262ms step_avg:203.55ms
+step:3677/4150 train_time:748502ms step_avg:203.56ms
+step:3678/4150 train_time:748741ms step_avg:203.57ms
+step:3679/4150 train_time:748976ms step_avg:203.58ms
+step:3680/4150 train_time:749212ms step_avg:203.59ms
+step:3681/4150 train_time:749445ms step_avg:203.60ms
+step:3682/4150 train_time:749685ms step_avg:203.61ms
+step:3683/4150 train_time:749921ms step_avg:203.62ms
+step:3684/4150 train_time:750160ms step_avg:203.63ms
+step:3685/4150 train_time:750393ms step_avg:203.63ms
+step:3686/4150 train_time:750632ms step_avg:203.64ms
+step:3687/4150 train_time:750863ms step_avg:203.65ms
+step:3688/4150 train_time:751101ms step_avg:203.66ms
+step:3689/4150 train_time:751334ms step_avg:203.67ms
+step:3690/4150 train_time:751575ms step_avg:203.68ms
+step:3691/4150 train_time:751807ms step_avg:203.69ms
+step:3692/4150 train_time:752045ms step_avg:203.70ms
+step:3693/4150 train_time:752280ms step_avg:203.70ms
+step:3694/4150 train_time:752518ms step_avg:203.71ms
+step:3695/4150 train_time:752752ms step_avg:203.72ms
+step:3696/4150 train_time:752988ms step_avg:203.73ms
+step:3697/4150 train_time:753221ms step_avg:203.74ms
+step:3698/4150 train_time:753460ms step_avg:203.75ms
+step:3699/4150 train_time:753693ms step_avg:203.76ms
+step:3700/4150 train_time:753931ms step_avg:203.77ms
+step:3701/4150 train_time:754168ms step_avg:203.77ms
+step:3702/4150 train_time:754404ms step_avg:203.78ms
+step:3703/4150 train_time:754638ms step_avg:203.79ms
+step:3704/4150 train_time:754878ms step_avg:203.80ms
+step:3705/4150 train_time:755113ms step_avg:203.81ms
+step:3706/4150 train_time:755352ms step_avg:203.82ms
+step:3707/4150 train_time:755586ms step_avg:203.83ms
+step:3708/4150 train_time:755823ms step_avg:203.84ms
+step:3709/4150 train_time:756057ms step_avg:203.84ms
+step:3710/4150 train_time:756295ms step_avg:203.85ms
+step:3711/4150 train_time:756528ms step_avg:203.86ms
+step:3712/4150 train_time:756766ms step_avg:203.87ms
+step:3713/4150 train_time:757001ms step_avg:203.88ms
+step:3714/4150 train_time:757237ms step_avg:203.89ms
+step:3715/4150 train_time:757476ms step_avg:203.90ms
+step:3716/4150 train_time:757713ms step_avg:203.91ms
+step:3717/4150 train_time:757948ms step_avg:203.91ms
+step:3718/4150 train_time:758185ms step_avg:203.92ms
+step:3719/4150 train_time:758422ms step_avg:203.93ms
+step:3720/4150 train_time:758662ms step_avg:203.94ms
+step:3721/4150 train_time:758897ms step_avg:203.95ms
+step:3722/4150 train_time:759135ms step_avg:203.96ms
+step:3723/4150 train_time:759369ms step_avg:203.97ms
+step:3724/4150 train_time:759606ms step_avg:203.98ms
+step:3725/4150 train_time:759845ms step_avg:203.99ms
+step:3726/4150 train_time:760078ms step_avg:203.99ms
+step:3727/4150 train_time:760313ms step_avg:204.00ms
+step:3728/4150 train_time:760553ms step_avg:204.01ms
+step:3729/4150 train_time:760791ms step_avg:204.02ms
+step:3730/4150 train_time:761025ms step_avg:204.03ms
+step:3731/4150 train_time:761263ms step_avg:204.04ms
+step:3732/4150 train_time:761502ms step_avg:204.05ms
+step:3733/4150 train_time:761736ms step_avg:204.05ms
+step:3734/4150 train_time:761976ms step_avg:204.06ms
+step:3735/4150 train_time:762211ms step_avg:204.07ms
+step:3736/4150 train_time:762448ms step_avg:204.08ms
+step:3737/4150 train_time:762682ms step_avg:204.09ms
+step:3738/4150 train_time:762925ms step_avg:204.10ms
+step:3739/4150 train_time:763161ms step_avg:204.11ms
+step:3740/4150 train_time:763400ms step_avg:204.12ms
+step:3741/4150 train_time:763638ms step_avg:204.13ms
+step:3742/4150 train_time:763874ms step_avg:204.14ms
+step:3743/4150 train_time:764106ms step_avg:204.14ms
+step:3744/4150 train_time:764344ms step_avg:204.15ms
+step:3745/4150 train_time:764581ms step_avg:204.16ms
+step:3746/4150 train_time:764818ms step_avg:204.17ms
+step:3747/4150 train_time:765052ms step_avg:204.18ms
+step:3748/4150 train_time:765287ms step_avg:204.19ms
+step:3749/4150 train_time:765524ms step_avg:204.19ms
+step:3750/4150 train_time:765764ms step_avg:204.20ms
+step:3750/4150 val_loss:2.9503 train_time:765979ms step_avg:204.26ms
+step:3751/4150 train_time:766001ms step_avg:204.21ms
+step:3752/4150 train_time:766241ms step_avg:204.22ms
+step:3753/4150 train_time:766476ms step_avg:204.23ms
+step:3754/4150 train_time:766711ms step_avg:204.24ms
+step:3755/4150 train_time:766945ms step_avg:204.25ms
+step:3756/4150 train_time:767185ms step_avg:204.26ms
+step:3757/4150 train_time:767423ms step_avg:204.26ms
+step:3758/4150 train_time:767660ms step_avg:204.27ms
+step:3759/4150 train_time:767891ms step_avg:204.28ms
+step:3760/4150 train_time:768127ms step_avg:204.29ms
+step:3761/4150 train_time:768365ms step_avg:204.30ms
+step:3762/4150 train_time:768600ms step_avg:204.31ms
+step:3763/4150 train_time:768830ms step_avg:204.31ms
+step:3764/4150 train_time:769065ms step_avg:204.32ms
+step:3765/4150 train_time:769302ms step_avg:204.33ms
+step:3766/4150 train_time:769540ms step_avg:204.34ms
+step:3767/4150 train_time:769776ms step_avg:204.35ms
+step:3768/4150 train_time:770012ms step_avg:204.36ms
+step:3769/4150 train_time:770245ms step_avg:204.36ms
+step:3770/4150 train_time:770484ms step_avg:204.37ms
+step:3771/4150 train_time:770717ms step_avg:204.38ms
+step:3772/4150 train_time:770956ms step_avg:204.39ms
+step:3773/4150 train_time:771189ms step_avg:204.40ms
+step:3774/4150 train_time:771428ms step_avg:204.41ms
+step:3775/4150 train_time:771664ms step_avg:204.41ms
+step:3776/4150 train_time:771903ms step_avg:204.42ms
+step:3777/4150 train_time:772138ms step_avg:204.43ms
+step:3778/4150 train_time:772381ms step_avg:204.44ms
+step:3779/4150 train_time:772615ms step_avg:204.45ms
+step:3780/4150 train_time:772851ms step_avg:204.46ms
+step:3781/4150 train_time:773084ms step_avg:204.47ms
+step:3782/4150 train_time:773323ms step_avg:204.47ms
+step:3783/4150 train_time:773556ms step_avg:204.48ms
+step:3784/4150 train_time:773793ms step_avg:204.49ms
+step:3785/4150 train_time:774028ms step_avg:204.50ms
+step:3786/4150 train_time:774269ms step_avg:204.51ms
+step:3787/4150 train_time:774502ms step_avg:204.52ms
+step:3788/4150 train_time:774741ms step_avg:204.52ms
+step:3789/4150 train_time:774975ms step_avg:204.53ms
+step:3790/4150 train_time:775215ms step_avg:204.54ms
+step:3791/4150 train_time:775449ms step_avg:204.55ms
+step:3792/4150 train_time:775688ms step_avg:204.56ms
+step:3793/4150 train_time:775921ms step_avg:204.57ms
+step:3794/4150 train_time:776158ms step_avg:204.58ms
+step:3795/4150 train_time:776394ms step_avg:204.58ms
+step:3796/4150 train_time:776635ms step_avg:204.59ms
+step:3797/4150 train_time:776868ms step_avg:204.60ms
+step:3798/4150 train_time:777105ms step_avg:204.61ms
+step:3799/4150 train_time:777339ms step_avg:204.62ms
+step:3800/4150 train_time:777575ms step_avg:204.62ms
+step:3801/4150 train_time:777810ms step_avg:204.63ms
+step:3802/4150 train_time:778050ms step_avg:204.64ms
+step:3803/4150 train_time:778284ms step_avg:204.65ms
+step:3804/4150 train_time:778522ms step_avg:204.66ms
+step:3805/4150 train_time:778758ms step_avg:204.67ms
+step:3806/4150 train_time:778996ms step_avg:204.68ms
+step:3807/4150 train_time:779229ms step_avg:204.68ms
+step:3808/4150 train_time:779467ms step_avg:204.69ms
+step:3809/4150 train_time:779700ms step_avg:204.70ms
+step:3810/4150 train_time:779936ms step_avg:204.71ms
+step:3811/4150 train_time:780169ms step_avg:204.71ms
+step:3812/4150 train_time:780405ms step_avg:204.72ms
+step:3813/4150 train_time:780640ms step_avg:204.73ms
+step:3814/4150 train_time:780877ms step_avg:204.74ms
+step:3815/4150 train_time:781111ms step_avg:204.75ms
+step:3816/4150 train_time:781349ms step_avg:204.76ms
+step:3817/4150 train_time:781584ms step_avg:204.76ms
+step:3818/4150 train_time:781821ms step_avg:204.77ms
+step:3819/4150 train_time:782054ms step_avg:204.78ms
+step:3820/4150 train_time:782290ms step_avg:204.79ms
+step:3821/4150 train_time:782524ms step_avg:204.80ms
+step:3822/4150 train_time:782761ms step_avg:204.80ms
+step:3823/4150 train_time:782998ms step_avg:204.81ms
+step:3824/4150 train_time:783234ms step_avg:204.82ms
+step:3825/4150 train_time:783468ms step_avg:204.83ms
+step:3826/4150 train_time:783706ms step_avg:204.84ms
+step:3827/4150 train_time:783942ms step_avg:204.84ms
+step:3828/4150 train_time:784178ms step_avg:204.85ms
+step:3829/4150 train_time:784416ms step_avg:204.86ms
+step:3830/4150 train_time:784654ms step_avg:204.87ms
+step:3831/4150 train_time:784890ms step_avg:204.88ms
+step:3832/4150 train_time:785129ms step_avg:204.89ms
+step:3833/4150 train_time:785361ms step_avg:204.89ms
+step:3834/4150 train_time:785599ms step_avg:204.90ms
+step:3835/4150 train_time:785832ms step_avg:204.91ms
+step:3836/4150 train_time:786068ms step_avg:204.92ms
+step:3837/4150 train_time:786302ms step_avg:204.93ms
+step:3838/4150 train_time:786540ms step_avg:204.93ms
+step:3839/4150 train_time:786778ms step_avg:204.94ms
+step:3840/4150 train_time:787016ms step_avg:204.95ms
+step:3841/4150 train_time:787249ms step_avg:204.96ms
+step:3842/4150 train_time:787485ms step_avg:204.97ms
+step:3843/4150 train_time:787721ms step_avg:204.98ms
+step:3844/4150 train_time:787957ms step_avg:204.98ms
+step:3845/4150 train_time:788193ms step_avg:204.99ms
+step:3846/4150 train_time:788431ms step_avg:205.00ms
+step:3847/4150 train_time:788665ms step_avg:205.01ms
+step:3848/4150 train_time:788902ms step_avg:205.02ms
+step:3849/4150 train_time:789136ms step_avg:205.02ms
+step:3850/4150 train_time:789372ms step_avg:205.03ms
+step:3851/4150 train_time:789606ms step_avg:205.04ms
+step:3852/4150 train_time:789843ms step_avg:205.05ms
+step:3853/4150 train_time:790082ms step_avg:205.06ms
+step:3854/4150 train_time:790323ms step_avg:205.07ms
+step:3855/4150 train_time:790557ms step_avg:205.07ms
+step:3856/4150 train_time:790794ms step_avg:205.08ms
+step:3857/4150 train_time:791028ms step_avg:205.09ms
+step:3858/4150 train_time:791266ms step_avg:205.10ms
+step:3859/4150 train_time:791498ms step_avg:205.10ms
+step:3860/4150 train_time:791737ms step_avg:205.11ms
+step:3861/4150 train_time:791971ms step_avg:205.12ms
+step:3862/4150 train_time:792209ms step_avg:205.13ms
+step:3863/4150 train_time:792441ms step_avg:205.14ms
+step:3864/4150 train_time:792680ms step_avg:205.15ms
+step:3865/4150 train_time:792920ms step_avg:205.15ms
+step:3866/4150 train_time:793159ms step_avg:205.16ms
+step:3867/4150 train_time:793395ms step_avg:205.17ms
+step:3868/4150 train_time:793635ms step_avg:205.18ms
+step:3869/4150 train_time:793871ms step_avg:205.19ms
+step:3870/4150 train_time:794108ms step_avg:205.20ms
+step:3871/4150 train_time:794344ms step_avg:205.20ms
+step:3872/4150 train_time:794580ms step_avg:205.21ms
+step:3873/4150 train_time:794816ms step_avg:205.22ms
+step:3874/4150 train_time:795050ms step_avg:205.23ms
+step:3875/4150 train_time:795286ms step_avg:205.24ms
+step:3876/4150 train_time:795523ms step_avg:205.24ms
+step:3877/4150 train_time:795758ms step_avg:205.25ms
+step:3878/4150 train_time:795995ms step_avg:205.26ms
+step:3879/4150 train_time:796233ms step_avg:205.27ms
+step:3880/4150 train_time:796473ms step_avg:205.28ms
+step:3881/4150 train_time:796706ms step_avg:205.28ms
+step:3882/4150 train_time:796943ms step_avg:205.29ms
+step:3883/4150 train_time:797178ms step_avg:205.30ms
+step:3884/4150 train_time:797415ms step_avg:205.31ms
+step:3885/4150 train_time:797652ms step_avg:205.32ms
+step:3886/4150 train_time:797890ms step_avg:205.32ms
+step:3887/4150 train_time:798124ms step_avg:205.33ms
+step:3888/4150 train_time:798361ms step_avg:205.34ms
+step:3889/4150 train_time:798592ms step_avg:205.35ms
+step:3890/4150 train_time:798829ms step_avg:205.35ms
+step:3891/4150 train_time:799066ms step_avg:205.36ms
+step:3892/4150 train_time:799302ms step_avg:205.37ms
+step:3893/4150 train_time:799539ms step_avg:205.38ms
+step:3894/4150 train_time:799776ms step_avg:205.39ms
+step:3895/4150 train_time:800011ms step_avg:205.39ms
+step:3896/4150 train_time:800250ms step_avg:205.40ms
+step:3897/4150 train_time:800486ms step_avg:205.41ms
+step:3898/4150 train_time:800723ms step_avg:205.42ms
+step:3899/4150 train_time:800960ms step_avg:205.43ms
+step:3900/4150 train_time:801198ms step_avg:205.44ms
+step:3901/4150 train_time:801433ms step_avg:205.44ms
+step:3902/4150 train_time:801671ms step_avg:205.45ms
+step:3903/4150 train_time:801903ms step_avg:205.46ms
+step:3904/4150 train_time:802142ms step_avg:205.47ms
+step:3905/4150 train_time:802375ms step_avg:205.47ms
+step:3906/4150 train_time:802613ms step_avg:205.48ms
+step:3907/4150 train_time:802845ms step_avg:205.49ms
+step:3908/4150 train_time:803082ms step_avg:205.50ms
+step:3909/4150 train_time:803319ms step_avg:205.50ms
+step:3910/4150 train_time:803556ms step_avg:205.51ms
+step:3911/4150 train_time:803796ms step_avg:205.52ms
+step:3912/4150 train_time:804029ms step_avg:205.53ms
+step:3913/4150 train_time:804264ms step_avg:205.54ms
+step:3914/4150 train_time:804502ms step_avg:205.54ms
+step:3915/4150 train_time:804738ms step_avg:205.55ms
+step:3916/4150 train_time:804975ms step_avg:205.56ms
+step:3917/4150 train_time:805210ms step_avg:205.57ms
+step:3918/4150 train_time:805448ms step_avg:205.58ms
+step:3919/4150 train_time:805682ms step_avg:205.58ms
+step:3920/4150 train_time:805919ms step_avg:205.59ms
+step:3921/4150 train_time:806154ms step_avg:205.60ms
+step:3922/4150 train_time:806395ms step_avg:205.61ms
+step:3923/4150 train_time:806628ms step_avg:205.62ms
+step:3924/4150 train_time:806866ms step_avg:205.62ms
+step:3925/4150 train_time:807101ms step_avg:205.63ms
+step:3926/4150 train_time:807339ms step_avg:205.64ms
+step:3927/4150 train_time:807575ms step_avg:205.65ms
+step:3928/4150 train_time:807811ms step_avg:205.65ms
+step:3929/4150 train_time:808046ms step_avg:205.66ms
+step:3930/4150 train_time:808283ms step_avg:205.67ms
+step:3931/4150 train_time:808516ms step_avg:205.68ms
+step:3932/4150 train_time:808754ms step_avg:205.69ms
+step:3933/4150 train_time:808986ms step_avg:205.69ms
+step:3934/4150 train_time:809223ms step_avg:205.70ms
+step:3935/4150 train_time:809456ms step_avg:205.71ms
+step:3936/4150 train_time:809699ms step_avg:205.72ms
+step:3937/4150 train_time:809934ms step_avg:205.72ms
+step:3938/4150 train_time:810172ms step_avg:205.73ms
+step:3939/4150 train_time:810405ms step_avg:205.74ms
+step:3940/4150 train_time:810643ms step_avg:205.75ms
+step:3941/4150 train_time:810879ms step_avg:205.75ms
+step:3942/4150 train_time:811115ms step_avg:205.76ms
+step:3943/4150 train_time:811347ms step_avg:205.77ms
+step:3944/4150 train_time:811585ms step_avg:205.78ms
+step:3945/4150 train_time:811821ms step_avg:205.78ms
+step:3946/4150 train_time:812058ms step_avg:205.79ms
+step:3947/4150 train_time:812297ms step_avg:205.80ms
+step:3948/4150 train_time:812538ms step_avg:205.81ms
+step:3949/4150 train_time:812773ms step_avg:205.82ms
+step:3950/4150 train_time:813016ms step_avg:205.83ms
+step:3951/4150 train_time:813251ms step_avg:205.83ms
+step:3952/4150 train_time:813488ms step_avg:205.84ms
+step:3953/4150 train_time:813721ms step_avg:205.85ms
+step:3954/4150 train_time:813961ms step_avg:205.86ms
+step:3955/4150 train_time:814199ms step_avg:205.87ms
+step:3956/4150 train_time:814432ms step_avg:205.87ms
+step:3957/4150 train_time:814667ms step_avg:205.88ms
+step:3958/4150 train_time:814905ms step_avg:205.89ms
+step:3959/4150 train_time:815141ms step_avg:205.90ms
+step:3960/4150 train_time:815379ms step_avg:205.90ms
+step:3961/4150 train_time:815613ms step_avg:205.91ms
+step:3962/4150 train_time:815851ms step_avg:205.92ms
+step:3963/4150 train_time:816085ms step_avg:205.93ms
+step:3964/4150 train_time:816322ms step_avg:205.93ms
+step:3965/4150 train_time:816556ms step_avg:205.94ms
+step:3966/4150 train_time:816791ms step_avg:205.95ms
+step:3967/4150 train_time:817026ms step_avg:205.96ms
+step:3968/4150 train_time:817266ms step_avg:205.96ms
+step:3969/4150 train_time:817496ms step_avg:205.97ms
+step:3970/4150 train_time:817740ms step_avg:205.98ms
+step:3971/4150 train_time:817974ms step_avg:205.99ms
+step:3972/4150 train_time:818210ms step_avg:205.99ms
+step:3973/4150 train_time:818443ms step_avg:206.00ms
+step:3974/4150 train_time:818681ms step_avg:206.01ms
+step:3975/4150 train_time:818914ms step_avg:206.02ms
+step:3976/4150 train_time:819154ms step_avg:206.02ms
+step:3977/4150 train_time:819389ms step_avg:206.03ms
+step:3978/4150 train_time:819626ms step_avg:206.04ms
+step:3979/4150 train_time:819861ms step_avg:206.05ms
+step:3980/4150 train_time:820097ms step_avg:206.05ms
+step:3981/4150 train_time:820331ms step_avg:206.06ms
+step:3982/4150 train_time:820569ms step_avg:206.07ms
+step:3983/4150 train_time:820807ms step_avg:206.08ms
+step:3984/4150 train_time:821041ms step_avg:206.08ms
+step:3985/4150 train_time:821273ms step_avg:206.09ms
+step:3986/4150 train_time:821512ms step_avg:206.10ms
+step:3987/4150 train_time:821746ms step_avg:206.11ms
+step:3988/4150 train_time:821986ms step_avg:206.11ms
+step:3989/4150 train_time:822218ms step_avg:206.12ms
+step:3990/4150 train_time:822455ms step_avg:206.13ms
+step:3991/4150 train_time:822689ms step_avg:206.14ms
+step:3992/4150 train_time:822927ms step_avg:206.14ms
+step:3993/4150 train_time:823161ms step_avg:206.15ms
+step:3994/4150 train_time:823399ms step_avg:206.16ms
+step:3995/4150 train_time:823635ms step_avg:206.17ms
+step:3996/4150 train_time:823876ms step_avg:206.18ms
+step:3997/4150 train_time:824110ms step_avg:206.18ms
+step:3998/4150 train_time:824346ms step_avg:206.19ms
+step:3999/4150 train_time:824581ms step_avg:206.20ms
+step:4000/4150 train_time:824821ms step_avg:206.21ms
+step:4000/4150 val_loss:2.9273 train_time:825037ms step_avg:206.26ms
+step:4001/4150 train_time:825061ms step_avg:206.21ms
+step:4002/4150 train_time:825303ms step_avg:206.22ms
+step:4003/4150 train_time:825540ms step_avg:206.23ms
+step:4004/4150 train_time:825775ms step_avg:206.24ms
+step:4005/4150 train_time:826009ms step_avg:206.24ms
+step:4006/4150 train_time:826249ms step_avg:206.25ms
+step:4007/4150 train_time:826489ms step_avg:206.26ms
+step:4008/4150 train_time:826724ms step_avg:206.27ms
+step:4009/4150 train_time:826955ms step_avg:206.27ms
+step:4010/4150 train_time:827194ms step_avg:206.28ms
+step:4011/4150 train_time:827432ms step_avg:206.29ms
+step:4012/4150 train_time:827669ms step_avg:206.30ms
+step:4013/4150 train_time:827902ms step_avg:206.31ms
+step:4014/4150 train_time:828138ms step_avg:206.31ms
+step:4015/4150 train_time:828373ms step_avg:206.32ms
+step:4016/4150 train_time:828612ms step_avg:206.33ms
+step:4017/4150 train_time:828843ms step_avg:206.33ms
+step:4018/4150 train_time:829079ms step_avg:206.34ms
+step:4019/4150 train_time:829317ms step_avg:206.35ms
+step:4020/4150 train_time:829553ms step_avg:206.36ms
+step:4021/4150 train_time:829788ms step_avg:206.36ms
+step:4022/4150 train_time:830023ms step_avg:206.37ms
+step:4023/4150 train_time:830257ms step_avg:206.38ms
+step:4024/4150 train_time:830497ms step_avg:206.39ms
+step:4025/4150 train_time:830733ms step_avg:206.39ms
+step:4026/4150 train_time:830968ms step_avg:206.40ms
+step:4027/4150 train_time:831203ms step_avg:206.41ms
+step:4028/4150 train_time:831441ms step_avg:206.42ms
+step:4029/4150 train_time:831676ms step_avg:206.42ms
+step:4030/4150 train_time:831913ms step_avg:206.43ms
+step:4031/4150 train_time:832146ms step_avg:206.44ms
+step:4032/4150 train_time:832387ms step_avg:206.45ms
+step:4033/4150 train_time:832622ms step_avg:206.45ms
+step:4034/4150 train_time:832861ms step_avg:206.46ms
+step:4035/4150 train_time:833091ms step_avg:206.47ms
+step:4036/4150 train_time:833326ms step_avg:206.47ms
+step:4037/4150 train_time:833562ms step_avg:206.48ms
+step:4038/4150 train_time:833803ms step_avg:206.49ms
+step:4039/4150 train_time:834038ms step_avg:206.50ms
+step:4040/4150 train_time:834275ms step_avg:206.50ms
+step:4041/4150 train_time:834510ms step_avg:206.51ms
+step:4042/4150 train_time:834749ms step_avg:206.52ms
+step:4043/4150 train_time:834980ms step_avg:206.52ms
+step:4044/4150 train_time:835218ms step_avg:206.53ms
+step:4045/4150 train_time:835452ms step_avg:206.54ms
+step:4046/4150 train_time:835687ms step_avg:206.55ms
+step:4047/4150 train_time:835920ms step_avg:206.55ms
+step:4048/4150 train_time:836156ms step_avg:206.56ms
+step:4049/4150 train_time:836390ms step_avg:206.57ms
+step:4050/4150 train_time:836629ms step_avg:206.58ms
+step:4051/4150 train_time:836865ms step_avg:206.58ms
+step:4052/4150 train_time:837101ms step_avg:206.59ms
+step:4053/4150 train_time:837336ms step_avg:206.60ms
+step:4054/4150 train_time:837574ms step_avg:206.60ms
+step:4055/4150 train_time:837807ms step_avg:206.61ms
+step:4056/4150 train_time:838045ms step_avg:206.62ms
+step:4057/4150 train_time:838279ms step_avg:206.63ms
+step:4058/4150 train_time:838516ms step_avg:206.63ms
+step:4059/4150 train_time:838751ms step_avg:206.64ms
+step:4060/4150 train_time:838987ms step_avg:206.65ms
+step:4061/4150 train_time:839225ms step_avg:206.65ms
+step:4062/4150 train_time:839460ms step_avg:206.66ms
+step:4063/4150 train_time:839692ms step_avg:206.67ms
+step:4064/4150 train_time:839930ms step_avg:206.68ms
+step:4065/4150 train_time:840167ms step_avg:206.68ms
+step:4066/4150 train_time:840401ms step_avg:206.69ms
+step:4067/4150 train_time:840637ms step_avg:206.70ms
+step:4068/4150 train_time:840875ms step_avg:206.70ms
+step:4069/4150 train_time:841115ms step_avg:206.71ms
+step:4070/4150 train_time:841354ms step_avg:206.72ms
+step:4071/4150 train_time:841589ms step_avg:206.73ms
+step:4072/4150 train_time:841823ms step_avg:206.73ms
+step:4073/4150 train_time:842058ms step_avg:206.74ms
+step:4074/4150 train_time:842297ms step_avg:206.75ms
+step:4075/4150 train_time:842532ms step_avg:206.76ms
+step:4076/4150 train_time:842768ms step_avg:206.76ms
+step:4077/4150 train_time:843004ms step_avg:206.77ms
+step:4078/4150 train_time:843241ms step_avg:206.78ms
+step:4079/4150 train_time:843475ms step_avg:206.78ms
+step:4080/4150 train_time:843711ms step_avg:206.79ms
+step:4081/4150 train_time:843947ms step_avg:206.80ms
+step:4082/4150 train_time:844186ms step_avg:206.81ms
+step:4083/4150 train_time:844421ms step_avg:206.81ms
+step:4084/4150 train_time:844662ms step_avg:206.82ms
+step:4085/4150 train_time:844898ms step_avg:206.83ms
+step:4086/4150 train_time:845135ms step_avg:206.84ms
+step:4087/4150 train_time:845371ms step_avg:206.84ms
+step:4088/4150 train_time:845607ms step_avg:206.85ms
+step:4089/4150 train_time:845843ms step_avg:206.86ms
+step:4090/4150 train_time:846086ms step_avg:206.87ms
+step:4091/4150 train_time:846321ms step_avg:206.87ms
+step:4092/4150 train_time:846558ms step_avg:206.88ms
+step:4093/4150 train_time:846792ms step_avg:206.89ms
+step:4094/4150 train_time:847031ms step_avg:206.90ms
+step:4095/4150 train_time:847265ms step_avg:206.90ms
+step:4096/4150 train_time:847504ms step_avg:206.91ms
+step:4097/4150 train_time:847738ms step_avg:206.92ms
+step:4098/4150 train_time:847973ms step_avg:206.92ms
+step:4099/4150 train_time:848207ms step_avg:206.93ms
+step:4100/4150 train_time:848446ms step_avg:206.94ms
+step:4101/4150 train_time:848686ms step_avg:206.95ms
+step:4102/4150 train_time:848923ms step_avg:206.95ms
+step:4103/4150 train_time:849156ms step_avg:206.96ms
+step:4104/4150 train_time:849394ms step_avg:206.97ms
+step:4105/4150 train_time:849627ms step_avg:206.97ms
+step:4106/4150 train_time:849865ms step_avg:206.98ms
+step:4107/4150 train_time:850098ms step_avg:206.99ms
+step:4108/4150 train_time:850335ms step_avg:206.99ms
+step:4109/4150 train_time:850571ms step_avg:207.00ms
+step:4110/4150 train_time:850809ms step_avg:207.01ms
+step:4111/4150 train_time:851045ms step_avg:207.02ms
+step:4112/4150 train_time:851282ms step_avg:207.02ms
+step:4113/4150 train_time:851517ms step_avg:207.03ms
+step:4114/4150 train_time:851753ms step_avg:207.04ms
+step:4115/4150 train_time:851988ms step_avg:207.04ms
+step:4116/4150 train_time:852225ms step_avg:207.05ms
+step:4117/4150 train_time:852462ms step_avg:207.06ms
+step:4118/4150 train_time:852698ms step_avg:207.07ms
+step:4119/4150 train_time:852932ms step_avg:207.07ms
+step:4120/4150 train_time:853169ms step_avg:207.08ms
+step:4121/4150 train_time:853404ms step_avg:207.09ms
+step:4122/4150 train_time:853641ms step_avg:207.09ms
+step:4123/4150 train_time:853874ms step_avg:207.10ms
+step:4124/4150 train_time:854112ms step_avg:207.11ms
+step:4125/4150 train_time:854346ms step_avg:207.11ms
+step:4126/4150 train_time:854585ms step_avg:207.12ms
+step:4127/4150 train_time:854818ms step_avg:207.13ms
+step:4128/4150 train_time:855057ms step_avg:207.14ms
+step:4129/4150 train_time:855292ms step_avg:207.14ms
+step:4130/4150 train_time:855527ms step_avg:207.15ms
+step:4131/4150 train_time:855764ms step_avg:207.16ms
+step:4132/4150 train_time:856004ms step_avg:207.16ms
+step:4133/4150 train_time:856241ms step_avg:207.17ms
+step:4134/4150 train_time:856481ms step_avg:207.18ms
+step:4135/4150 train_time:856716ms step_avg:207.19ms
+step:4136/4150 train_time:856951ms step_avg:207.19ms
+step:4137/4150 train_time:857187ms step_avg:207.20ms
+step:4138/4150 train_time:857423ms step_avg:207.21ms
+step:4139/4150 train_time:857662ms step_avg:207.21ms
+step:4140/4150 train_time:857900ms step_avg:207.22ms
+step:4141/4150 train_time:858133ms step_avg:207.23ms
+step:4142/4150 train_time:858369ms step_avg:207.24ms
+step:4143/4150 train_time:858602ms step_avg:207.24ms
+step:4144/4150 train_time:858841ms step_avg:207.25ms
+step:4145/4150 train_time:859072ms step_avg:207.26ms
+step:4146/4150 train_time:859310ms step_avg:207.26ms
+step:4147/4150 train_time:859544ms step_avg:207.27ms
+step:4148/4150 train_time:859781ms step_avg:207.28ms
+step:4149/4150 train_time:860014ms step_avg:207.28ms
+step:4150/4150 train_time:860252ms step_avg:207.29ms
+step:4150/4150 val_loss:2.9161 train_time:860467ms step_avg:207.34ms
+peak memory allocated: 59977 MiB reserved: 60344 MiB

--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/README.md
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/README.md
@@ -1,0 +1,45 @@
+# MUDDFormer connections (GPT-2 Medium / `train_gpt_medium.py`)
+
+Add MUDD (Multiway Dynamic Dense Connections, [Xiao et al. 2025](https://arxiv.org/abs/2502.12170)) to the **last two transformer blocks** of the Medium speedrun model (`GPT` with **16 layers**, **d_model=1024**, **8 heads × 128** head dim). The idea matches the Small-track PR: trim routing cost, reuse one small MLP for several cheap “extra outputs,” and fold legacy scalars / backout into learnable MUDD biases so we can squeeze **loss per step** without paying much wall-clock.
+
+## What the code does today (N = 16)
+
+MUDD still means: an MLP on the current hidden produces per-token weights over a small set of earlier representations; those weights route adds into V and the residual (we skip separate Q/K MUDD paths from the paper). With **N = 16**, the active indices are **`i = 14` (N−2)** and **`i = 15` (N−1)** — not layers 9–10 as on the 11-layer Small model.
+
+### Layer **14** (`num_layers - 2`)
+
+- **Sources for `v_mudd` and the layer-14 residual delta:** `{x0, h_backout, x}` — three slots. Here **`h_backout`** is the hidden snapshot taken at **`backout_layer = 11`** (post-MLP), same role as the old “h7 / early deep” snapshot on Small, but at the depth Medium’s block mask / skip layout uses (`train_gpt_medium.py` around `h_backout_snap` / `if i == backout_layer`).
+- **`v_mudd`** is shaped like V and added after the QKV matmul (`1.15 *` blend of the three sources, then view to `(B, T, heads, head_dim)`).
+- **Residual on layer 14:** fused self-reference `(1 + m_self) * x + m0 * x0 + m_bo * h_backout` (same trick as Small v2’s `(1 + m_r9) * x + …`).
+- **Extra columns from the same `dense_w1[0]` → `dense_w2[0]` stack** (width `L + 5` with `L = 3`):
+  - **`next_ve_gate`** for **layer 15** attention (replaces that layer’s static `ve_gate_w` path for the value-embed gate — analogous to “layer 10” on Small).
+  - **Six dynamic scalars for layer 15:** `resid_attn`, `post_attn`, `resid_mlp`, `post_mlp`, `x0_lambda`, `bigram_lambda` (replace the static per-layer tensors for **the last layer only**), with biases chosen so the effective init matches the old scalars (`dense_bs` init in `_init_mudd`).
+
+### Layer **15** (`num_layers - 1`) — **post main loop**
+
+- There is **no** `elif i == num_layers - 1` inside the compiled layer loop. The final residual MUDD runs **once after** `for i in range(self.num_layers)`, then `norm` → logits / fused loss.
+- **Sources (5):** `{x0, h_backout, h14, ve_bank0, skip_connection}`  
+  - **`h14`:** post-MLP snapshot at layer 14 (`h_n2_snap`).  
+  - **`ve_bank0`:** `ve_list[0]` → **`ve[0]`** in the five-bank tensor, i.e. the VE bank attached to **layer 0** in this model’s `ve_list` wiring (Small’s post-loop mix used **`ve[1]`** for the layer-1 bank — different index because the layer↔bank map differs between tracks).  
+  - **`skip_connection`:** snapshot at **layer 4** (after that block’s MLP) — Medium uses **layer 4** as the long-window skip tap for this path (Small used layer 3 in the analogous v3 write-up).
+- **No self-reference** in that five-way sum: plain `x += m0*x0 + …` style mix; **`dense_bs[1, 1, 1] = -4.34`** absorbs the old scalar **backout** on the `h_backout` slot (same idea as Small: effective initial `≈ -0.5 * h_backout` after `_mudd_scale`).
+
+### Optimizer / init (unchanged in spirit from Small)
+
+- **`dense_w1` / `dense_w2` / `dense_bs`:** replicated Adam, **`lr_mul=0.25`**, `betas=(0.9, 0.99)`, no WD on `dense_bs`; **`dense_w2` starts at zero** so MUDD starts as a no-op except where biases explicitly encode static inits (gates / backout slot).
+- **`_mudd_scale = 0.2 / sqrt(L)`** with **`L = 3`** on the first MUDD block.
+
+
+### Results
+losses = [2.9161, 2.9165, 2.9176, 2.9179, 2.9172, 2.9171]
+times = [860467, 860193, 860109, 860808, 860679, 860614]
+```bash
+print("p=%.4f" % scipy.stats.ttest_1samp(medium_losses, 2.92, alternative="less").pvalue)
+# p=0.0001
+
+print("losses:", torch.std_mean(torch.tensor(losses)))
+# losses: (tensor(0.0007), tensor(2.9171))
+
+print("time:", torch.std_mean(torch.tensor(times)))
+# time: (tensor(277.5980), tensor(860478.3125))
+```

--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/aa761942-38a2-468c-9cdd-7b06002634f5.txt
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/aa761942-38a2-468c-9cdd-7b06002634f5.txt
@@ -1,0 +1,6376 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+import numpy as np
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
+
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = False # turn off fp8 for now -> requires tuning of scales which hasnt been done on medium track
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(16, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
+
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
+        self.yarn = Yarn(head_dim, max_seq_len)
+
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+        self.embed.weight.label = 'embed'
+
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
+        self.embed2.weight.label = 'embed2'
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [2, 4, 6]
+        skip_out = [9, 10, 11]
+        backout_layer = 11
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
+            short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
+
+        skip_idx = 0
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve_list[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
+            )
+            next_ve_gate = None
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
+                skip_idx += 1
+                x = x + skip_gate_out * skip_connections.pop()
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
+            else:
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                h_backout_snap = x
+
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
+        x = norm(x)
+
+        if not self.training:
+            loss = 0
+            for i in range(4):
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
+                logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+                loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
+            return loss
+
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return min(11,args.ws_schedule[ws_idx] // 2), args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/12:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/12:
+        lr_max = 1.73  # (24/8)**0.5
+    if x > 3/12:
+        lr_max = 2.0
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
+
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / (args.num_scheduled_iterations/4)
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        # only apply yarn for first few
+        if new_ws_long != self.ws_long and new_ws_long<=13:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
+                                524288, 524288, 524288, 524288,
+                                524288, 524288, 524288, 524288
+                               )
+    train_bs_extension: int = 32 * 2048 * 8
+    train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3/4
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11, 13,
+                          15, 17, 19, 21,
+                          23, 23, 23, 23)
+    ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
+    ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=16,
+    num_heads=8,
+    head_dim=128,
+    model_dim=1024,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Mon Apr 27 08:20:45 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   46C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   39C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   46C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   40C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   45C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          283578      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    1   N/A  N/A          283579      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    2   N/A  N/A          283580      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    3   N/A  N/A          283581      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    4   N/A  N/A          283582      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    5   N/A  N/A          283583      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    6   N/A  N/A          283584      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    7   N/A  N/A          283585      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 343, 344, 345, 687, 688, 689, 1031, 1032, 1033, 1374, 1375, 1376, 1718, 1719, 1720, 2062, 2063, 2064, 2406, 2407, 2408, 2749, 2750, 2751] for warmup
+Resetting Model
+step:0/4150 val_loss:10.8327 train_time:0ms step_avg:0.04ms
+step:1/4150 train_time:68ms step_avg:67.63ms
+step:2/4150 train_time:114ms step_avg:56.85ms
+step:3/4150 train_time:182ms step_avg:60.52ms
+step:4/4150 train_time:248ms step_avg:62.08ms
+step:5/4150 train_time:317ms step_avg:63.35ms
+step:6/4150 train_time:382ms step_avg:63.60ms
+step:7/4150 train_time:451ms step_avg:64.38ms
+step:8/4150 train_time:516ms step_avg:64.48ms
+step:9/4150 train_time:585ms step_avg:64.98ms
+step:10/4150 train_time:650ms step_avg:65.04ms
+step:11/4150 train_time:720ms step_avg:65.42ms
+step:12/4150 train_time:785ms step_avg:65.44ms
+step:13/4150 train_time:855ms step_avg:65.75ms
+step:14/4150 train_time:921ms step_avg:65.77ms
+step:15/4150 train_time:992ms step_avg:66.16ms
+step:16/4150 train_time:1061ms step_avg:66.30ms
+step:17/4150 train_time:1131ms step_avg:66.53ms
+step:18/4150 train_time:1197ms step_avg:66.49ms
+step:19/4150 train_time:1267ms step_avg:66.68ms
+step:20/4150 train_time:1333ms step_avg:66.64ms
+step:21/4150 train_time:1403ms step_avg:66.79ms
+step:22/4150 train_time:1468ms step_avg:66.74ms
+step:23/4150 train_time:1538ms step_avg:66.88ms
+step:24/4150 train_time:1604ms step_avg:66.82ms
+step:25/4150 train_time:1673ms step_avg:66.92ms
+step:26/4150 train_time:1739ms step_avg:66.87ms
+step:27/4150 train_time:1808ms step_avg:66.97ms
+step:28/4150 train_time:1874ms step_avg:66.94ms
+step:29/4150 train_time:1944ms step_avg:67.05ms
+step:30/4150 train_time:2010ms step_avg:67.01ms
+step:31/4150 train_time:2080ms step_avg:67.11ms
+step:32/4150 train_time:2147ms step_avg:67.08ms
+step:33/4150 train_time:2216ms step_avg:67.17ms
+step:34/4150 train_time:2282ms step_avg:67.11ms
+step:35/4150 train_time:2351ms step_avg:67.18ms
+step:36/4150 train_time:2417ms step_avg:67.13ms
+step:37/4150 train_time:2486ms step_avg:67.20ms
+step:38/4150 train_time:2552ms step_avg:67.16ms
+step:39/4150 train_time:2621ms step_avg:67.22ms
+step:40/4150 train_time:2687ms step_avg:67.18ms
+step:41/4150 train_time:2757ms step_avg:67.24ms
+step:42/4150 train_time:2822ms step_avg:67.19ms
+step:43/4150 train_time:2892ms step_avg:67.26ms
+step:44/4150 train_time:2959ms step_avg:67.25ms
+step:45/4150 train_time:3030ms step_avg:67.34ms
+step:46/4150 train_time:3097ms step_avg:67.32ms
+step:47/4150 train_time:3166ms step_avg:67.37ms
+step:48/4150 train_time:3233ms step_avg:67.35ms
+step:49/4150 train_time:3302ms step_avg:67.40ms
+step:50/4150 train_time:3368ms step_avg:67.36ms
+step:51/4150 train_time:3439ms step_avg:67.43ms
+step:52/4150 train_time:3504ms step_avg:67.39ms
+step:53/4150 train_time:3574ms step_avg:67.43ms
+step:54/4150 train_time:3640ms step_avg:67.40ms
+step:55/4150 train_time:3709ms step_avg:67.44ms
+step:56/4150 train_time:3775ms step_avg:67.41ms
+step:57/4150 train_time:3845ms step_avg:67.45ms
+step:58/4150 train_time:3910ms step_avg:67.42ms
+step:59/4150 train_time:3981ms step_avg:67.48ms
+step:60/4150 train_time:4047ms step_avg:67.44ms
+step:61/4150 train_time:4116ms step_avg:67.48ms
+step:62/4150 train_time:4182ms step_avg:67.45ms
+step:63/4150 train_time:4251ms step_avg:67.48ms
+step:64/4150 train_time:4317ms step_avg:67.46ms
+step:65/4150 train_time:4387ms step_avg:67.50ms
+step:66/4150 train_time:4453ms step_avg:67.47ms
+step:67/4150 train_time:4523ms step_avg:67.50ms
+step:68/4150 train_time:4589ms step_avg:67.48ms
+step:69/4150 train_time:4659ms step_avg:67.52ms
+step:70/4150 train_time:4724ms step_avg:67.48ms
+step:71/4150 train_time:4793ms step_avg:67.51ms
+step:72/4150 train_time:4859ms step_avg:67.48ms
+step:73/4150 train_time:4928ms step_avg:67.51ms
+step:74/4150 train_time:4994ms step_avg:67.48ms
+step:75/4150 train_time:5063ms step_avg:67.51ms
+step:76/4150 train_time:5129ms step_avg:67.49ms
+step:77/4150 train_time:5200ms step_avg:67.53ms
+step:78/4150 train_time:5265ms step_avg:67.50ms
+step:79/4150 train_time:5335ms step_avg:67.53ms
+step:80/4150 train_time:5401ms step_avg:67.51ms
+step:81/4150 train_time:5471ms step_avg:67.54ms
+step:82/4150 train_time:5537ms step_avg:67.52ms
+step:83/4150 train_time:5607ms step_avg:67.56ms
+step:84/4150 train_time:5672ms step_avg:67.53ms
+step:85/4150 train_time:5742ms step_avg:67.55ms
+step:86/4150 train_time:5807ms step_avg:67.53ms
+step:87/4150 train_time:5878ms step_avg:67.56ms
+step:88/4150 train_time:5943ms step_avg:67.54ms
+step:89/4150 train_time:6013ms step_avg:67.56ms
+step:90/4150 train_time:6079ms step_avg:67.55ms
+step:91/4150 train_time:6149ms step_avg:67.57ms
+step:92/4150 train_time:6215ms step_avg:67.55ms
+step:93/4150 train_time:6285ms step_avg:67.58ms
+step:94/4150 train_time:6350ms step_avg:67.56ms
+step:95/4150 train_time:6421ms step_avg:67.59ms
+step:96/4150 train_time:6487ms step_avg:67.57ms
+step:97/4150 train_time:6556ms step_avg:67.59ms
+step:98/4150 train_time:6622ms step_avg:67.57ms
+step:99/4150 train_time:6691ms step_avg:67.59ms
+step:100/4150 train_time:6756ms step_avg:67.56ms
+step:101/4150 train_time:6825ms step_avg:67.58ms
+step:102/4150 train_time:6891ms step_avg:67.56ms
+step:103/4150 train_time:6961ms step_avg:67.58ms
+step:104/4150 train_time:7026ms step_avg:67.56ms
+step:105/4150 train_time:7096ms step_avg:67.58ms
+step:106/4150 train_time:7163ms step_avg:67.57ms
+step:107/4150 train_time:7232ms step_avg:67.59ms
+step:108/4150 train_time:7297ms step_avg:67.57ms
+step:109/4150 train_time:7367ms step_avg:67.59ms
+step:110/4150 train_time:7434ms step_avg:67.58ms
+step:111/4150 train_time:7503ms step_avg:67.59ms
+step:112/4150 train_time:7568ms step_avg:67.57ms
+step:113/4150 train_time:7638ms step_avg:67.59ms
+step:114/4150 train_time:7703ms step_avg:67.57ms
+step:115/4150 train_time:7773ms step_avg:67.59ms
+step:116/4150 train_time:7839ms step_avg:67.58ms
+step:117/4150 train_time:7909ms step_avg:67.60ms
+step:118/4150 train_time:7975ms step_avg:67.58ms
+step:119/4150 train_time:8044ms step_avg:67.60ms
+step:120/4150 train_time:8110ms step_avg:67.58ms
+step:121/4150 train_time:8180ms step_avg:67.60ms
+step:122/4150 train_time:8245ms step_avg:67.58ms
+step:123/4150 train_time:8315ms step_avg:67.60ms
+step:124/4150 train_time:8381ms step_avg:67.59ms
+step:125/4150 train_time:8451ms step_avg:67.61ms
+step:126/4150 train_time:8517ms step_avg:67.60ms
+step:127/4150 train_time:8586ms step_avg:67.61ms
+step:128/4150 train_time:8652ms step_avg:67.60ms
+step:129/4150 train_time:8722ms step_avg:67.61ms
+step:130/4150 train_time:8788ms step_avg:67.60ms
+step:131/4150 train_time:8858ms step_avg:67.62ms
+step:132/4150 train_time:8924ms step_avg:67.61ms
+step:133/4150 train_time:8994ms step_avg:67.62ms
+step:134/4150 train_time:9059ms step_avg:67.60ms
+step:135/4150 train_time:9128ms step_avg:67.62ms
+step:136/4150 train_time:9194ms step_avg:67.60ms
+step:137/4150 train_time:9263ms step_avg:67.61ms
+step:138/4150 train_time:9329ms step_avg:67.60ms
+step:139/4150 train_time:9399ms step_avg:67.62ms
+step:140/4150 train_time:9464ms step_avg:67.60ms
+step:141/4150 train_time:9533ms step_avg:67.61ms
+step:142/4150 train_time:9599ms step_avg:67.60ms
+step:143/4150 train_time:9668ms step_avg:67.61ms
+step:144/4150 train_time:9734ms step_avg:67.60ms
+step:145/4150 train_time:9805ms step_avg:67.62ms
+step:146/4150 train_time:9870ms step_avg:67.61ms
+step:147/4150 train_time:9940ms step_avg:67.62ms
+step:148/4150 train_time:10005ms step_avg:67.60ms
+step:149/4150 train_time:10074ms step_avg:67.61ms
+step:150/4150 train_time:10141ms step_avg:67.61ms
+step:151/4150 train_time:10210ms step_avg:67.62ms
+step:152/4150 train_time:10276ms step_avg:67.60ms
+step:153/4150 train_time:10346ms step_avg:67.62ms
+step:154/4150 train_time:10413ms step_avg:67.61ms
+step:155/4150 train_time:10481ms step_avg:67.62ms
+step:156/4150 train_time:10547ms step_avg:67.61ms
+step:157/4150 train_time:10616ms step_avg:67.62ms
+step:158/4150 train_time:10682ms step_avg:67.60ms
+step:159/4150 train_time:10751ms step_avg:67.62ms
+step:160/4150 train_time:10817ms step_avg:67.60ms
+step:161/4150 train_time:10886ms step_avg:67.61ms
+step:162/4150 train_time:10951ms step_avg:67.60ms
+step:163/4150 train_time:11019ms step_avg:67.60ms
+step:164/4150 train_time:11085ms step_avg:67.59ms
+step:165/4150 train_time:11155ms step_avg:67.60ms
+step:166/4150 train_time:11220ms step_avg:67.59ms
+step:167/4150 train_time:11289ms step_avg:67.60ms
+step:168/4150 train_time:11355ms step_avg:67.59ms
+step:169/4150 train_time:11424ms step_avg:67.60ms
+step:170/4150 train_time:11490ms step_avg:67.59ms
+step:171/4150 train_time:11559ms step_avg:67.60ms
+step:172/4150 train_time:11625ms step_avg:67.58ms
+step:173/4150 train_time:11694ms step_avg:67.59ms
+step:174/4150 train_time:11759ms step_avg:67.58ms
+step:175/4150 train_time:11828ms step_avg:67.59ms
+step:176/4150 train_time:11894ms step_avg:67.58ms
+step:177/4150 train_time:11965ms step_avg:67.60ms
+step:178/4150 train_time:12030ms step_avg:67.58ms
+step:179/4150 train_time:12099ms step_avg:67.59ms
+step:180/4150 train_time:12164ms step_avg:67.58ms
+step:181/4150 train_time:12234ms step_avg:67.59ms
+step:182/4150 train_time:12300ms step_avg:67.58ms
+step:183/4150 train_time:12369ms step_avg:67.59ms
+step:184/4150 train_time:12434ms step_avg:67.58ms
+step:185/4150 train_time:12504ms step_avg:67.59ms
+step:186/4150 train_time:12570ms step_avg:67.58ms
+step:187/4150 train_time:12640ms step_avg:67.59ms
+step:188/4150 train_time:12705ms step_avg:67.58ms
+step:189/4150 train_time:12774ms step_avg:67.59ms
+step:190/4150 train_time:12839ms step_avg:67.57ms
+step:191/4150 train_time:12908ms step_avg:67.58ms
+step:192/4150 train_time:12973ms step_avg:67.57ms
+step:193/4150 train_time:13044ms step_avg:67.58ms
+step:194/4150 train_time:13109ms step_avg:67.57ms
+step:195/4150 train_time:13179ms step_avg:67.58ms
+step:196/4150 train_time:13244ms step_avg:67.57ms
+step:197/4150 train_time:13314ms step_avg:67.58ms
+step:198/4150 train_time:13379ms step_avg:67.57ms
+step:199/4150 train_time:13449ms step_avg:67.58ms
+step:200/4150 train_time:13514ms step_avg:67.57ms
+step:201/4150 train_time:13584ms step_avg:67.58ms
+step:202/4150 train_time:13649ms step_avg:67.57ms
+step:203/4150 train_time:13718ms step_avg:67.58ms
+step:204/4150 train_time:13783ms step_avg:67.56ms
+step:205/4150 train_time:13853ms step_avg:67.57ms
+step:206/4150 train_time:13918ms step_avg:67.56ms
+step:207/4150 train_time:13987ms step_avg:67.57ms
+step:208/4150 train_time:14052ms step_avg:67.56ms
+step:209/4150 train_time:14122ms step_avg:67.57ms
+step:210/4150 train_time:14187ms step_avg:67.56ms
+step:211/4150 train_time:14257ms step_avg:67.57ms
+step:212/4150 train_time:14322ms step_avg:67.56ms
+step:213/4150 train_time:14391ms step_avg:67.56ms
+step:214/4150 train_time:14456ms step_avg:67.55ms
+step:215/4150 train_time:14525ms step_avg:67.56ms
+step:216/4150 train_time:14591ms step_avg:67.55ms
+step:217/4150 train_time:14661ms step_avg:67.56ms
+step:218/4150 train_time:14726ms step_avg:67.55ms
+step:219/4150 train_time:14795ms step_avg:67.56ms
+step:220/4150 train_time:14861ms step_avg:67.55ms
+step:221/4150 train_time:14930ms step_avg:67.56ms
+step:222/4150 train_time:14995ms step_avg:67.55ms
+step:223/4150 train_time:15064ms step_avg:67.55ms
+step:224/4150 train_time:15130ms step_avg:67.54ms
+step:225/4150 train_time:15199ms step_avg:67.55ms
+step:226/4150 train_time:15264ms step_avg:67.54ms
+step:227/4150 train_time:15334ms step_avg:67.55ms
+step:228/4150 train_time:15400ms step_avg:67.54ms
+step:229/4150 train_time:15469ms step_avg:67.55ms
+step:230/4150 train_time:15534ms step_avg:67.54ms
+step:231/4150 train_time:15605ms step_avg:67.55ms
+step:232/4150 train_time:15670ms step_avg:67.54ms
+step:233/4150 train_time:15740ms step_avg:67.55ms
+step:234/4150 train_time:15804ms step_avg:67.54ms
+step:235/4150 train_time:15874ms step_avg:67.55ms
+step:236/4150 train_time:15940ms step_avg:67.54ms
+step:237/4150 train_time:16010ms step_avg:67.55ms
+step:238/4150 train_time:16075ms step_avg:67.54ms
+step:239/4150 train_time:16144ms step_avg:67.55ms
+step:240/4150 train_time:16209ms step_avg:67.54ms
+step:241/4150 train_time:16278ms step_avg:67.54ms
+step:242/4150 train_time:16343ms step_avg:67.53ms
+step:243/4150 train_time:16412ms step_avg:67.54ms
+step:244/4150 train_time:16478ms step_avg:67.53ms
+step:245/4150 train_time:16547ms step_avg:67.54ms
+step:246/4150 train_time:16612ms step_avg:67.53ms
+step:247/4150 train_time:16682ms step_avg:67.54ms
+step:248/4150 train_time:16747ms step_avg:67.53ms
+step:249/4150 train_time:16816ms step_avg:67.53ms
+step:250/4150 train_time:16881ms step_avg:67.53ms
+step:250/4150 val_loss:4.4778 train_time:16946ms step_avg:67.78ms
+step:251/4150 train_time:16971ms step_avg:67.61ms
+step:252/4150 train_time:17020ms step_avg:67.54ms
+step:253/4150 train_time:17089ms step_avg:67.54ms
+step:254/4150 train_time:17155ms step_avg:67.54ms
+step:255/4150 train_time:17226ms step_avg:67.55ms
+step:256/4150 train_time:17292ms step_avg:67.55ms
+step:257/4150 train_time:17361ms step_avg:67.55ms
+step:258/4150 train_time:17427ms step_avg:67.55ms
+step:259/4150 train_time:17496ms step_avg:67.55ms
+step:260/4150 train_time:17561ms step_avg:67.54ms
+step:261/4150 train_time:17630ms step_avg:67.55ms
+step:262/4150 train_time:17696ms step_avg:67.54ms
+step:263/4150 train_time:17764ms step_avg:67.54ms
+step:264/4150 train_time:17829ms step_avg:67.54ms
+step:265/4150 train_time:17898ms step_avg:67.54ms
+step:266/4150 train_time:17963ms step_avg:67.53ms
+step:267/4150 train_time:18032ms step_avg:67.54ms
+step:268/4150 train_time:18097ms step_avg:67.53ms
+step:269/4150 train_time:18167ms step_avg:67.53ms
+step:270/4150 train_time:18232ms step_avg:67.52ms
+step:271/4150 train_time:18301ms step_avg:67.53ms
+step:272/4150 train_time:18367ms step_avg:67.53ms
+step:273/4150 train_time:18437ms step_avg:67.53ms
+step:274/4150 train_time:18502ms step_avg:67.53ms
+step:275/4150 train_time:18570ms step_avg:67.53ms
+step:276/4150 train_time:18635ms step_avg:67.52ms
+step:277/4150 train_time:18705ms step_avg:67.53ms
+step:278/4150 train_time:18770ms step_avg:67.52ms
+step:279/4150 train_time:18838ms step_avg:67.52ms
+step:280/4150 train_time:18904ms step_avg:67.52ms
+step:281/4150 train_time:18974ms step_avg:67.52ms
+step:282/4150 train_time:19039ms step_avg:67.51ms
+step:283/4150 train_time:19109ms step_avg:67.52ms
+step:284/4150 train_time:19173ms step_avg:67.51ms
+step:285/4150 train_time:19242ms step_avg:67.52ms
+step:286/4150 train_time:19307ms step_avg:67.51ms
+step:287/4150 train_time:19377ms step_avg:67.51ms
+step:288/4150 train_time:19442ms step_avg:67.51ms
+step:289/4150 train_time:19511ms step_avg:67.51ms
+step:290/4150 train_time:19576ms step_avg:67.50ms
+step:291/4150 train_time:19646ms step_avg:67.51ms
+step:292/4150 train_time:19711ms step_avg:67.50ms
+step:293/4150 train_time:19780ms step_avg:67.51ms
+step:294/4150 train_time:19846ms step_avg:67.50ms
+step:295/4150 train_time:19915ms step_avg:67.51ms
+step:296/4150 train_time:19980ms step_avg:67.50ms
+step:297/4150 train_time:20051ms step_avg:67.51ms
+step:298/4150 train_time:20117ms step_avg:67.51ms
+step:299/4150 train_time:20185ms step_avg:67.51ms
+step:300/4150 train_time:20251ms step_avg:67.50ms
+step:301/4150 train_time:20319ms step_avg:67.51ms
+step:302/4150 train_time:20385ms step_avg:67.50ms
+step:303/4150 train_time:20454ms step_avg:67.51ms
+step:304/4150 train_time:20520ms step_avg:67.50ms
+step:305/4150 train_time:20589ms step_avg:67.51ms
+step:306/4150 train_time:20654ms step_avg:67.50ms
+step:307/4150 train_time:20723ms step_avg:67.50ms
+step:308/4150 train_time:20788ms step_avg:67.49ms
+step:309/4150 train_time:20857ms step_avg:67.50ms
+step:310/4150 train_time:20922ms step_avg:67.49ms
+step:311/4150 train_time:20991ms step_avg:67.50ms
+step:312/4150 train_time:21056ms step_avg:67.49ms
+step:313/4150 train_time:21125ms step_avg:67.49ms
+step:314/4150 train_time:21190ms step_avg:67.48ms
+step:315/4150 train_time:21259ms step_avg:67.49ms
+step:316/4150 train_time:21325ms step_avg:67.48ms
+step:317/4150 train_time:21393ms step_avg:67.49ms
+step:318/4150 train_time:21459ms step_avg:67.48ms
+step:319/4150 train_time:21528ms step_avg:67.49ms
+step:320/4150 train_time:21594ms step_avg:67.48ms
+step:321/4150 train_time:21663ms step_avg:67.49ms
+step:322/4150 train_time:21728ms step_avg:67.48ms
+step:323/4150 train_time:21797ms step_avg:67.48ms
+step:324/4150 train_time:21863ms step_avg:67.48ms
+step:325/4150 train_time:21932ms step_avg:67.48ms
+step:326/4150 train_time:21997ms step_avg:67.47ms
+step:327/4150 train_time:22066ms step_avg:67.48ms
+step:328/4150 train_time:22131ms step_avg:67.47ms
+step:329/4150 train_time:22199ms step_avg:67.47ms
+step:330/4150 train_time:22265ms step_avg:67.47ms
+step:331/4150 train_time:22335ms step_avg:67.48ms
+step:332/4150 train_time:22400ms step_avg:67.47ms
+step:333/4150 train_time:22468ms step_avg:67.47ms
+step:334/4150 train_time:22533ms step_avg:67.46ms
+step:335/4150 train_time:22602ms step_avg:67.47ms
+step:336/4150 train_time:22668ms step_avg:67.47ms
+step:337/4150 train_time:22737ms step_avg:67.47ms
+step:338/4150 train_time:22803ms step_avg:67.46ms
+step:339/4150 train_time:22872ms step_avg:67.47ms
+step:340/4150 train_time:22938ms step_avg:67.46ms
+step:341/4150 train_time:23007ms step_avg:67.47ms
+step:342/4150 train_time:23072ms step_avg:67.46ms
+step:343/4150 train_time:23140ms step_avg:67.46ms
+step:344/4150 train_time:23206ms step_avg:67.46ms
+step:345/4150 train_time:23280ms step_avg:67.48ms
+step:346/4150 train_time:23401ms step_avg:67.63ms
+step:347/4150 train_time:23521ms step_avg:67.78ms
+step:348/4150 train_time:23644ms step_avg:67.94ms
+step:349/4150 train_time:23766ms step_avg:68.10ms
+step:350/4150 train_time:23887ms step_avg:68.25ms
+step:351/4150 train_time:24010ms step_avg:68.40ms
+step:352/4150 train_time:24130ms step_avg:68.55ms
+step:353/4150 train_time:24252ms step_avg:68.70ms
+step:354/4150 train_time:24371ms step_avg:68.84ms
+step:355/4150 train_time:24493ms step_avg:68.99ms
+step:356/4150 train_time:24613ms step_avg:69.14ms
+step:357/4150 train_time:24735ms step_avg:69.29ms
+step:358/4150 train_time:24857ms step_avg:69.43ms
+step:359/4150 train_time:24980ms step_avg:69.58ms
+step:360/4150 train_time:25100ms step_avg:69.72ms
+step:361/4150 train_time:25221ms step_avg:69.86ms
+step:362/4150 train_time:25342ms step_avg:70.01ms
+step:363/4150 train_time:25465ms step_avg:70.15ms
+step:364/4150 train_time:25585ms step_avg:70.29ms
+step:365/4150 train_time:25709ms step_avg:70.43ms
+step:366/4150 train_time:25828ms step_avg:70.57ms
+step:367/4150 train_time:25950ms step_avg:70.71ms
+step:368/4150 train_time:26070ms step_avg:70.84ms
+step:369/4150 train_time:26193ms step_avg:70.98ms
+step:370/4150 train_time:26314ms step_avg:71.12ms
+step:371/4150 train_time:26437ms step_avg:71.26ms
+step:372/4150 train_time:26557ms step_avg:71.39ms
+step:373/4150 train_time:26680ms step_avg:71.53ms
+step:374/4150 train_time:26800ms step_avg:71.66ms
+step:375/4150 train_time:26922ms step_avg:71.79ms
+step:376/4150 train_time:27043ms step_avg:71.92ms
+step:377/4150 train_time:27166ms step_avg:72.06ms
+step:378/4150 train_time:27286ms step_avg:72.18ms
+step:379/4150 train_time:27409ms step_avg:72.32ms
+step:380/4150 train_time:27529ms step_avg:72.44ms
+step:381/4150 train_time:27650ms step_avg:72.57ms
+step:382/4150 train_time:27770ms step_avg:72.70ms
+step:383/4150 train_time:27893ms step_avg:72.83ms
+step:384/4150 train_time:28012ms step_avg:72.95ms
+step:385/4150 train_time:28134ms step_avg:73.08ms
+step:386/4150 train_time:28255ms step_avg:73.20ms
+step:387/4150 train_time:28376ms step_avg:73.32ms
+step:388/4150 train_time:28497ms step_avg:73.45ms
+step:389/4150 train_time:28619ms step_avg:73.57ms
+step:390/4150 train_time:28740ms step_avg:73.69ms
+step:391/4150 train_time:28864ms step_avg:73.82ms
+step:392/4150 train_time:28985ms step_avg:73.94ms
+step:393/4150 train_time:29110ms step_avg:74.07ms
+step:394/4150 train_time:29229ms step_avg:74.19ms
+step:395/4150 train_time:29352ms step_avg:74.31ms
+step:396/4150 train_time:29471ms step_avg:74.42ms
+step:397/4150 train_time:29593ms step_avg:74.54ms
+step:398/4150 train_time:29714ms step_avg:74.66ms
+step:399/4150 train_time:29836ms step_avg:74.78ms
+step:400/4150 train_time:29957ms step_avg:74.89ms
+step:401/4150 train_time:30079ms step_avg:75.01ms
+step:402/4150 train_time:30199ms step_avg:75.12ms
+step:403/4150 train_time:30321ms step_avg:75.24ms
+step:404/4150 train_time:30442ms step_avg:75.35ms
+step:405/4150 train_time:30565ms step_avg:75.47ms
+step:406/4150 train_time:30686ms step_avg:75.58ms
+step:407/4150 train_time:30810ms step_avg:75.70ms
+step:408/4150 train_time:30929ms step_avg:75.81ms
+step:409/4150 train_time:31053ms step_avg:75.92ms
+step:410/4150 train_time:31174ms step_avg:76.03ms
+step:411/4150 train_time:31297ms step_avg:76.15ms
+step:412/4150 train_time:31417ms step_avg:76.25ms
+step:413/4150 train_time:31539ms step_avg:76.37ms
+step:414/4150 train_time:31660ms step_avg:76.47ms
+step:415/4150 train_time:31784ms step_avg:76.59ms
+step:416/4150 train_time:31904ms step_avg:76.69ms
+step:417/4150 train_time:32026ms step_avg:76.80ms
+step:418/4150 train_time:32147ms step_avg:76.91ms
+step:419/4150 train_time:32269ms step_avg:77.01ms
+step:420/4150 train_time:32389ms step_avg:77.12ms
+step:421/4150 train_time:32511ms step_avg:77.22ms
+step:422/4150 train_time:32632ms step_avg:77.33ms
+step:423/4150 train_time:32754ms step_avg:77.43ms
+step:424/4150 train_time:32874ms step_avg:77.53ms
+step:425/4150 train_time:32997ms step_avg:77.64ms
+step:426/4150 train_time:33117ms step_avg:77.74ms
+step:427/4150 train_time:33240ms step_avg:77.85ms
+step:428/4150 train_time:33360ms step_avg:77.95ms
+step:429/4150 train_time:33484ms step_avg:78.05ms
+step:430/4150 train_time:33605ms step_avg:78.15ms
+step:431/4150 train_time:33727ms step_avg:78.25ms
+step:432/4150 train_time:33847ms step_avg:78.35ms
+step:433/4150 train_time:33971ms step_avg:78.45ms
+step:434/4150 train_time:34089ms step_avg:78.55ms
+step:435/4150 train_time:34211ms step_avg:78.65ms
+step:436/4150 train_time:34331ms step_avg:78.74ms
+step:437/4150 train_time:34453ms step_avg:78.84ms
+step:438/4150 train_time:34574ms step_avg:78.94ms
+step:439/4150 train_time:34697ms step_avg:79.04ms
+step:440/4150 train_time:34816ms step_avg:79.13ms
+step:441/4150 train_time:34938ms step_avg:79.22ms
+step:442/4150 train_time:35060ms step_avg:79.32ms
+step:443/4150 train_time:35182ms step_avg:79.42ms
+step:444/4150 train_time:35303ms step_avg:79.51ms
+step:445/4150 train_time:35425ms step_avg:79.61ms
+step:446/4150 train_time:35546ms step_avg:79.70ms
+step:447/4150 train_time:35669ms step_avg:79.80ms
+step:448/4150 train_time:35789ms step_avg:79.89ms
+step:449/4150 train_time:35912ms step_avg:79.98ms
+step:450/4150 train_time:36033ms step_avg:80.07ms
+step:451/4150 train_time:36155ms step_avg:80.17ms
+step:452/4150 train_time:36276ms step_avg:80.26ms
+step:453/4150 train_time:36399ms step_avg:80.35ms
+step:454/4150 train_time:36520ms step_avg:80.44ms
+step:455/4150 train_time:36643ms step_avg:80.53ms
+step:456/4150 train_time:36765ms step_avg:80.62ms
+step:457/4150 train_time:36887ms step_avg:80.71ms
+step:458/4150 train_time:37006ms step_avg:80.80ms
+step:459/4150 train_time:37129ms step_avg:80.89ms
+step:460/4150 train_time:37250ms step_avg:80.98ms
+step:461/4150 train_time:37372ms step_avg:81.07ms
+step:462/4150 train_time:37492ms step_avg:81.15ms
+step:463/4150 train_time:37614ms step_avg:81.24ms
+step:464/4150 train_time:37734ms step_avg:81.32ms
+step:465/4150 train_time:37856ms step_avg:81.41ms
+step:466/4150 train_time:37976ms step_avg:81.49ms
+step:467/4150 train_time:38099ms step_avg:81.58ms
+step:468/4150 train_time:38219ms step_avg:81.66ms
+step:469/4150 train_time:38342ms step_avg:81.75ms
+step:470/4150 train_time:38462ms step_avg:81.83ms
+step:471/4150 train_time:38585ms step_avg:81.92ms
+step:472/4150 train_time:38705ms step_avg:82.00ms
+step:473/4150 train_time:38827ms step_avg:82.09ms
+step:474/4150 train_time:38949ms step_avg:82.17ms
+step:475/4150 train_time:39072ms step_avg:82.26ms
+step:476/4150 train_time:39192ms step_avg:82.34ms
+step:477/4150 train_time:39314ms step_avg:82.42ms
+step:478/4150 train_time:39435ms step_avg:82.50ms
+step:479/4150 train_time:39556ms step_avg:82.58ms
+step:480/4150 train_time:39677ms step_avg:82.66ms
+step:481/4150 train_time:39800ms step_avg:82.74ms
+step:482/4150 train_time:39920ms step_avg:82.82ms
+step:483/4150 train_time:40042ms step_avg:82.90ms
+step:484/4150 train_time:40164ms step_avg:82.98ms
+step:485/4150 train_time:40285ms step_avg:83.06ms
+step:486/4150 train_time:40407ms step_avg:83.14ms
+step:487/4150 train_time:40529ms step_avg:83.22ms
+step:488/4150 train_time:40649ms step_avg:83.30ms
+step:489/4150 train_time:40771ms step_avg:83.38ms
+step:490/4150 train_time:40891ms step_avg:83.45ms
+step:491/4150 train_time:41012ms step_avg:83.53ms
+step:492/4150 train_time:41132ms step_avg:83.60ms
+step:493/4150 train_time:41254ms step_avg:83.68ms
+step:494/4150 train_time:41374ms step_avg:83.75ms
+step:495/4150 train_time:41496ms step_avg:83.83ms
+step:496/4150 train_time:41616ms step_avg:83.90ms
+step:497/4150 train_time:41740ms step_avg:83.98ms
+step:498/4150 train_time:41860ms step_avg:84.06ms
+step:499/4150 train_time:41982ms step_avg:84.13ms
+step:500/4150 train_time:42102ms step_avg:84.20ms
+step:500/4150 val_loss:3.9055 train_time:42214ms step_avg:84.43ms
+step:501/4150 train_time:42235ms step_avg:84.30ms
+step:502/4150 train_time:42347ms step_avg:84.36ms
+step:503/4150 train_time:42470ms step_avg:84.43ms
+step:504/4150 train_time:42593ms step_avg:84.51ms
+step:505/4150 train_time:42714ms step_avg:84.58ms
+step:506/4150 train_time:42833ms step_avg:84.65ms
+step:507/4150 train_time:42953ms step_avg:84.72ms
+step:508/4150 train_time:43072ms step_avg:84.79ms
+step:509/4150 train_time:43195ms step_avg:84.86ms
+step:510/4150 train_time:43317ms step_avg:84.94ms
+step:511/4150 train_time:43442ms step_avg:85.01ms
+step:512/4150 train_time:43562ms step_avg:85.08ms
+step:513/4150 train_time:43683ms step_avg:85.15ms
+step:514/4150 train_time:43803ms step_avg:85.22ms
+step:515/4150 train_time:43923ms step_avg:85.29ms
+step:516/4150 train_time:44042ms step_avg:85.35ms
+step:517/4150 train_time:44164ms step_avg:85.42ms
+step:518/4150 train_time:44286ms step_avg:85.49ms
+step:519/4150 train_time:44408ms step_avg:85.56ms
+step:520/4150 train_time:44529ms step_avg:85.63ms
+step:521/4150 train_time:44651ms step_avg:85.70ms
+step:522/4150 train_time:44770ms step_avg:85.77ms
+step:523/4150 train_time:44892ms step_avg:85.84ms
+step:524/4150 train_time:45012ms step_avg:85.90ms
+step:525/4150 train_time:45135ms step_avg:85.97ms
+step:526/4150 train_time:45256ms step_avg:86.04ms
+step:527/4150 train_time:45380ms step_avg:86.11ms
+step:528/4150 train_time:45502ms step_avg:86.18ms
+step:529/4150 train_time:45625ms step_avg:86.25ms
+step:530/4150 train_time:45745ms step_avg:86.31ms
+step:531/4150 train_time:45865ms step_avg:86.38ms
+step:532/4150 train_time:45985ms step_avg:86.44ms
+step:533/4150 train_time:46107ms step_avg:86.50ms
+step:534/4150 train_time:46228ms step_avg:86.57ms
+step:535/4150 train_time:46350ms step_avg:86.64ms
+step:536/4150 train_time:46471ms step_avg:86.70ms
+step:537/4150 train_time:46594ms step_avg:86.77ms
+step:538/4150 train_time:46714ms step_avg:86.83ms
+step:539/4150 train_time:46835ms step_avg:86.89ms
+step:540/4150 train_time:46957ms step_avg:86.96ms
+step:541/4150 train_time:47079ms step_avg:87.02ms
+step:542/4150 train_time:47200ms step_avg:87.09ms
+step:543/4150 train_time:47323ms step_avg:87.15ms
+step:544/4150 train_time:47442ms step_avg:87.21ms
+step:545/4150 train_time:47563ms step_avg:87.27ms
+step:546/4150 train_time:47683ms step_avg:87.33ms
+step:547/4150 train_time:47803ms step_avg:87.39ms
+step:548/4150 train_time:47923ms step_avg:87.45ms
+step:549/4150 train_time:48045ms step_avg:87.51ms
+step:550/4150 train_time:48165ms step_avg:87.57ms
+step:551/4150 train_time:48287ms step_avg:87.64ms
+step:552/4150 train_time:48409ms step_avg:87.70ms
+step:553/4150 train_time:48530ms step_avg:87.76ms
+step:554/4150 train_time:48649ms step_avg:87.81ms
+step:555/4150 train_time:48770ms step_avg:87.87ms
+step:556/4150 train_time:48891ms step_avg:87.93ms
+step:557/4150 train_time:49014ms step_avg:88.00ms
+step:558/4150 train_time:49134ms step_avg:88.05ms
+step:559/4150 train_time:49256ms step_avg:88.11ms
+step:560/4150 train_time:49379ms step_avg:88.18ms
+step:561/4150 train_time:49502ms step_avg:88.24ms
+step:562/4150 train_time:49622ms step_avg:88.29ms
+step:563/4150 train_time:49743ms step_avg:88.35ms
+step:564/4150 train_time:49862ms step_avg:88.41ms
+step:565/4150 train_time:49983ms step_avg:88.47ms
+step:566/4150 train_time:50103ms step_avg:88.52ms
+step:567/4150 train_time:50225ms step_avg:88.58ms
+step:568/4150 train_time:50345ms step_avg:88.64ms
+step:569/4150 train_time:50467ms step_avg:88.70ms
+step:570/4150 train_time:50589ms step_avg:88.75ms
+step:571/4150 train_time:50711ms step_avg:88.81ms
+step:572/4150 train_time:50830ms step_avg:88.86ms
+step:573/4150 train_time:50952ms step_avg:88.92ms
+step:574/4150 train_time:51073ms step_avg:88.98ms
+step:575/4150 train_time:51195ms step_avg:89.03ms
+step:576/4150 train_time:51315ms step_avg:89.09ms
+step:577/4150 train_time:51439ms step_avg:89.15ms
+step:578/4150 train_time:51560ms step_avg:89.20ms
+step:579/4150 train_time:51682ms step_avg:89.26ms
+step:580/4150 train_time:51803ms step_avg:89.32ms
+step:581/4150 train_time:51924ms step_avg:89.37ms
+step:582/4150 train_time:52044ms step_avg:89.42ms
+step:583/4150 train_time:52166ms step_avg:89.48ms
+step:584/4150 train_time:52287ms step_avg:89.53ms
+step:585/4150 train_time:52409ms step_avg:89.59ms
+step:586/4150 train_time:52530ms step_avg:89.64ms
+step:587/4150 train_time:52653ms step_avg:89.70ms
+step:588/4150 train_time:52772ms step_avg:89.75ms
+step:589/4150 train_time:52894ms step_avg:89.80ms
+step:590/4150 train_time:53015ms step_avg:89.86ms
+step:591/4150 train_time:53138ms step_avg:89.91ms
+step:592/4150 train_time:53258ms step_avg:89.96ms
+step:593/4150 train_time:53381ms step_avg:90.02ms
+step:594/4150 train_time:53502ms step_avg:90.07ms
+step:595/4150 train_time:53625ms step_avg:90.13ms
+step:596/4150 train_time:53744ms step_avg:90.17ms
+step:597/4150 train_time:53865ms step_avg:90.23ms
+step:598/4150 train_time:53987ms step_avg:90.28ms
+step:599/4150 train_time:54108ms step_avg:90.33ms
+step:600/4150 train_time:54228ms step_avg:90.38ms
+step:601/4150 train_time:54351ms step_avg:90.43ms
+step:602/4150 train_time:54472ms step_avg:90.49ms
+step:603/4150 train_time:54595ms step_avg:90.54ms
+step:604/4150 train_time:54715ms step_avg:90.59ms
+step:605/4150 train_time:54837ms step_avg:90.64ms
+step:606/4150 train_time:54957ms step_avg:90.69ms
+step:607/4150 train_time:55080ms step_avg:90.74ms
+step:608/4150 train_time:55201ms step_avg:90.79ms
+step:609/4150 train_time:55323ms step_avg:90.84ms
+step:610/4150 train_time:55443ms step_avg:90.89ms
+step:611/4150 train_time:55564ms step_avg:90.94ms
+step:612/4150 train_time:55686ms step_avg:90.99ms
+step:613/4150 train_time:55807ms step_avg:91.04ms
+step:614/4150 train_time:55928ms step_avg:91.09ms
+step:615/4150 train_time:56049ms step_avg:91.14ms
+step:616/4150 train_time:56170ms step_avg:91.19ms
+step:617/4150 train_time:56293ms step_avg:91.24ms
+step:618/4150 train_time:56413ms step_avg:91.28ms
+step:619/4150 train_time:56535ms step_avg:91.33ms
+step:620/4150 train_time:56656ms step_avg:91.38ms
+step:621/4150 train_time:56777ms step_avg:91.43ms
+step:622/4150 train_time:56899ms step_avg:91.48ms
+step:623/4150 train_time:57021ms step_avg:91.53ms
+step:624/4150 train_time:57141ms step_avg:91.57ms
+step:625/4150 train_time:57263ms step_avg:91.62ms
+step:626/4150 train_time:57383ms step_avg:91.67ms
+step:627/4150 train_time:57504ms step_avg:91.71ms
+step:628/4150 train_time:57624ms step_avg:91.76ms
+step:629/4150 train_time:57746ms step_avg:91.81ms
+step:630/4150 train_time:57866ms step_avg:91.85ms
+step:631/4150 train_time:57988ms step_avg:91.90ms
+step:632/4150 train_time:58108ms step_avg:91.94ms
+step:633/4150 train_time:58231ms step_avg:91.99ms
+step:634/4150 train_time:58352ms step_avg:92.04ms
+step:635/4150 train_time:58473ms step_avg:92.08ms
+step:636/4150 train_time:58594ms step_avg:92.13ms
+step:637/4150 train_time:58716ms step_avg:92.18ms
+step:638/4150 train_time:58836ms step_avg:92.22ms
+step:639/4150 train_time:58958ms step_avg:92.27ms
+step:640/4150 train_time:59079ms step_avg:92.31ms
+step:641/4150 train_time:59201ms step_avg:92.36ms
+step:642/4150 train_time:59322ms step_avg:92.40ms
+step:643/4150 train_time:59443ms step_avg:92.45ms
+step:644/4150 train_time:59563ms step_avg:92.49ms
+step:645/4150 train_time:59686ms step_avg:92.54ms
+step:646/4150 train_time:59806ms step_avg:92.58ms
+step:647/4150 train_time:59927ms step_avg:92.62ms
+step:648/4150 train_time:60047ms step_avg:92.67ms
+step:649/4150 train_time:60169ms step_avg:92.71ms
+step:650/4150 train_time:60290ms step_avg:92.75ms
+step:651/4150 train_time:60412ms step_avg:92.80ms
+step:652/4150 train_time:60533ms step_avg:92.84ms
+step:653/4150 train_time:60655ms step_avg:92.89ms
+step:654/4150 train_time:60777ms step_avg:92.93ms
+step:655/4150 train_time:60900ms step_avg:92.98ms
+step:656/4150 train_time:61020ms step_avg:93.02ms
+step:657/4150 train_time:61143ms step_avg:93.06ms
+step:658/4150 train_time:61263ms step_avg:93.10ms
+step:659/4150 train_time:61385ms step_avg:93.15ms
+step:660/4150 train_time:61505ms step_avg:93.19ms
+step:661/4150 train_time:61626ms step_avg:93.23ms
+step:662/4150 train_time:61746ms step_avg:93.27ms
+step:663/4150 train_time:61868ms step_avg:93.31ms
+step:664/4150 train_time:61988ms step_avg:93.36ms
+step:665/4150 train_time:62109ms step_avg:93.40ms
+step:666/4150 train_time:62230ms step_avg:93.44ms
+step:667/4150 train_time:62352ms step_avg:93.48ms
+step:668/4150 train_time:62472ms step_avg:93.52ms
+step:669/4150 train_time:62594ms step_avg:93.56ms
+step:670/4150 train_time:62715ms step_avg:93.60ms
+step:671/4150 train_time:62839ms step_avg:93.65ms
+step:672/4150 train_time:62959ms step_avg:93.69ms
+step:673/4150 train_time:63082ms step_avg:93.73ms
+step:674/4150 train_time:63203ms step_avg:93.77ms
+step:675/4150 train_time:63324ms step_avg:93.81ms
+step:676/4150 train_time:63444ms step_avg:93.85ms
+step:677/4150 train_time:63565ms step_avg:93.89ms
+step:678/4150 train_time:63687ms step_avg:93.93ms
+step:679/4150 train_time:63809ms step_avg:93.97ms
+step:680/4150 train_time:63928ms step_avg:94.01ms
+step:681/4150 train_time:64051ms step_avg:94.05ms
+step:682/4150 train_time:64171ms step_avg:94.09ms
+step:683/4150 train_time:64293ms step_avg:94.13ms
+step:684/4150 train_time:64414ms step_avg:94.17ms
+step:685/4150 train_time:64536ms step_avg:94.21ms
+step:686/4150 train_time:64657ms step_avg:94.25ms
+step:687/4150 train_time:64779ms step_avg:94.29ms
+step:688/4150 train_time:64899ms step_avg:94.33ms
+step:689/4150 train_time:65026ms step_avg:94.38ms
+step:690/4150 train_time:65207ms step_avg:94.50ms
+step:691/4150 train_time:65386ms step_avg:94.62ms
+step:692/4150 train_time:65564ms step_avg:94.75ms
+step:693/4150 train_time:65743ms step_avg:94.87ms
+step:694/4150 train_time:65923ms step_avg:94.99ms
+step:695/4150 train_time:66102ms step_avg:95.11ms
+step:696/4150 train_time:66282ms step_avg:95.23ms
+step:697/4150 train_time:66464ms step_avg:95.36ms
+step:698/4150 train_time:66644ms step_avg:95.48ms
+step:699/4150 train_time:66822ms step_avg:95.60ms
+step:700/4150 train_time:67000ms step_avg:95.71ms
+step:701/4150 train_time:67179ms step_avg:95.83ms
+step:702/4150 train_time:67360ms step_avg:95.95ms
+step:703/4150 train_time:67539ms step_avg:96.07ms
+step:704/4150 train_time:67720ms step_avg:96.19ms
+step:705/4150 train_time:67898ms step_avg:96.31ms
+step:706/4150 train_time:68077ms step_avg:96.43ms
+step:707/4150 train_time:68254ms step_avg:96.54ms
+step:708/4150 train_time:68434ms step_avg:96.66ms
+step:709/4150 train_time:68612ms step_avg:96.77ms
+step:710/4150 train_time:68792ms step_avg:96.89ms
+step:711/4150 train_time:68971ms step_avg:97.01ms
+step:712/4150 train_time:69150ms step_avg:97.12ms
+step:713/4150 train_time:69327ms step_avg:97.23ms
+step:714/4150 train_time:69507ms step_avg:97.35ms
+step:715/4150 train_time:69684ms step_avg:97.46ms
+step:716/4150 train_time:69866ms step_avg:97.58ms
+step:717/4150 train_time:70045ms step_avg:97.69ms
+step:718/4150 train_time:70223ms step_avg:97.80ms
+step:719/4150 train_time:70400ms step_avg:97.91ms
+step:720/4150 train_time:70580ms step_avg:98.03ms
+step:721/4150 train_time:70757ms step_avg:98.14ms
+step:722/4150 train_time:70938ms step_avg:98.25ms
+step:723/4150 train_time:71118ms step_avg:98.37ms
+step:724/4150 train_time:71298ms step_avg:98.48ms
+step:725/4150 train_time:71478ms step_avg:98.59ms
+step:726/4150 train_time:71657ms step_avg:98.70ms
+step:727/4150 train_time:71838ms step_avg:98.81ms
+step:728/4150 train_time:72017ms step_avg:98.92ms
+step:729/4150 train_time:72196ms step_avg:99.03ms
+step:730/4150 train_time:72376ms step_avg:99.14ms
+step:731/4150 train_time:72553ms step_avg:99.25ms
+step:732/4150 train_time:72733ms step_avg:99.36ms
+step:733/4150 train_time:72911ms step_avg:99.47ms
+step:734/4150 train_time:73090ms step_avg:99.58ms
+step:735/4150 train_time:73268ms step_avg:99.68ms
+step:736/4150 train_time:73448ms step_avg:99.79ms
+step:737/4150 train_time:73626ms step_avg:99.90ms
+step:738/4150 train_time:73806ms step_avg:100.01ms
+step:739/4150 train_time:73987ms step_avg:100.12ms
+step:740/4150 train_time:74165ms step_avg:100.22ms
+step:741/4150 train_time:74344ms step_avg:100.33ms
+step:742/4150 train_time:74521ms step_avg:100.43ms
+step:743/4150 train_time:74699ms step_avg:100.54ms
+step:744/4150 train_time:74880ms step_avg:100.65ms
+step:745/4150 train_time:75060ms step_avg:100.75ms
+step:746/4150 train_time:75241ms step_avg:100.86ms
+step:747/4150 train_time:75419ms step_avg:100.96ms
+step:748/4150 train_time:75599ms step_avg:101.07ms
+step:749/4150 train_time:75778ms step_avg:101.17ms
+step:750/4150 train_time:75959ms step_avg:101.28ms
+step:750/4150 val_loss:3.5553 train_time:76126ms step_avg:101.50ms
+step:751/4150 train_time:76149ms step_avg:101.40ms
+step:752/4150 train_time:76325ms step_avg:101.50ms
+step:753/4150 train_time:76511ms step_avg:101.61ms
+step:754/4150 train_time:76689ms step_avg:101.71ms
+step:755/4150 train_time:76865ms step_avg:101.81ms
+step:756/4150 train_time:77042ms step_avg:101.91ms
+step:757/4150 train_time:77221ms step_avg:102.01ms
+step:758/4150 train_time:77406ms step_avg:102.12ms
+step:759/4150 train_time:77588ms step_avg:102.22ms
+step:760/4150 train_time:77767ms step_avg:102.33ms
+step:761/4150 train_time:77944ms step_avg:102.42ms
+step:762/4150 train_time:78123ms step_avg:102.52ms
+step:763/4150 train_time:78303ms step_avg:102.62ms
+step:764/4150 train_time:78487ms step_avg:102.73ms
+step:765/4150 train_time:78668ms step_avg:102.83ms
+step:766/4150 train_time:78848ms step_avg:102.93ms
+step:767/4150 train_time:79025ms step_avg:103.03ms
+step:768/4150 train_time:79203ms step_avg:103.13ms
+step:769/4150 train_time:79383ms step_avg:103.23ms
+step:770/4150 train_time:79564ms step_avg:103.33ms
+step:771/4150 train_time:79743ms step_avg:103.43ms
+step:772/4150 train_time:79923ms step_avg:103.53ms
+step:773/4150 train_time:80102ms step_avg:103.62ms
+step:774/4150 train_time:80279ms step_avg:103.72ms
+step:775/4150 train_time:80458ms step_avg:103.82ms
+step:776/4150 train_time:80638ms step_avg:103.92ms
+step:777/4150 train_time:80818ms step_avg:104.01ms
+step:778/4150 train_time:80998ms step_avg:104.11ms
+step:779/4150 train_time:81174ms step_avg:104.20ms
+step:780/4150 train_time:81353ms step_avg:104.30ms
+step:781/4150 train_time:81533ms step_avg:104.40ms
+step:782/4150 train_time:81715ms step_avg:104.49ms
+step:783/4150 train_time:81892ms step_avg:104.59ms
+step:784/4150 train_time:82070ms step_avg:104.68ms
+step:785/4150 train_time:82250ms step_avg:104.78ms
+step:786/4150 train_time:82428ms step_avg:104.87ms
+step:787/4150 train_time:82609ms step_avg:104.97ms
+step:788/4150 train_time:82791ms step_avg:105.06ms
+step:789/4150 train_time:82971ms step_avg:105.16ms
+step:790/4150 train_time:83151ms step_avg:105.25ms
+step:791/4150 train_time:83329ms step_avg:105.35ms
+step:792/4150 train_time:83510ms step_avg:105.44ms
+step:793/4150 train_time:83691ms step_avg:105.54ms
+step:794/4150 train_time:83872ms step_avg:105.63ms
+step:795/4150 train_time:84051ms step_avg:105.72ms
+step:796/4150 train_time:84228ms step_avg:105.81ms
+step:797/4150 train_time:84408ms step_avg:105.91ms
+step:798/4150 train_time:84588ms step_avg:106.00ms
+step:799/4150 train_time:84768ms step_avg:106.09ms
+step:800/4150 train_time:84946ms step_avg:106.18ms
+step:801/4150 train_time:85125ms step_avg:106.27ms
+step:802/4150 train_time:85305ms step_avg:106.37ms
+step:803/4150 train_time:85485ms step_avg:106.46ms
+step:804/4150 train_time:85667ms step_avg:106.55ms
+step:805/4150 train_time:85847ms step_avg:106.64ms
+step:806/4150 train_time:86028ms step_avg:106.73ms
+step:807/4150 train_time:86208ms step_avg:106.82ms
+step:808/4150 train_time:86390ms step_avg:106.92ms
+step:809/4150 train_time:86568ms step_avg:107.01ms
+step:810/4150 train_time:86750ms step_avg:107.10ms
+step:811/4150 train_time:86928ms step_avg:107.19ms
+step:812/4150 train_time:87108ms step_avg:107.28ms
+step:813/4150 train_time:87285ms step_avg:107.36ms
+step:814/4150 train_time:87465ms step_avg:107.45ms
+step:815/4150 train_time:87644ms step_avg:107.54ms
+step:816/4150 train_time:87824ms step_avg:107.63ms
+step:817/4150 train_time:88003ms step_avg:107.72ms
+step:818/4150 train_time:88182ms step_avg:107.80ms
+step:819/4150 train_time:88362ms step_avg:107.89ms
+step:820/4150 train_time:88542ms step_avg:107.98ms
+step:821/4150 train_time:88721ms step_avg:108.06ms
+step:822/4150 train_time:88902ms step_avg:108.15ms
+step:823/4150 train_time:89083ms step_avg:108.24ms
+step:824/4150 train_time:89261ms step_avg:108.33ms
+step:825/4150 train_time:89440ms step_avg:108.41ms
+step:826/4150 train_time:89619ms step_avg:108.50ms
+step:827/4150 train_time:89798ms step_avg:108.58ms
+step:828/4150 train_time:89978ms step_avg:108.67ms
+step:829/4150 train_time:90156ms step_avg:108.75ms
+step:830/4150 train_time:90335ms step_avg:108.84ms
+step:831/4150 train_time:90514ms step_avg:108.92ms
+step:832/4150 train_time:90693ms step_avg:109.01ms
+step:833/4150 train_time:90871ms step_avg:109.09ms
+step:834/4150 train_time:91050ms step_avg:109.17ms
+step:835/4150 train_time:91227ms step_avg:109.25ms
+step:836/4150 train_time:91406ms step_avg:109.34ms
+step:837/4150 train_time:91584ms step_avg:109.42ms
+step:838/4150 train_time:91763ms step_avg:109.50ms
+step:839/4150 train_time:91943ms step_avg:109.59ms
+step:840/4150 train_time:92122ms step_avg:109.67ms
+step:841/4150 train_time:92301ms step_avg:109.75ms
+step:842/4150 train_time:92481ms step_avg:109.83ms
+step:843/4150 train_time:92659ms step_avg:109.92ms
+step:844/4150 train_time:92840ms step_avg:110.00ms
+step:845/4150 train_time:93018ms step_avg:110.08ms
+step:846/4150 train_time:93200ms step_avg:110.17ms
+step:847/4150 train_time:93377ms step_avg:110.24ms
+step:848/4150 train_time:93557ms step_avg:110.33ms
+step:849/4150 train_time:93736ms step_avg:110.41ms
+step:850/4150 train_time:93915ms step_avg:110.49ms
+step:851/4150 train_time:94093ms step_avg:110.57ms
+step:852/4150 train_time:94272ms step_avg:110.65ms
+step:853/4150 train_time:94449ms step_avg:110.73ms
+step:854/4150 train_time:94628ms step_avg:110.81ms
+step:855/4150 train_time:94809ms step_avg:110.89ms
+step:856/4150 train_time:94989ms step_avg:110.97ms
+step:857/4150 train_time:95168ms step_avg:111.05ms
+step:858/4150 train_time:95348ms step_avg:111.13ms
+step:859/4150 train_time:95525ms step_avg:111.21ms
+step:860/4150 train_time:95706ms step_avg:111.29ms
+step:861/4150 train_time:95885ms step_avg:111.36ms
+step:862/4150 train_time:96066ms step_avg:111.45ms
+step:863/4150 train_time:96244ms step_avg:111.52ms
+step:864/4150 train_time:96424ms step_avg:111.60ms
+step:865/4150 train_time:96603ms step_avg:111.68ms
+step:866/4150 train_time:96784ms step_avg:111.76ms
+step:867/4150 train_time:96963ms step_avg:111.84ms
+step:868/4150 train_time:97144ms step_avg:111.92ms
+step:869/4150 train_time:97324ms step_avg:111.99ms
+step:870/4150 train_time:97502ms step_avg:112.07ms
+step:871/4150 train_time:97681ms step_avg:112.15ms
+step:872/4150 train_time:97862ms step_avg:112.23ms
+step:873/4150 train_time:98040ms step_avg:112.30ms
+step:874/4150 train_time:98221ms step_avg:112.38ms
+step:875/4150 train_time:98399ms step_avg:112.46ms
+step:876/4150 train_time:98579ms step_avg:112.53ms
+step:877/4150 train_time:98757ms step_avg:112.61ms
+step:878/4150 train_time:98935ms step_avg:112.68ms
+step:879/4150 train_time:99114ms step_avg:112.76ms
+step:880/4150 train_time:99296ms step_avg:112.84ms
+step:881/4150 train_time:99475ms step_avg:112.91ms
+step:882/4150 train_time:99655ms step_avg:112.99ms
+step:883/4150 train_time:99833ms step_avg:113.06ms
+step:884/4150 train_time:100011ms step_avg:113.14ms
+step:885/4150 train_time:100189ms step_avg:113.21ms
+step:886/4150 train_time:100369ms step_avg:113.28ms
+step:887/4150 train_time:100550ms step_avg:113.36ms
+step:888/4150 train_time:100731ms step_avg:113.44ms
+step:889/4150 train_time:100908ms step_avg:113.51ms
+step:890/4150 train_time:101088ms step_avg:113.58ms
+step:891/4150 train_time:101267ms step_avg:113.66ms
+step:892/4150 train_time:101449ms step_avg:113.73ms
+step:893/4150 train_time:101628ms step_avg:113.81ms
+step:894/4150 train_time:101809ms step_avg:113.88ms
+step:895/4150 train_time:101990ms step_avg:113.96ms
+step:896/4150 train_time:102170ms step_avg:114.03ms
+step:897/4150 train_time:102346ms step_avg:114.10ms
+step:898/4150 train_time:102527ms step_avg:114.17ms
+step:899/4150 train_time:102706ms step_avg:114.24ms
+step:900/4150 train_time:102887ms step_avg:114.32ms
+step:901/4150 train_time:103065ms step_avg:114.39ms
+step:902/4150 train_time:103245ms step_avg:114.46ms
+step:903/4150 train_time:103421ms step_avg:114.53ms
+step:904/4150 train_time:103601ms step_avg:114.60ms
+step:905/4150 train_time:103781ms step_avg:114.68ms
+step:906/4150 train_time:103964ms step_avg:114.75ms
+step:907/4150 train_time:104143ms step_avg:114.82ms
+step:908/4150 train_time:104324ms step_avg:114.89ms
+step:909/4150 train_time:104502ms step_avg:114.96ms
+step:910/4150 train_time:104682ms step_avg:115.04ms
+step:911/4150 train_time:104860ms step_avg:115.10ms
+step:912/4150 train_time:105040ms step_avg:115.17ms
+step:913/4150 train_time:105218ms step_avg:115.24ms
+step:914/4150 train_time:105397ms step_avg:115.31ms
+step:915/4150 train_time:105574ms step_avg:115.38ms
+step:916/4150 train_time:105753ms step_avg:115.45ms
+step:917/4150 train_time:105932ms step_avg:115.52ms
+step:918/4150 train_time:106112ms step_avg:115.59ms
+step:919/4150 train_time:106292ms step_avg:115.66ms
+step:920/4150 train_time:106472ms step_avg:115.73ms
+step:921/4150 train_time:106653ms step_avg:115.80ms
+step:922/4150 train_time:106832ms step_avg:115.87ms
+step:923/4150 train_time:107011ms step_avg:115.94ms
+step:924/4150 train_time:107191ms step_avg:116.01ms
+step:925/4150 train_time:107368ms step_avg:116.07ms
+step:926/4150 train_time:107548ms step_avg:116.14ms
+step:927/4150 train_time:107727ms step_avg:116.21ms
+step:928/4150 train_time:107908ms step_avg:116.28ms
+step:929/4150 train_time:108087ms step_avg:116.35ms
+step:930/4150 train_time:108267ms step_avg:116.42ms
+step:931/4150 train_time:108445ms step_avg:116.48ms
+step:932/4150 train_time:108623ms step_avg:116.55ms
+step:933/4150 train_time:108802ms step_avg:116.62ms
+step:934/4150 train_time:108983ms step_avg:116.68ms
+step:935/4150 train_time:109163ms step_avg:116.75ms
+step:936/4150 train_time:109342ms step_avg:116.82ms
+step:937/4150 train_time:109520ms step_avg:116.88ms
+step:938/4150 train_time:109700ms step_avg:116.95ms
+step:939/4150 train_time:109878ms step_avg:117.02ms
+step:940/4150 train_time:110058ms step_avg:117.08ms
+step:941/4150 train_time:110238ms step_avg:117.15ms
+step:942/4150 train_time:110417ms step_avg:117.21ms
+step:943/4150 train_time:110594ms step_avg:117.28ms
+step:944/4150 train_time:110773ms step_avg:117.34ms
+step:945/4150 train_time:110952ms step_avg:117.41ms
+step:946/4150 train_time:111131ms step_avg:117.47ms
+step:947/4150 train_time:111311ms step_avg:117.54ms
+step:948/4150 train_time:111490ms step_avg:117.61ms
+step:949/4150 train_time:111667ms step_avg:117.67ms
+step:950/4150 train_time:111848ms step_avg:117.74ms
+step:951/4150 train_time:112026ms step_avg:117.80ms
+step:952/4150 train_time:112208ms step_avg:117.87ms
+step:953/4150 train_time:112388ms step_avg:117.93ms
+step:954/4150 train_time:112566ms step_avg:117.99ms
+step:955/4150 train_time:112745ms step_avg:118.06ms
+step:956/4150 train_time:112925ms step_avg:118.12ms
+step:957/4150 train_time:113104ms step_avg:118.19ms
+step:958/4150 train_time:113285ms step_avg:118.25ms
+step:959/4150 train_time:113464ms step_avg:118.31ms
+step:960/4150 train_time:113645ms step_avg:118.38ms
+step:961/4150 train_time:113824ms step_avg:118.44ms
+step:962/4150 train_time:114003ms step_avg:118.51ms
+step:963/4150 train_time:114183ms step_avg:118.57ms
+step:964/4150 train_time:114364ms step_avg:118.64ms
+step:965/4150 train_time:114544ms step_avg:118.70ms
+step:966/4150 train_time:114723ms step_avg:118.76ms
+step:967/4150 train_time:114903ms step_avg:118.82ms
+step:968/4150 train_time:115082ms step_avg:118.89ms
+step:969/4150 train_time:115260ms step_avg:118.95ms
+step:970/4150 train_time:115440ms step_avg:119.01ms
+step:971/4150 train_time:115619ms step_avg:119.07ms
+step:972/4150 train_time:115797ms step_avg:119.13ms
+step:973/4150 train_time:115976ms step_avg:119.19ms
+step:974/4150 train_time:116155ms step_avg:119.26ms
+step:975/4150 train_time:116332ms step_avg:119.31ms
+step:976/4150 train_time:116512ms step_avg:119.38ms
+step:977/4150 train_time:116694ms step_avg:119.44ms
+step:978/4150 train_time:116874ms step_avg:119.50ms
+step:979/4150 train_time:117054ms step_avg:119.56ms
+step:980/4150 train_time:117235ms step_avg:119.63ms
+step:981/4150 train_time:117414ms step_avg:119.69ms
+step:982/4150 train_time:117594ms step_avg:119.75ms
+step:983/4150 train_time:117772ms step_avg:119.81ms
+step:984/4150 train_time:117952ms step_avg:119.87ms
+step:985/4150 train_time:118129ms step_avg:119.93ms
+step:986/4150 train_time:118309ms step_avg:119.99ms
+step:987/4150 train_time:118489ms step_avg:120.05ms
+step:988/4150 train_time:118669ms step_avg:120.11ms
+step:989/4150 train_time:118846ms step_avg:120.17ms
+step:990/4150 train_time:119027ms step_avg:120.23ms
+step:991/4150 train_time:119207ms step_avg:120.29ms
+step:992/4150 train_time:119387ms step_avg:120.35ms
+step:993/4150 train_time:119569ms step_avg:120.41ms
+step:994/4150 train_time:119748ms step_avg:120.47ms
+step:995/4150 train_time:119927ms step_avg:120.53ms
+step:996/4150 train_time:120106ms step_avg:120.59ms
+step:997/4150 train_time:120284ms step_avg:120.65ms
+step:998/4150 train_time:120462ms step_avg:120.70ms
+step:999/4150 train_time:120642ms step_avg:120.76ms
+step:1000/4150 train_time:120821ms step_avg:120.82ms
+step:1000/4150 val_loss:3.4462 train_time:120986ms step_avg:120.99ms
+step:1001/4150 train_time:121009ms step_avg:120.89ms
+step:1002/4150 train_time:121181ms step_avg:120.94ms
+step:1003/4150 train_time:121366ms step_avg:121.00ms
+step:1004/4150 train_time:121546ms step_avg:121.06ms
+step:1005/4150 train_time:121723ms step_avg:121.12ms
+step:1006/4150 train_time:121900ms step_avg:121.17ms
+step:1007/4150 train_time:122078ms step_avg:121.23ms
+step:1008/4150 train_time:122259ms step_avg:121.29ms
+step:1009/4150 train_time:122438ms step_avg:121.35ms
+step:1010/4150 train_time:122619ms step_avg:121.40ms
+step:1011/4150 train_time:122798ms step_avg:121.46ms
+step:1012/4150 train_time:122976ms step_avg:121.52ms
+step:1013/4150 train_time:123152ms step_avg:121.57ms
+step:1014/4150 train_time:123331ms step_avg:121.63ms
+step:1015/4150 train_time:123511ms step_avg:121.69ms
+step:1016/4150 train_time:123688ms step_avg:121.74ms
+step:1017/4150 train_time:123865ms step_avg:121.79ms
+step:1018/4150 train_time:124044ms step_avg:121.85ms
+step:1019/4150 train_time:124224ms step_avg:121.91ms
+step:1020/4150 train_time:124406ms step_avg:121.97ms
+step:1021/4150 train_time:124584ms step_avg:122.02ms
+step:1022/4150 train_time:124765ms step_avg:122.08ms
+step:1023/4150 train_time:124941ms step_avg:122.13ms
+step:1024/4150 train_time:125120ms step_avg:122.19ms
+step:1025/4150 train_time:125298ms step_avg:122.24ms
+step:1026/4150 train_time:125481ms step_avg:122.30ms
+step:1027/4150 train_time:125660ms step_avg:122.36ms
+step:1028/4150 train_time:125840ms step_avg:122.41ms
+step:1029/4150 train_time:126017ms step_avg:122.47ms
+step:1030/4150 train_time:126197ms step_avg:122.52ms
+step:1031/4150 train_time:126376ms step_avg:122.58ms
+step:1032/4150 train_time:126557ms step_avg:122.63ms
+step:1033/4150 train_time:126739ms step_avg:122.69ms
+step:1034/4150 train_time:126974ms step_avg:122.80ms
+step:1035/4150 train_time:127208ms step_avg:122.91ms
+step:1036/4150 train_time:127445ms step_avg:123.02ms
+step:1037/4150 train_time:127678ms step_avg:123.12ms
+step:1038/4150 train_time:127911ms step_avg:123.23ms
+step:1039/4150 train_time:128142ms step_avg:123.33ms
+step:1040/4150 train_time:128378ms step_avg:123.44ms
+step:1041/4150 train_time:128611ms step_avg:123.55ms
+step:1042/4150 train_time:128846ms step_avg:123.65ms
+step:1043/4150 train_time:129075ms step_avg:123.75ms
+step:1044/4150 train_time:129311ms step_avg:123.86ms
+step:1045/4150 train_time:129544ms step_avg:123.97ms
+step:1046/4150 train_time:129781ms step_avg:124.07ms
+step:1047/4150 train_time:130013ms step_avg:124.18ms
+step:1048/4150 train_time:130246ms step_avg:124.28ms
+step:1049/4150 train_time:130478ms step_avg:124.38ms
+step:1050/4150 train_time:130714ms step_avg:124.49ms
+step:1051/4150 train_time:130949ms step_avg:124.59ms
+step:1052/4150 train_time:131184ms step_avg:124.70ms
+step:1053/4150 train_time:131414ms step_avg:124.80ms
+step:1054/4150 train_time:131649ms step_avg:124.90ms
+step:1055/4150 train_time:131883ms step_avg:125.01ms
+step:1056/4150 train_time:132117ms step_avg:125.11ms
+step:1057/4150 train_time:132346ms step_avg:125.21ms
+step:1058/4150 train_time:132579ms step_avg:125.31ms
+step:1059/4150 train_time:132810ms step_avg:125.41ms
+step:1060/4150 train_time:133047ms step_avg:125.52ms
+step:1061/4150 train_time:133275ms step_avg:125.61ms
+step:1062/4150 train_time:133511ms step_avg:125.72ms
+step:1063/4150 train_time:133743ms step_avg:125.82ms
+step:1064/4150 train_time:133980ms step_avg:125.92ms
+step:1065/4150 train_time:134210ms step_avg:126.02ms
+step:1066/4150 train_time:134444ms step_avg:126.12ms
+step:1067/4150 train_time:134675ms step_avg:126.22ms
+step:1068/4150 train_time:134910ms step_avg:126.32ms
+step:1069/4150 train_time:135143ms step_avg:126.42ms
+step:1070/4150 train_time:135380ms step_avg:126.52ms
+step:1071/4150 train_time:135608ms step_avg:126.62ms
+step:1072/4150 train_time:135844ms step_avg:126.72ms
+step:1073/4150 train_time:136075ms step_avg:126.82ms
+step:1074/4150 train_time:136310ms step_avg:126.92ms
+step:1075/4150 train_time:136543ms step_avg:127.02ms
+step:1076/4150 train_time:136776ms step_avg:127.12ms
+step:1077/4150 train_time:137010ms step_avg:127.21ms
+step:1078/4150 train_time:137246ms step_avg:127.32ms
+step:1079/4150 train_time:137477ms step_avg:127.41ms
+step:1080/4150 train_time:137711ms step_avg:127.51ms
+step:1081/4150 train_time:137945ms step_avg:127.61ms
+step:1082/4150 train_time:138179ms step_avg:127.71ms
+step:1083/4150 train_time:138412ms step_avg:127.80ms
+step:1084/4150 train_time:138646ms step_avg:127.90ms
+step:1085/4150 train_time:138876ms step_avg:128.00ms
+step:1086/4150 train_time:139111ms step_avg:128.10ms
+step:1087/4150 train_time:139345ms step_avg:128.19ms
+step:1088/4150 train_time:139579ms step_avg:128.29ms
+step:1089/4150 train_time:139808ms step_avg:128.38ms
+step:1090/4150 train_time:140044ms step_avg:128.48ms
+step:1091/4150 train_time:140276ms step_avg:128.58ms
+step:1092/4150 train_time:140510ms step_avg:128.67ms
+step:1093/4150 train_time:140741ms step_avg:128.77ms
+step:1094/4150 train_time:140975ms step_avg:128.86ms
+step:1095/4150 train_time:141208ms step_avg:128.96ms
+step:1096/4150 train_time:141442ms step_avg:129.05ms
+step:1097/4150 train_time:141674ms step_avg:129.15ms
+step:1098/4150 train_time:141905ms step_avg:129.24ms
+step:1099/4150 train_time:142136ms step_avg:129.33ms
+step:1100/4150 train_time:142370ms step_avg:129.43ms
+step:1101/4150 train_time:142601ms step_avg:129.52ms
+step:1102/4150 train_time:142836ms step_avg:129.62ms
+step:1103/4150 train_time:143066ms step_avg:129.71ms
+step:1104/4150 train_time:143303ms step_avg:129.80ms
+step:1105/4150 train_time:143535ms step_avg:129.90ms
+step:1106/4150 train_time:143768ms step_avg:129.99ms
+step:1107/4150 train_time:143999ms step_avg:130.08ms
+step:1108/4150 train_time:144234ms step_avg:130.17ms
+step:1109/4150 train_time:144467ms step_avg:130.27ms
+step:1110/4150 train_time:144703ms step_avg:130.36ms
+step:1111/4150 train_time:144935ms step_avg:130.45ms
+step:1112/4150 train_time:145168ms step_avg:130.55ms
+step:1113/4150 train_time:145399ms step_avg:130.64ms
+step:1114/4150 train_time:145634ms step_avg:130.73ms
+step:1115/4150 train_time:145867ms step_avg:130.82ms
+step:1116/4150 train_time:146102ms step_avg:130.92ms
+step:1117/4150 train_time:146334ms step_avg:131.01ms
+step:1118/4150 train_time:146567ms step_avg:131.10ms
+step:1119/4150 train_time:146801ms step_avg:131.19ms
+step:1120/4150 train_time:147037ms step_avg:131.28ms
+step:1121/4150 train_time:147270ms step_avg:131.37ms
+step:1122/4150 train_time:147503ms step_avg:131.46ms
+step:1123/4150 train_time:147735ms step_avg:131.55ms
+step:1124/4150 train_time:147971ms step_avg:131.65ms
+step:1125/4150 train_time:148203ms step_avg:131.74ms
+step:1126/4150 train_time:148437ms step_avg:131.83ms
+step:1127/4150 train_time:148669ms step_avg:131.92ms
+step:1128/4150 train_time:148904ms step_avg:132.01ms
+step:1129/4150 train_time:149138ms step_avg:132.10ms
+step:1130/4150 train_time:149372ms step_avg:132.19ms
+step:1131/4150 train_time:149603ms step_avg:132.27ms
+step:1132/4150 train_time:149837ms step_avg:132.36ms
+step:1133/4150 train_time:150067ms step_avg:132.45ms
+step:1134/4150 train_time:150300ms step_avg:132.54ms
+step:1135/4150 train_time:150530ms step_avg:132.63ms
+step:1136/4150 train_time:150765ms step_avg:132.72ms
+step:1137/4150 train_time:150997ms step_avg:132.80ms
+step:1138/4150 train_time:151232ms step_avg:132.89ms
+step:1139/4150 train_time:151463ms step_avg:132.98ms
+step:1140/4150 train_time:151699ms step_avg:133.07ms
+step:1141/4150 train_time:151932ms step_avg:133.16ms
+step:1142/4150 train_time:152167ms step_avg:133.25ms
+step:1143/4150 train_time:152400ms step_avg:133.33ms
+step:1144/4150 train_time:152636ms step_avg:133.42ms
+step:1145/4150 train_time:152869ms step_avg:133.51ms
+step:1146/4150 train_time:153105ms step_avg:133.60ms
+step:1147/4150 train_time:153334ms step_avg:133.68ms
+step:1148/4150 train_time:153569ms step_avg:133.77ms
+step:1149/4150 train_time:153800ms step_avg:133.86ms
+step:1150/4150 train_time:154036ms step_avg:133.94ms
+step:1151/4150 train_time:154267ms step_avg:134.03ms
+step:1152/4150 train_time:154502ms step_avg:134.12ms
+step:1153/4150 train_time:154734ms step_avg:134.20ms
+step:1154/4150 train_time:154969ms step_avg:134.29ms
+step:1155/4150 train_time:155202ms step_avg:134.37ms
+step:1156/4150 train_time:155434ms step_avg:134.46ms
+step:1157/4150 train_time:155669ms step_avg:134.55ms
+step:1158/4150 train_time:155902ms step_avg:134.63ms
+step:1159/4150 train_time:156132ms step_avg:134.71ms
+step:1160/4150 train_time:156366ms step_avg:134.80ms
+step:1161/4150 train_time:156597ms step_avg:134.88ms
+step:1162/4150 train_time:156835ms step_avg:134.97ms
+step:1163/4150 train_time:157065ms step_avg:135.05ms
+step:1164/4150 train_time:157299ms step_avg:135.14ms
+step:1165/4150 train_time:157529ms step_avg:135.22ms
+step:1166/4150 train_time:157765ms step_avg:135.30ms
+step:1167/4150 train_time:157995ms step_avg:135.39ms
+step:1168/4150 train_time:158228ms step_avg:135.47ms
+step:1169/4150 train_time:158458ms step_avg:135.55ms
+step:1170/4150 train_time:158693ms step_avg:135.64ms
+step:1171/4150 train_time:158924ms step_avg:135.72ms
+step:1172/4150 train_time:159162ms step_avg:135.80ms
+step:1173/4150 train_time:159394ms step_avg:135.89ms
+step:1174/4150 train_time:159629ms step_avg:135.97ms
+step:1175/4150 train_time:159861ms step_avg:136.05ms
+step:1176/4150 train_time:160094ms step_avg:136.13ms
+step:1177/4150 train_time:160325ms step_avg:136.22ms
+step:1178/4150 train_time:160560ms step_avg:136.30ms
+step:1179/4150 train_time:160790ms step_avg:136.38ms
+step:1180/4150 train_time:161029ms step_avg:136.46ms
+step:1181/4150 train_time:161260ms step_avg:136.55ms
+step:1182/4150 train_time:161494ms step_avg:136.63ms
+step:1183/4150 train_time:161726ms step_avg:136.71ms
+step:1184/4150 train_time:161961ms step_avg:136.79ms
+step:1185/4150 train_time:162192ms step_avg:136.87ms
+step:1186/4150 train_time:162427ms step_avg:136.95ms
+step:1187/4150 train_time:162657ms step_avg:137.03ms
+step:1188/4150 train_time:162893ms step_avg:137.12ms
+step:1189/4150 train_time:163124ms step_avg:137.19ms
+step:1190/4150 train_time:163360ms step_avg:137.28ms
+step:1191/4150 train_time:163590ms step_avg:137.35ms
+step:1192/4150 train_time:163827ms step_avg:137.44ms
+step:1193/4150 train_time:164058ms step_avg:137.52ms
+step:1194/4150 train_time:164292ms step_avg:137.60ms
+step:1195/4150 train_time:164523ms step_avg:137.68ms
+step:1196/4150 train_time:164758ms step_avg:137.76ms
+step:1197/4150 train_time:164989ms step_avg:137.84ms
+step:1198/4150 train_time:165224ms step_avg:137.92ms
+step:1199/4150 train_time:165455ms step_avg:137.99ms
+step:1200/4150 train_time:165688ms step_avg:138.07ms
+step:1201/4150 train_time:165920ms step_avg:138.15ms
+step:1202/4150 train_time:166155ms step_avg:138.23ms
+step:1203/4150 train_time:166386ms step_avg:138.31ms
+step:1204/4150 train_time:166622ms step_avg:138.39ms
+step:1205/4150 train_time:166857ms step_avg:138.47ms
+step:1206/4150 train_time:167091ms step_avg:138.55ms
+step:1207/4150 train_time:167323ms step_avg:138.63ms
+step:1208/4150 train_time:167557ms step_avg:138.71ms
+step:1209/4150 train_time:167788ms step_avg:138.78ms
+step:1210/4150 train_time:168022ms step_avg:138.86ms
+step:1211/4150 train_time:168255ms step_avg:138.94ms
+step:1212/4150 train_time:168488ms step_avg:139.02ms
+step:1213/4150 train_time:168720ms step_avg:139.09ms
+step:1214/4150 train_time:168953ms step_avg:139.17ms
+step:1215/4150 train_time:169186ms step_avg:139.25ms
+step:1216/4150 train_time:169421ms step_avg:139.33ms
+step:1217/4150 train_time:169654ms step_avg:139.40ms
+step:1218/4150 train_time:169886ms step_avg:139.48ms
+step:1219/4150 train_time:170118ms step_avg:139.56ms
+step:1220/4150 train_time:170352ms step_avg:139.63ms
+step:1221/4150 train_time:170583ms step_avg:139.71ms
+step:1222/4150 train_time:170816ms step_avg:139.78ms
+step:1223/4150 train_time:171047ms step_avg:139.86ms
+step:1224/4150 train_time:171283ms step_avg:139.94ms
+step:1225/4150 train_time:171513ms step_avg:140.01ms
+step:1226/4150 train_time:171746ms step_avg:140.09ms
+step:1227/4150 train_time:171977ms step_avg:140.16ms
+step:1228/4150 train_time:172211ms step_avg:140.24ms
+step:1229/4150 train_time:172445ms step_avg:140.31ms
+step:1230/4150 train_time:172679ms step_avg:140.39ms
+step:1231/4150 train_time:172908ms step_avg:140.46ms
+step:1232/4150 train_time:173143ms step_avg:140.54ms
+step:1233/4150 train_time:173375ms step_avg:140.61ms
+step:1234/4150 train_time:173607ms step_avg:140.69ms
+step:1235/4150 train_time:173839ms step_avg:140.76ms
+step:1236/4150 train_time:174075ms step_avg:140.84ms
+step:1237/4150 train_time:174309ms step_avg:140.91ms
+step:1238/4150 train_time:174545ms step_avg:140.99ms
+step:1239/4150 train_time:174776ms step_avg:141.06ms
+step:1240/4150 train_time:175010ms step_avg:141.14ms
+step:1241/4150 train_time:175245ms step_avg:141.21ms
+step:1242/4150 train_time:175480ms step_avg:141.29ms
+step:1243/4150 train_time:175711ms step_avg:141.36ms
+step:1244/4150 train_time:175946ms step_avg:141.44ms
+step:1245/4150 train_time:176178ms step_avg:141.51ms
+step:1246/4150 train_time:176412ms step_avg:141.58ms
+step:1247/4150 train_time:176643ms step_avg:141.65ms
+step:1248/4150 train_time:176878ms step_avg:141.73ms
+step:1249/4150 train_time:177108ms step_avg:141.80ms
+step:1250/4150 train_time:177344ms step_avg:141.88ms
+step:1250/4150 val_loss:3.3583 train_time:177556ms step_avg:142.04ms
+step:1251/4150 train_time:177579ms step_avg:141.95ms
+step:1252/4150 train_time:177815ms step_avg:142.02ms
+step:1253/4150 train_time:178047ms step_avg:142.10ms
+step:1254/4150 train_time:178280ms step_avg:142.17ms
+step:1255/4150 train_time:178507ms step_avg:142.24ms
+step:1256/4150 train_time:178744ms step_avg:142.31ms
+step:1257/4150 train_time:178979ms step_avg:142.39ms
+step:1258/4150 train_time:179211ms step_avg:142.46ms
+step:1259/4150 train_time:179440ms step_avg:142.53ms
+step:1260/4150 train_time:179672ms step_avg:142.60ms
+step:1261/4150 train_time:179904ms step_avg:142.67ms
+step:1262/4150 train_time:180142ms step_avg:142.74ms
+step:1263/4150 train_time:180372ms step_avg:142.81ms
+step:1264/4150 train_time:180606ms step_avg:142.88ms
+step:1265/4150 train_time:180839ms step_avg:142.96ms
+step:1266/4150 train_time:181075ms step_avg:143.03ms
+step:1267/4150 train_time:181305ms step_avg:143.10ms
+step:1268/4150 train_time:181538ms step_avg:143.17ms
+step:1269/4150 train_time:181769ms step_avg:143.24ms
+step:1270/4150 train_time:182004ms step_avg:143.31ms
+step:1271/4150 train_time:182237ms step_avg:143.38ms
+step:1272/4150 train_time:182470ms step_avg:143.45ms
+step:1273/4150 train_time:182702ms step_avg:143.52ms
+step:1274/4150 train_time:182937ms step_avg:143.59ms
+step:1275/4150 train_time:183168ms step_avg:143.66ms
+step:1276/4150 train_time:183403ms step_avg:143.73ms
+step:1277/4150 train_time:183633ms step_avg:143.80ms
+step:1278/4150 train_time:183868ms step_avg:143.87ms
+step:1279/4150 train_time:184100ms step_avg:143.94ms
+step:1280/4150 train_time:184335ms step_avg:144.01ms
+step:1281/4150 train_time:184565ms step_avg:144.08ms
+step:1282/4150 train_time:184798ms step_avg:144.15ms
+step:1283/4150 train_time:185031ms step_avg:144.22ms
+step:1284/4150 train_time:185266ms step_avg:144.29ms
+step:1285/4150 train_time:185497ms step_avg:144.36ms
+step:1286/4150 train_time:185731ms step_avg:144.43ms
+step:1287/4150 train_time:185964ms step_avg:144.49ms
+step:1288/4150 train_time:186198ms step_avg:144.56ms
+step:1289/4150 train_time:186429ms step_avg:144.63ms
+step:1290/4150 train_time:186661ms step_avg:144.70ms
+step:1291/4150 train_time:186892ms step_avg:144.77ms
+step:1292/4150 train_time:187125ms step_avg:144.83ms
+step:1293/4150 train_time:187356ms step_avg:144.90ms
+step:1294/4150 train_time:187590ms step_avg:144.97ms
+step:1295/4150 train_time:187823ms step_avg:145.04ms
+step:1296/4150 train_time:188060ms step_avg:145.11ms
+step:1297/4150 train_time:188290ms step_avg:145.17ms
+step:1298/4150 train_time:188525ms step_avg:145.24ms
+step:1299/4150 train_time:188755ms step_avg:145.31ms
+step:1300/4150 train_time:188990ms step_avg:145.38ms
+step:1301/4150 train_time:189223ms step_avg:145.44ms
+step:1302/4150 train_time:189458ms step_avg:145.51ms
+step:1303/4150 train_time:189689ms step_avg:145.58ms
+step:1304/4150 train_time:189923ms step_avg:145.65ms
+step:1305/4150 train_time:190156ms step_avg:145.71ms
+step:1306/4150 train_time:190390ms step_avg:145.78ms
+step:1307/4150 train_time:190620ms step_avg:145.85ms
+step:1308/4150 train_time:190854ms step_avg:145.91ms
+step:1309/4150 train_time:191085ms step_avg:145.98ms
+step:1310/4150 train_time:191322ms step_avg:146.05ms
+step:1311/4150 train_time:191553ms step_avg:146.11ms
+step:1312/4150 train_time:191787ms step_avg:146.18ms
+step:1313/4150 train_time:192020ms step_avg:146.25ms
+step:1314/4150 train_time:192256ms step_avg:146.31ms
+step:1315/4150 train_time:192485ms step_avg:146.38ms
+step:1316/4150 train_time:192719ms step_avg:146.44ms
+step:1317/4150 train_time:192950ms step_avg:146.51ms
+step:1318/4150 train_time:193183ms step_avg:146.57ms
+step:1319/4150 train_time:193413ms step_avg:146.64ms
+step:1320/4150 train_time:193649ms step_avg:146.70ms
+step:1321/4150 train_time:193885ms step_avg:146.77ms
+step:1322/4150 train_time:194117ms step_avg:146.84ms
+step:1323/4150 train_time:194348ms step_avg:146.90ms
+step:1324/4150 train_time:194585ms step_avg:146.97ms
+step:1325/4150 train_time:194818ms step_avg:147.03ms
+step:1326/4150 train_time:195051ms step_avg:147.10ms
+step:1327/4150 train_time:195285ms step_avg:147.16ms
+step:1328/4150 train_time:195519ms step_avg:147.23ms
+step:1329/4150 train_time:195751ms step_avg:147.29ms
+step:1330/4150 train_time:195984ms step_avg:147.36ms
+step:1331/4150 train_time:196213ms step_avg:147.42ms
+step:1332/4150 train_time:196447ms step_avg:147.48ms
+step:1333/4150 train_time:196679ms step_avg:147.55ms
+step:1334/4150 train_time:196913ms step_avg:147.61ms
+step:1335/4150 train_time:197147ms step_avg:147.68ms
+step:1336/4150 train_time:197384ms step_avg:147.74ms
+step:1337/4150 train_time:197614ms step_avg:147.80ms
+step:1338/4150 train_time:197849ms step_avg:147.87ms
+step:1339/4150 train_time:198079ms step_avg:147.93ms
+step:1340/4150 train_time:198315ms step_avg:148.00ms
+step:1341/4150 train_time:198546ms step_avg:148.06ms
+step:1342/4150 train_time:198781ms step_avg:148.12ms
+step:1343/4150 train_time:199014ms step_avg:148.19ms
+step:1344/4150 train_time:199248ms step_avg:148.25ms
+step:1345/4150 train_time:199477ms step_avg:148.31ms
+step:1346/4150 train_time:199711ms step_avg:148.37ms
+step:1347/4150 train_time:199944ms step_avg:148.44ms
+step:1348/4150 train_time:200178ms step_avg:148.50ms
+step:1349/4150 train_time:200408ms step_avg:148.56ms
+step:1350/4150 train_time:200644ms step_avg:148.63ms
+step:1351/4150 train_time:200876ms step_avg:148.69ms
+step:1352/4150 train_time:201110ms step_avg:148.75ms
+step:1353/4150 train_time:201342ms step_avg:148.81ms
+step:1354/4150 train_time:201579ms step_avg:148.88ms
+step:1355/4150 train_time:201811ms step_avg:148.94ms
+step:1356/4150 train_time:202046ms step_avg:149.00ms
+step:1357/4150 train_time:202281ms step_avg:149.07ms
+step:1358/4150 train_time:202516ms step_avg:149.13ms
+step:1359/4150 train_time:202748ms step_avg:149.19ms
+step:1360/4150 train_time:202980ms step_avg:149.25ms
+step:1361/4150 train_time:203211ms step_avg:149.31ms
+step:1362/4150 train_time:203445ms step_avg:149.37ms
+step:1363/4150 train_time:203675ms step_avg:149.43ms
+step:1364/4150 train_time:203909ms step_avg:149.49ms
+step:1365/4150 train_time:204142ms step_avg:149.55ms
+step:1366/4150 train_time:204378ms step_avg:149.62ms
+step:1367/4150 train_time:204609ms step_avg:149.68ms
+step:1368/4150 train_time:204842ms step_avg:149.74ms
+step:1369/4150 train_time:205073ms step_avg:149.80ms
+step:1370/4150 train_time:205307ms step_avg:149.86ms
+step:1371/4150 train_time:205541ms step_avg:149.92ms
+step:1372/4150 train_time:205777ms step_avg:149.98ms
+step:1373/4150 train_time:206008ms step_avg:150.04ms
+step:1374/4150 train_time:206242ms step_avg:150.10ms
+step:1375/4150 train_time:206473ms step_avg:150.16ms
+step:1376/4150 train_time:206705ms step_avg:150.22ms
+step:1377/4150 train_time:206941ms step_avg:150.28ms
+step:1378/4150 train_time:207176ms step_avg:150.35ms
+step:1379/4150 train_time:207410ms step_avg:150.41ms
+step:1380/4150 train_time:207642ms step_avg:150.47ms
+step:1381/4150 train_time:207873ms step_avg:150.52ms
+step:1382/4150 train_time:208110ms step_avg:150.59ms
+step:1383/4150 train_time:208342ms step_avg:150.65ms
+step:1384/4150 train_time:208578ms step_avg:150.71ms
+step:1385/4150 train_time:208808ms step_avg:150.76ms
+step:1386/4150 train_time:209043ms step_avg:150.82ms
+step:1387/4150 train_time:209274ms step_avg:150.88ms
+step:1388/4150 train_time:209507ms step_avg:150.94ms
+step:1389/4150 train_time:209740ms step_avg:151.00ms
+step:1390/4150 train_time:209975ms step_avg:151.06ms
+step:1391/4150 train_time:210209ms step_avg:151.12ms
+step:1392/4150 train_time:210442ms step_avg:151.18ms
+step:1393/4150 train_time:210674ms step_avg:151.24ms
+step:1394/4150 train_time:210910ms step_avg:151.30ms
+step:1395/4150 train_time:211141ms step_avg:151.36ms
+step:1396/4150 train_time:211377ms step_avg:151.42ms
+step:1397/4150 train_time:211610ms step_avg:151.47ms
+step:1398/4150 train_time:211845ms step_avg:151.53ms
+step:1399/4150 train_time:212077ms step_avg:151.59ms
+step:1400/4150 train_time:212311ms step_avg:151.65ms
+step:1401/4150 train_time:212544ms step_avg:151.71ms
+step:1402/4150 train_time:212780ms step_avg:151.77ms
+step:1403/4150 train_time:213012ms step_avg:151.83ms
+step:1404/4150 train_time:213246ms step_avg:151.88ms
+step:1405/4150 train_time:213479ms step_avg:151.94ms
+step:1406/4150 train_time:213715ms step_avg:152.00ms
+step:1407/4150 train_time:213947ms step_avg:152.06ms
+step:1408/4150 train_time:214185ms step_avg:152.12ms
+step:1409/4150 train_time:214416ms step_avg:152.18ms
+step:1410/4150 train_time:214651ms step_avg:152.23ms
+step:1411/4150 train_time:214884ms step_avg:152.29ms
+step:1412/4150 train_time:215119ms step_avg:152.35ms
+step:1413/4150 train_time:215351ms step_avg:152.41ms
+step:1414/4150 train_time:215585ms step_avg:152.46ms
+step:1415/4150 train_time:215815ms step_avg:152.52ms
+step:1416/4150 train_time:216051ms step_avg:152.58ms
+step:1417/4150 train_time:216283ms step_avg:152.63ms
+step:1418/4150 train_time:216518ms step_avg:152.69ms
+step:1419/4150 train_time:216752ms step_avg:152.75ms
+step:1420/4150 train_time:216985ms step_avg:152.81ms
+step:1421/4150 train_time:217217ms step_avg:152.86ms
+step:1422/4150 train_time:217452ms step_avg:152.92ms
+step:1423/4150 train_time:217686ms step_avg:152.98ms
+step:1424/4150 train_time:217920ms step_avg:153.03ms
+step:1425/4150 train_time:218153ms step_avg:153.09ms
+step:1426/4150 train_time:218389ms step_avg:153.15ms
+step:1427/4150 train_time:218622ms step_avg:153.20ms
+step:1428/4150 train_time:218859ms step_avg:153.26ms
+step:1429/4150 train_time:219091ms step_avg:153.32ms
+step:1430/4150 train_time:219324ms step_avg:153.37ms
+step:1431/4150 train_time:219556ms step_avg:153.43ms
+step:1432/4150 train_time:219792ms step_avg:153.49ms
+step:1433/4150 train_time:220024ms step_avg:153.54ms
+step:1434/4150 train_time:220261ms step_avg:153.60ms
+step:1435/4150 train_time:220493ms step_avg:153.65ms
+step:1436/4150 train_time:220727ms step_avg:153.71ms
+step:1437/4150 train_time:220960ms step_avg:153.76ms
+step:1438/4150 train_time:221196ms step_avg:153.82ms
+step:1439/4150 train_time:221428ms step_avg:153.88ms
+step:1440/4150 train_time:221665ms step_avg:153.93ms
+step:1441/4150 train_time:221897ms step_avg:153.99ms
+step:1442/4150 train_time:222131ms step_avg:154.04ms
+step:1443/4150 train_time:222364ms step_avg:154.10ms
+step:1444/4150 train_time:222600ms step_avg:154.16ms
+step:1445/4150 train_time:222833ms step_avg:154.21ms
+step:1446/4150 train_time:223065ms step_avg:154.26ms
+step:1447/4150 train_time:223296ms step_avg:154.32ms
+step:1448/4150 train_time:223533ms step_avg:154.37ms
+step:1449/4150 train_time:223766ms step_avg:154.43ms
+step:1450/4150 train_time:223999ms step_avg:154.48ms
+step:1451/4150 train_time:224231ms step_avg:154.54ms
+step:1452/4150 train_time:224467ms step_avg:154.59ms
+step:1453/4150 train_time:224703ms step_avg:154.65ms
+step:1454/4150 train_time:224941ms step_avg:154.71ms
+step:1455/4150 train_time:225173ms step_avg:154.76ms
+step:1456/4150 train_time:225409ms step_avg:154.81ms
+step:1457/4150 train_time:225646ms step_avg:154.87ms
+step:1458/4150 train_time:225882ms step_avg:154.93ms
+step:1459/4150 train_time:226112ms step_avg:154.98ms
+step:1460/4150 train_time:226346ms step_avg:155.03ms
+step:1461/4150 train_time:226583ms step_avg:155.09ms
+step:1462/4150 train_time:226819ms step_avg:155.14ms
+step:1463/4150 train_time:227051ms step_avg:155.20ms
+step:1464/4150 train_time:227283ms step_avg:155.25ms
+step:1465/4150 train_time:227516ms step_avg:155.30ms
+step:1466/4150 train_time:227752ms step_avg:155.36ms
+step:1467/4150 train_time:227985ms step_avg:155.41ms
+step:1468/4150 train_time:228219ms step_avg:155.46ms
+step:1469/4150 train_time:228451ms step_avg:155.51ms
+step:1470/4150 train_time:228685ms step_avg:155.57ms
+step:1471/4150 train_time:228917ms step_avg:155.62ms
+step:1472/4150 train_time:229151ms step_avg:155.67ms
+step:1473/4150 train_time:229384ms step_avg:155.73ms
+step:1474/4150 train_time:229619ms step_avg:155.78ms
+step:1475/4150 train_time:229853ms step_avg:155.83ms
+step:1476/4150 train_time:230089ms step_avg:155.89ms
+step:1477/4150 train_time:230321ms step_avg:155.94ms
+step:1478/4150 train_time:230558ms step_avg:155.99ms
+step:1479/4150 train_time:230793ms step_avg:156.05ms
+step:1480/4150 train_time:231027ms step_avg:156.10ms
+step:1481/4150 train_time:231262ms step_avg:156.15ms
+step:1482/4150 train_time:231499ms step_avg:156.21ms
+step:1483/4150 train_time:231734ms step_avg:156.26ms
+step:1484/4150 train_time:231970ms step_avg:156.31ms
+step:1485/4150 train_time:232202ms step_avg:156.37ms
+step:1486/4150 train_time:232439ms step_avg:156.42ms
+step:1487/4150 train_time:232671ms step_avg:156.47ms
+step:1488/4150 train_time:232904ms step_avg:156.52ms
+step:1489/4150 train_time:233135ms step_avg:156.57ms
+step:1490/4150 train_time:233371ms step_avg:156.62ms
+step:1491/4150 train_time:233602ms step_avg:156.67ms
+step:1492/4150 train_time:233838ms step_avg:156.73ms
+step:1493/4150 train_time:234068ms step_avg:156.78ms
+step:1494/4150 train_time:234303ms step_avg:156.83ms
+step:1495/4150 train_time:234534ms step_avg:156.88ms
+step:1496/4150 train_time:234772ms step_avg:156.93ms
+step:1497/4150 train_time:235006ms step_avg:156.98ms
+step:1498/4150 train_time:235240ms step_avg:157.04ms
+step:1499/4150 train_time:235472ms step_avg:157.09ms
+step:1500/4150 train_time:235709ms step_avg:157.14ms
+step:1500/4150 val_loss:3.3205 train_time:235923ms step_avg:157.28ms
+step:1501/4150 train_time:235946ms step_avg:157.19ms
+step:1502/4150 train_time:236181ms step_avg:157.24ms
+step:1503/4150 train_time:236416ms step_avg:157.30ms
+step:1504/4150 train_time:236649ms step_avg:157.35ms
+step:1505/4150 train_time:236881ms step_avg:157.40ms
+step:1506/4150 train_time:237117ms step_avg:157.45ms
+step:1507/4150 train_time:237353ms step_avg:157.50ms
+step:1508/4150 train_time:237588ms step_avg:157.55ms
+step:1509/4150 train_time:237818ms step_avg:157.60ms
+step:1510/4150 train_time:238052ms step_avg:157.65ms
+step:1511/4150 train_time:238286ms step_avg:157.70ms
+step:1512/4150 train_time:238523ms step_avg:157.75ms
+step:1513/4150 train_time:238753ms step_avg:157.80ms
+step:1514/4150 train_time:238986ms step_avg:157.85ms
+step:1515/4150 train_time:239219ms step_avg:157.90ms
+step:1516/4150 train_time:239457ms step_avg:157.95ms
+step:1517/4150 train_time:239688ms step_avg:158.00ms
+step:1518/4150 train_time:239920ms step_avg:158.05ms
+step:1519/4150 train_time:240152ms step_avg:158.10ms
+step:1520/4150 train_time:240388ms step_avg:158.15ms
+step:1521/4150 train_time:240621ms step_avg:158.20ms
+step:1522/4150 train_time:240855ms step_avg:158.25ms
+step:1523/4150 train_time:241088ms step_avg:158.30ms
+step:1524/4150 train_time:241324ms step_avg:158.35ms
+step:1525/4150 train_time:241557ms step_avg:158.40ms
+step:1526/4150 train_time:241793ms step_avg:158.45ms
+step:1527/4150 train_time:242024ms step_avg:158.50ms
+step:1528/4150 train_time:242259ms step_avg:158.55ms
+step:1529/4150 train_time:242494ms step_avg:158.60ms
+step:1530/4150 train_time:242728ms step_avg:158.65ms
+step:1531/4150 train_time:242958ms step_avg:158.69ms
+step:1532/4150 train_time:243196ms step_avg:158.74ms
+step:1533/4150 train_time:243430ms step_avg:158.79ms
+step:1534/4150 train_time:243667ms step_avg:158.84ms
+step:1535/4150 train_time:243894ms step_avg:158.89ms
+step:1536/4150 train_time:244130ms step_avg:158.94ms
+step:1537/4150 train_time:244364ms step_avg:158.99ms
+step:1538/4150 train_time:244600ms step_avg:159.04ms
+step:1539/4150 train_time:244831ms step_avg:159.08ms
+step:1540/4150 train_time:245069ms step_avg:159.14ms
+step:1541/4150 train_time:245301ms step_avg:159.18ms
+step:1542/4150 train_time:245534ms step_avg:159.23ms
+step:1543/4150 train_time:245764ms step_avg:159.28ms
+step:1544/4150 train_time:245999ms step_avg:159.33ms
+step:1545/4150 train_time:246232ms step_avg:159.37ms
+step:1546/4150 train_time:246469ms step_avg:159.42ms
+step:1547/4150 train_time:246700ms step_avg:159.47ms
+step:1548/4150 train_time:246934ms step_avg:159.52ms
+step:1549/4150 train_time:247167ms step_avg:159.57ms
+step:1550/4150 train_time:247402ms step_avg:159.61ms
+step:1551/4150 train_time:247634ms step_avg:159.66ms
+step:1552/4150 train_time:247870ms step_avg:159.71ms
+step:1553/4150 train_time:248100ms step_avg:159.76ms
+step:1554/4150 train_time:248333ms step_avg:159.80ms
+step:1555/4150 train_time:248567ms step_avg:159.85ms
+step:1556/4150 train_time:248801ms step_avg:159.90ms
+step:1557/4150 train_time:249036ms step_avg:159.95ms
+step:1558/4150 train_time:249271ms step_avg:159.99ms
+step:1559/4150 train_time:249505ms step_avg:160.04ms
+step:1560/4150 train_time:249740ms step_avg:160.09ms
+step:1561/4150 train_time:249974ms step_avg:160.14ms
+step:1562/4150 train_time:250209ms step_avg:160.18ms
+step:1563/4150 train_time:250441ms step_avg:160.23ms
+step:1564/4150 train_time:250678ms step_avg:160.28ms
+step:1565/4150 train_time:250911ms step_avg:160.33ms
+step:1566/4150 train_time:251148ms step_avg:160.38ms
+step:1567/4150 train_time:251380ms step_avg:160.42ms
+step:1568/4150 train_time:251616ms step_avg:160.47ms
+step:1569/4150 train_time:251846ms step_avg:160.51ms
+step:1570/4150 train_time:252081ms step_avg:160.56ms
+step:1571/4150 train_time:252313ms step_avg:160.61ms
+step:1572/4150 train_time:252549ms step_avg:160.65ms
+step:1573/4150 train_time:252780ms step_avg:160.70ms
+step:1574/4150 train_time:253014ms step_avg:160.75ms
+step:1575/4150 train_time:253246ms step_avg:160.79ms
+step:1576/4150 train_time:253484ms step_avg:160.84ms
+step:1577/4150 train_time:253718ms step_avg:160.89ms
+step:1578/4150 train_time:253953ms step_avg:160.93ms
+step:1579/4150 train_time:254186ms step_avg:160.98ms
+step:1580/4150 train_time:254421ms step_avg:161.03ms
+step:1581/4150 train_time:254655ms step_avg:161.07ms
+step:1582/4150 train_time:254893ms step_avg:161.12ms
+step:1583/4150 train_time:255125ms step_avg:161.17ms
+step:1584/4150 train_time:255358ms step_avg:161.21ms
+step:1585/4150 train_time:255593ms step_avg:161.26ms
+step:1586/4150 train_time:255829ms step_avg:161.30ms
+step:1587/4150 train_time:256059ms step_avg:161.35ms
+step:1588/4150 train_time:256293ms step_avg:161.39ms
+step:1589/4150 train_time:256525ms step_avg:161.44ms
+step:1590/4150 train_time:256760ms step_avg:161.48ms
+step:1591/4150 train_time:256992ms step_avg:161.53ms
+step:1592/4150 train_time:257226ms step_avg:161.57ms
+step:1593/4150 train_time:257457ms step_avg:161.62ms
+step:1594/4150 train_time:257690ms step_avg:161.66ms
+step:1595/4150 train_time:257922ms step_avg:161.71ms
+step:1596/4150 train_time:258158ms step_avg:161.75ms
+step:1597/4150 train_time:258390ms step_avg:161.80ms
+step:1598/4150 train_time:258626ms step_avg:161.84ms
+step:1599/4150 train_time:258856ms step_avg:161.89ms
+step:1600/4150 train_time:259092ms step_avg:161.93ms
+step:1601/4150 train_time:259324ms step_avg:161.98ms
+step:1602/4150 train_time:259560ms step_avg:162.02ms
+step:1603/4150 train_time:259793ms step_avg:162.07ms
+step:1604/4150 train_time:260029ms step_avg:162.11ms
+step:1605/4150 train_time:260258ms step_avg:162.15ms
+step:1606/4150 train_time:260495ms step_avg:162.20ms
+step:1607/4150 train_time:260731ms step_avg:162.25ms
+step:1608/4150 train_time:260963ms step_avg:162.29ms
+step:1609/4150 train_time:261194ms step_avg:162.33ms
+step:1610/4150 train_time:261428ms step_avg:162.38ms
+step:1611/4150 train_time:261660ms step_avg:162.42ms
+step:1612/4150 train_time:261896ms step_avg:162.47ms
+step:1613/4150 train_time:262131ms step_avg:162.51ms
+step:1614/4150 train_time:262366ms step_avg:162.56ms
+step:1615/4150 train_time:262596ms step_avg:162.60ms
+step:1616/4150 train_time:262832ms step_avg:162.64ms
+step:1617/4150 train_time:263063ms step_avg:162.69ms
+step:1618/4150 train_time:263298ms step_avg:162.73ms
+step:1619/4150 train_time:263530ms step_avg:162.77ms
+step:1620/4150 train_time:263763ms step_avg:162.82ms
+step:1621/4150 train_time:263996ms step_avg:162.86ms
+step:1622/4150 train_time:264232ms step_avg:162.91ms
+step:1623/4150 train_time:264466ms step_avg:162.95ms
+step:1624/4150 train_time:264701ms step_avg:162.99ms
+step:1625/4150 train_time:264934ms step_avg:163.04ms
+step:1626/4150 train_time:265170ms step_avg:163.08ms
+step:1627/4150 train_time:265404ms step_avg:163.12ms
+step:1628/4150 train_time:265641ms step_avg:163.17ms
+step:1629/4150 train_time:265871ms step_avg:163.21ms
+step:1630/4150 train_time:266105ms step_avg:163.25ms
+step:1631/4150 train_time:266336ms step_avg:163.30ms
+step:1632/4150 train_time:266572ms step_avg:163.34ms
+step:1633/4150 train_time:266804ms step_avg:163.38ms
+step:1634/4150 train_time:267040ms step_avg:163.43ms
+step:1635/4150 train_time:267273ms step_avg:163.47ms
+step:1636/4150 train_time:267509ms step_avg:163.51ms
+step:1637/4150 train_time:267742ms step_avg:163.56ms
+step:1638/4150 train_time:267977ms step_avg:163.60ms
+step:1639/4150 train_time:268212ms step_avg:163.64ms
+step:1640/4150 train_time:268449ms step_avg:163.69ms
+step:1641/4150 train_time:268683ms step_avg:163.73ms
+step:1642/4150 train_time:268918ms step_avg:163.77ms
+step:1643/4150 train_time:269150ms step_avg:163.82ms
+step:1644/4150 train_time:269385ms step_avg:163.86ms
+step:1645/4150 train_time:269617ms step_avg:163.90ms
+step:1646/4150 train_time:269853ms step_avg:163.94ms
+step:1647/4150 train_time:270085ms step_avg:163.99ms
+step:1648/4150 train_time:270319ms step_avg:164.03ms
+step:1649/4150 train_time:270548ms step_avg:164.07ms
+step:1650/4150 train_time:270784ms step_avg:164.11ms
+step:1651/4150 train_time:271017ms step_avg:164.15ms
+step:1652/4150 train_time:271252ms step_avg:164.20ms
+step:1653/4150 train_time:271482ms step_avg:164.24ms
+step:1654/4150 train_time:271714ms step_avg:164.28ms
+step:1655/4150 train_time:271946ms step_avg:164.32ms
+step:1656/4150 train_time:272182ms step_avg:164.36ms
+step:1657/4150 train_time:272417ms step_avg:164.40ms
+step:1658/4150 train_time:272653ms step_avg:164.45ms
+step:1659/4150 train_time:272887ms step_avg:164.49ms
+step:1660/4150 train_time:273121ms step_avg:164.53ms
+step:1661/4150 train_time:273358ms step_avg:164.57ms
+step:1662/4150 train_time:273594ms step_avg:164.62ms
+step:1663/4150 train_time:273824ms step_avg:164.66ms
+step:1664/4150 train_time:274061ms step_avg:164.70ms
+step:1665/4150 train_time:274293ms step_avg:164.74ms
+step:1666/4150 train_time:274529ms step_avg:164.78ms
+step:1667/4150 train_time:274762ms step_avg:164.82ms
+step:1668/4150 train_time:274995ms step_avg:164.87ms
+step:1669/4150 train_time:275227ms step_avg:164.91ms
+step:1670/4150 train_time:275462ms step_avg:164.95ms
+step:1671/4150 train_time:275694ms step_avg:164.99ms
+step:1672/4150 train_time:275929ms step_avg:165.03ms
+step:1673/4150 train_time:276160ms step_avg:165.07ms
+step:1674/4150 train_time:276397ms step_avg:165.11ms
+step:1675/4150 train_time:276630ms step_avg:165.15ms
+step:1676/4150 train_time:276865ms step_avg:165.19ms
+step:1677/4150 train_time:277095ms step_avg:165.23ms
+step:1678/4150 train_time:277331ms step_avg:165.27ms
+step:1679/4150 train_time:277564ms step_avg:165.32ms
+step:1680/4150 train_time:277799ms step_avg:165.36ms
+step:1681/4150 train_time:278031ms step_avg:165.40ms
+step:1682/4150 train_time:278270ms step_avg:165.44ms
+step:1683/4150 train_time:278503ms step_avg:165.48ms
+step:1684/4150 train_time:278737ms step_avg:165.52ms
+step:1685/4150 train_time:278972ms step_avg:165.56ms
+step:1686/4150 train_time:279208ms step_avg:165.60ms
+step:1687/4150 train_time:279438ms step_avg:165.64ms
+step:1688/4150 train_time:279673ms step_avg:165.68ms
+step:1689/4150 train_time:279905ms step_avg:165.72ms
+step:1690/4150 train_time:280140ms step_avg:165.76ms
+step:1691/4150 train_time:280377ms step_avg:165.81ms
+step:1692/4150 train_time:280611ms step_avg:165.85ms
+step:1693/4150 train_time:280843ms step_avg:165.88ms
+step:1694/4150 train_time:281079ms step_avg:165.93ms
+step:1695/4150 train_time:281311ms step_avg:165.97ms
+step:1696/4150 train_time:281547ms step_avg:166.01ms
+step:1697/4150 train_time:281777ms step_avg:166.04ms
+step:1698/4150 train_time:282014ms step_avg:166.09ms
+step:1699/4150 train_time:282247ms step_avg:166.13ms
+step:1700/4150 train_time:282482ms step_avg:166.17ms
+step:1701/4150 train_time:282715ms step_avg:166.21ms
+step:1702/4150 train_time:282954ms step_avg:166.25ms
+step:1703/4150 train_time:283187ms step_avg:166.29ms
+step:1704/4150 train_time:283420ms step_avg:166.33ms
+step:1705/4150 train_time:283652ms step_avg:166.36ms
+step:1706/4150 train_time:283888ms step_avg:166.41ms
+step:1707/4150 train_time:284119ms step_avg:166.44ms
+step:1708/4150 train_time:284354ms step_avg:166.48ms
+step:1709/4150 train_time:284584ms step_avg:166.52ms
+step:1710/4150 train_time:284819ms step_avg:166.56ms
+step:1711/4150 train_time:285050ms step_avg:166.60ms
+step:1712/4150 train_time:285285ms step_avg:166.64ms
+step:1713/4150 train_time:285517ms step_avg:166.68ms
+step:1714/4150 train_time:285753ms step_avg:166.72ms
+step:1715/4150 train_time:285984ms step_avg:166.75ms
+step:1716/4150 train_time:286218ms step_avg:166.79ms
+step:1717/4150 train_time:286451ms step_avg:166.83ms
+step:1718/4150 train_time:286687ms step_avg:166.87ms
+step:1719/4150 train_time:286919ms step_avg:166.91ms
+step:1720/4150 train_time:287156ms step_avg:166.95ms
+step:1721/4150 train_time:287394ms step_avg:166.99ms
+step:1722/4150 train_time:287630ms step_avg:167.03ms
+step:1723/4150 train_time:287862ms step_avg:167.07ms
+step:1724/4150 train_time:288099ms step_avg:167.11ms
+step:1725/4150 train_time:288335ms step_avg:167.15ms
+step:1726/4150 train_time:288573ms step_avg:167.19ms
+step:1727/4150 train_time:288805ms step_avg:167.23ms
+step:1728/4150 train_time:289041ms step_avg:167.27ms
+step:1729/4150 train_time:289274ms step_avg:167.31ms
+step:1730/4150 train_time:289511ms step_avg:167.35ms
+step:1731/4150 train_time:289744ms step_avg:167.39ms
+step:1732/4150 train_time:289978ms step_avg:167.42ms
+step:1733/4150 train_time:290211ms step_avg:167.46ms
+step:1734/4150 train_time:290446ms step_avg:167.50ms
+step:1735/4150 train_time:290679ms step_avg:167.54ms
+step:1736/4150 train_time:290915ms step_avg:167.58ms
+step:1737/4150 train_time:291148ms step_avg:167.62ms
+step:1738/4150 train_time:291384ms step_avg:167.65ms
+step:1739/4150 train_time:291618ms step_avg:167.69ms
+step:1740/4150 train_time:291852ms step_avg:167.73ms
+step:1741/4150 train_time:292083ms step_avg:167.77ms
+step:1742/4150 train_time:292320ms step_avg:167.81ms
+step:1743/4150 train_time:292552ms step_avg:167.84ms
+step:1744/4150 train_time:292789ms step_avg:167.88ms
+step:1745/4150 train_time:293022ms step_avg:167.92ms
+step:1746/4150 train_time:293258ms step_avg:167.96ms
+step:1747/4150 train_time:293492ms step_avg:168.00ms
+step:1748/4150 train_time:293730ms step_avg:168.04ms
+step:1749/4150 train_time:293962ms step_avg:168.07ms
+step:1750/4150 train_time:294199ms step_avg:168.11ms
+step:1750/4150 val_loss:3.2309 train_time:294414ms step_avg:168.24ms
+step:1751/4150 train_time:294437ms step_avg:168.15ms
+step:1752/4150 train_time:294677ms step_avg:168.19ms
+step:1753/4150 train_time:294909ms step_avg:168.23ms
+step:1754/4150 train_time:295140ms step_avg:168.27ms
+step:1755/4150 train_time:295370ms step_avg:168.30ms
+step:1756/4150 train_time:295607ms step_avg:168.34ms
+step:1757/4150 train_time:295847ms step_avg:168.38ms
+step:1758/4150 train_time:296081ms step_avg:168.42ms
+step:1759/4150 train_time:296313ms step_avg:168.46ms
+step:1760/4150 train_time:296549ms step_avg:168.49ms
+step:1761/4150 train_time:296784ms step_avg:168.53ms
+step:1762/4150 train_time:297018ms step_avg:168.57ms
+step:1763/4150 train_time:297249ms step_avg:168.60ms
+step:1764/4150 train_time:297485ms step_avg:168.64ms
+step:1765/4150 train_time:297719ms step_avg:168.68ms
+step:1766/4150 train_time:297957ms step_avg:168.72ms
+step:1767/4150 train_time:298189ms step_avg:168.75ms
+step:1768/4150 train_time:298423ms step_avg:168.79ms
+step:1769/4150 train_time:298658ms step_avg:168.83ms
+step:1770/4150 train_time:298899ms step_avg:168.87ms
+step:1771/4150 train_time:299130ms step_avg:168.90ms
+step:1772/4150 train_time:299365ms step_avg:168.94ms
+step:1773/4150 train_time:299599ms step_avg:168.98ms
+step:1774/4150 train_time:299838ms step_avg:169.02ms
+step:1775/4150 train_time:300069ms step_avg:169.05ms
+step:1776/4150 train_time:300304ms step_avg:169.09ms
+step:1777/4150 train_time:300537ms step_avg:169.13ms
+step:1778/4150 train_time:300771ms step_avg:169.16ms
+step:1779/4150 train_time:301003ms step_avg:169.20ms
+step:1780/4150 train_time:301241ms step_avg:169.24ms
+step:1781/4150 train_time:301473ms step_avg:169.27ms
+step:1782/4150 train_time:301709ms step_avg:169.31ms
+step:1783/4150 train_time:301941ms step_avg:169.34ms
+step:1784/4150 train_time:302180ms step_avg:169.38ms
+step:1785/4150 train_time:302410ms step_avg:169.42ms
+step:1786/4150 train_time:302647ms step_avg:169.45ms
+step:1787/4150 train_time:302881ms step_avg:169.49ms
+step:1788/4150 train_time:303119ms step_avg:169.53ms
+step:1789/4150 train_time:303351ms step_avg:169.56ms
+step:1790/4150 train_time:303587ms step_avg:169.60ms
+step:1791/4150 train_time:303822ms step_avg:169.64ms
+step:1792/4150 train_time:304060ms step_avg:169.68ms
+step:1793/4150 train_time:304294ms step_avg:169.71ms
+step:1794/4150 train_time:304529ms step_avg:169.75ms
+step:1795/4150 train_time:304764ms step_avg:169.78ms
+step:1796/4150 train_time:305002ms step_avg:169.82ms
+step:1797/4150 train_time:305236ms step_avg:169.86ms
+step:1798/4150 train_time:305472ms step_avg:169.90ms
+step:1799/4150 train_time:305706ms step_avg:169.93ms
+step:1800/4150 train_time:305945ms step_avg:169.97ms
+step:1801/4150 train_time:306179ms step_avg:170.01ms
+step:1802/4150 train_time:306419ms step_avg:170.04ms
+step:1803/4150 train_time:306649ms step_avg:170.08ms
+step:1804/4150 train_time:306884ms step_avg:170.11ms
+step:1805/4150 train_time:307118ms step_avg:170.15ms
+step:1806/4150 train_time:307355ms step_avg:170.19ms
+step:1807/4150 train_time:307585ms step_avg:170.22ms
+step:1808/4150 train_time:307820ms step_avg:170.25ms
+step:1809/4150 train_time:308053ms step_avg:170.29ms
+step:1810/4150 train_time:308288ms step_avg:170.32ms
+step:1811/4150 train_time:308524ms step_avg:170.36ms
+step:1812/4150 train_time:308760ms step_avg:170.40ms
+step:1813/4150 train_time:308992ms step_avg:170.43ms
+step:1814/4150 train_time:309228ms step_avg:170.47ms
+step:1815/4150 train_time:309464ms step_avg:170.50ms
+step:1816/4150 train_time:309698ms step_avg:170.54ms
+step:1817/4150 train_time:309930ms step_avg:170.57ms
+step:1818/4150 train_time:310165ms step_avg:170.61ms
+step:1819/4150 train_time:310401ms step_avg:170.64ms
+step:1820/4150 train_time:310638ms step_avg:170.68ms
+step:1821/4150 train_time:310870ms step_avg:170.71ms
+step:1822/4150 train_time:311105ms step_avg:170.75ms
+step:1823/4150 train_time:311341ms step_avg:170.78ms
+step:1824/4150 train_time:311582ms step_avg:170.82ms
+step:1825/4150 train_time:311816ms step_avg:170.86ms
+step:1826/4150 train_time:312053ms step_avg:170.89ms
+step:1827/4150 train_time:312286ms step_avg:170.93ms
+step:1828/4150 train_time:312521ms step_avg:170.96ms
+step:1829/4150 train_time:312754ms step_avg:171.00ms
+step:1830/4150 train_time:312989ms step_avg:171.03ms
+step:1831/4150 train_time:313222ms step_avg:171.07ms
+step:1832/4150 train_time:313458ms step_avg:171.10ms
+step:1833/4150 train_time:313690ms step_avg:171.13ms
+step:1834/4150 train_time:313927ms step_avg:171.17ms
+step:1835/4150 train_time:314161ms step_avg:171.20ms
+step:1836/4150 train_time:314397ms step_avg:171.24ms
+step:1837/4150 train_time:314630ms step_avg:171.27ms
+step:1838/4150 train_time:314868ms step_avg:171.31ms
+step:1839/4150 train_time:315102ms step_avg:171.34ms
+step:1840/4150 train_time:315337ms step_avg:171.38ms
+step:1841/4150 train_time:315571ms step_avg:171.41ms
+step:1842/4150 train_time:315806ms step_avg:171.45ms
+step:1843/4150 train_time:316040ms step_avg:171.48ms
+step:1844/4150 train_time:316276ms step_avg:171.52ms
+step:1845/4150 train_time:316508ms step_avg:171.55ms
+step:1846/4150 train_time:316747ms step_avg:171.59ms
+step:1847/4150 train_time:316981ms step_avg:171.62ms
+step:1848/4150 train_time:317217ms step_avg:171.65ms
+step:1849/4150 train_time:317451ms step_avg:171.69ms
+step:1850/4150 train_time:317687ms step_avg:171.72ms
+step:1851/4150 train_time:317919ms step_avg:171.76ms
+step:1852/4150 train_time:318155ms step_avg:171.79ms
+step:1853/4150 train_time:318388ms step_avg:171.82ms
+step:1854/4150 train_time:318625ms step_avg:171.86ms
+step:1855/4150 train_time:318861ms step_avg:171.89ms
+step:1856/4150 train_time:319100ms step_avg:171.93ms
+step:1857/4150 train_time:319334ms step_avg:171.96ms
+step:1858/4150 train_time:319569ms step_avg:172.00ms
+step:1859/4150 train_time:319801ms step_avg:172.03ms
+step:1860/4150 train_time:320037ms step_avg:172.06ms
+step:1861/4150 train_time:320272ms step_avg:172.10ms
+step:1862/4150 train_time:320508ms step_avg:172.13ms
+step:1863/4150 train_time:320742ms step_avg:172.16ms
+step:1864/4150 train_time:320980ms step_avg:172.20ms
+step:1865/4150 train_time:321214ms step_avg:172.23ms
+step:1866/4150 train_time:321452ms step_avg:172.27ms
+step:1867/4150 train_time:321684ms step_avg:172.30ms
+step:1868/4150 train_time:321920ms step_avg:172.33ms
+step:1869/4150 train_time:322152ms step_avg:172.37ms
+step:1870/4150 train_time:322387ms step_avg:172.40ms
+step:1871/4150 train_time:322619ms step_avg:172.43ms
+step:1872/4150 train_time:322855ms step_avg:172.47ms
+step:1873/4150 train_time:323088ms step_avg:172.50ms
+step:1874/4150 train_time:323323ms step_avg:172.53ms
+step:1875/4150 train_time:323555ms step_avg:172.56ms
+step:1876/4150 train_time:323790ms step_avg:172.60ms
+step:1877/4150 train_time:324024ms step_avg:172.63ms
+step:1878/4150 train_time:324263ms step_avg:172.66ms
+step:1879/4150 train_time:324496ms step_avg:172.70ms
+step:1880/4150 train_time:324730ms step_avg:172.73ms
+step:1881/4150 train_time:324962ms step_avg:172.76ms
+step:1882/4150 train_time:325202ms step_avg:172.80ms
+step:1883/4150 train_time:325436ms step_avg:172.83ms
+step:1884/4150 train_time:325675ms step_avg:172.86ms
+step:1885/4150 train_time:325908ms step_avg:172.90ms
+step:1886/4150 train_time:326142ms step_avg:172.93ms
+step:1887/4150 train_time:326378ms step_avg:172.96ms
+step:1888/4150 train_time:326614ms step_avg:172.99ms
+step:1889/4150 train_time:326846ms step_avg:173.03ms
+step:1890/4150 train_time:327079ms step_avg:173.06ms
+step:1891/4150 train_time:327314ms step_avg:173.09ms
+step:1892/4150 train_time:327550ms step_avg:173.12ms
+step:1893/4150 train_time:327783ms step_avg:173.16ms
+step:1894/4150 train_time:328019ms step_avg:173.19ms
+step:1895/4150 train_time:328251ms step_avg:173.22ms
+step:1896/4150 train_time:328486ms step_avg:173.25ms
+step:1897/4150 train_time:328721ms step_avg:173.28ms
+step:1898/4150 train_time:328957ms step_avg:173.32ms
+step:1899/4150 train_time:329189ms step_avg:173.35ms
+step:1900/4150 train_time:329425ms step_avg:173.38ms
+step:1901/4150 train_time:329661ms step_avg:173.41ms
+step:1902/4150 train_time:329900ms step_avg:173.45ms
+step:1903/4150 train_time:330132ms step_avg:173.48ms
+step:1904/4150 train_time:330365ms step_avg:173.51ms
+step:1905/4150 train_time:330598ms step_avg:173.54ms
+step:1906/4150 train_time:330836ms step_avg:173.58ms
+step:1907/4150 train_time:331070ms step_avg:173.61ms
+step:1908/4150 train_time:331304ms step_avg:173.64ms
+step:1909/4150 train_time:331537ms step_avg:173.67ms
+step:1910/4150 train_time:331773ms step_avg:173.70ms
+step:1911/4150 train_time:332005ms step_avg:173.73ms
+step:1912/4150 train_time:332241ms step_avg:173.77ms
+step:1913/4150 train_time:332474ms step_avg:173.80ms
+step:1914/4150 train_time:332709ms step_avg:173.83ms
+step:1915/4150 train_time:332942ms step_avg:173.86ms
+step:1916/4150 train_time:333178ms step_avg:173.89ms
+step:1917/4150 train_time:333410ms step_avg:173.92ms
+step:1918/4150 train_time:333646ms step_avg:173.96ms
+step:1919/4150 train_time:333882ms step_avg:173.99ms
+step:1920/4150 train_time:334119ms step_avg:174.02ms
+step:1921/4150 train_time:334354ms step_avg:174.05ms
+step:1922/4150 train_time:334588ms step_avg:174.08ms
+step:1923/4150 train_time:334820ms step_avg:174.11ms
+step:1924/4150 train_time:335058ms step_avg:174.15ms
+step:1925/4150 train_time:335291ms step_avg:174.18ms
+step:1926/4150 train_time:335526ms step_avg:174.21ms
+step:1927/4150 train_time:335757ms step_avg:174.24ms
+step:1928/4150 train_time:335995ms step_avg:174.27ms
+step:1929/4150 train_time:336227ms step_avg:174.30ms
+step:1930/4150 train_time:336465ms step_avg:174.33ms
+step:1931/4150 train_time:336700ms step_avg:174.37ms
+step:1932/4150 train_time:336935ms step_avg:174.40ms
+step:1933/4150 train_time:337166ms step_avg:174.43ms
+step:1934/4150 train_time:337402ms step_avg:174.46ms
+step:1935/4150 train_time:337635ms step_avg:174.49ms
+step:1936/4150 train_time:337872ms step_avg:174.52ms
+step:1937/4150 train_time:338105ms step_avg:174.55ms
+step:1938/4150 train_time:338338ms step_avg:174.58ms
+step:1939/4150 train_time:338570ms step_avg:174.61ms
+step:1940/4150 train_time:338805ms step_avg:174.64ms
+step:1941/4150 train_time:339036ms step_avg:174.67ms
+step:1942/4150 train_time:339275ms step_avg:174.70ms
+step:1943/4150 train_time:339506ms step_avg:174.73ms
+step:1944/4150 train_time:339741ms step_avg:174.76ms
+step:1945/4150 train_time:339974ms step_avg:174.79ms
+step:1946/4150 train_time:340208ms step_avg:174.82ms
+step:1947/4150 train_time:340439ms step_avg:174.85ms
+step:1948/4150 train_time:340676ms step_avg:174.89ms
+step:1949/4150 train_time:340911ms step_avg:174.92ms
+step:1950/4150 train_time:341145ms step_avg:174.95ms
+step:1951/4150 train_time:341379ms step_avg:174.98ms
+step:1952/4150 train_time:341615ms step_avg:175.01ms
+step:1953/4150 train_time:341850ms step_avg:175.04ms
+step:1954/4150 train_time:342085ms step_avg:175.07ms
+step:1955/4150 train_time:342316ms step_avg:175.10ms
+step:1956/4150 train_time:342551ms step_avg:175.13ms
+step:1957/4150 train_time:342783ms step_avg:175.16ms
+step:1958/4150 train_time:343020ms step_avg:175.19ms
+step:1959/4150 train_time:343251ms step_avg:175.22ms
+step:1960/4150 train_time:343487ms step_avg:175.25ms
+step:1961/4150 train_time:343721ms step_avg:175.28ms
+step:1962/4150 train_time:343960ms step_avg:175.31ms
+step:1963/4150 train_time:344193ms step_avg:175.34ms
+step:1964/4150 train_time:344430ms step_avg:175.37ms
+step:1965/4150 train_time:344664ms step_avg:175.40ms
+step:1966/4150 train_time:344901ms step_avg:175.43ms
+step:1967/4150 train_time:345134ms step_avg:175.46ms
+step:1968/4150 train_time:345371ms step_avg:175.49ms
+step:1969/4150 train_time:345603ms step_avg:175.52ms
+step:1970/4150 train_time:345843ms step_avg:175.55ms
+step:1971/4150 train_time:346077ms step_avg:175.58ms
+step:1972/4150 train_time:346311ms step_avg:175.61ms
+step:1973/4150 train_time:346544ms step_avg:175.64ms
+step:1974/4150 train_time:346779ms step_avg:175.67ms
+step:1975/4150 train_time:347013ms step_avg:175.70ms
+step:1976/4150 train_time:347246ms step_avg:175.73ms
+step:1977/4150 train_time:347479ms step_avg:175.76ms
+step:1978/4150 train_time:347716ms step_avg:175.79ms
+step:1979/4150 train_time:347949ms step_avg:175.82ms
+step:1980/4150 train_time:348186ms step_avg:175.85ms
+step:1981/4150 train_time:348419ms step_avg:175.88ms
+step:1982/4150 train_time:348655ms step_avg:175.91ms
+step:1983/4150 train_time:348887ms step_avg:175.94ms
+step:1984/4150 train_time:349120ms step_avg:175.97ms
+step:1985/4150 train_time:349351ms step_avg:176.00ms
+step:1986/4150 train_time:349587ms step_avg:176.03ms
+step:1987/4150 train_time:349819ms step_avg:176.05ms
+step:1988/4150 train_time:350057ms step_avg:176.09ms
+step:1989/4150 train_time:350291ms step_avg:176.11ms
+step:1990/4150 train_time:350526ms step_avg:176.14ms
+step:1991/4150 train_time:350757ms step_avg:176.17ms
+step:1992/4150 train_time:350997ms step_avg:176.20ms
+step:1993/4150 train_time:351231ms step_avg:176.23ms
+step:1994/4150 train_time:351466ms step_avg:176.26ms
+step:1995/4150 train_time:351698ms step_avg:176.29ms
+step:1996/4150 train_time:351934ms step_avg:176.32ms
+step:1997/4150 train_time:352165ms step_avg:176.35ms
+step:1998/4150 train_time:352401ms step_avg:176.38ms
+step:1999/4150 train_time:352634ms step_avg:176.41ms
+step:2000/4150 train_time:352868ms step_avg:176.43ms
+step:2000/4150 val_loss:3.1829 train_time:353083ms step_avg:176.54ms
+step:2001/4150 train_time:353106ms step_avg:176.46ms
+step:2002/4150 train_time:353344ms step_avg:176.50ms
+step:2003/4150 train_time:353578ms step_avg:176.52ms
+step:2004/4150 train_time:353812ms step_avg:176.55ms
+step:2005/4150 train_time:354043ms step_avg:176.58ms
+step:2006/4150 train_time:354282ms step_avg:176.61ms
+step:2007/4150 train_time:354517ms step_avg:176.64ms
+step:2008/4150 train_time:354751ms step_avg:176.67ms
+step:2009/4150 train_time:354984ms step_avg:176.70ms
+step:2010/4150 train_time:355219ms step_avg:176.73ms
+step:2011/4150 train_time:355453ms step_avg:176.75ms
+step:2012/4150 train_time:355688ms step_avg:176.78ms
+step:2013/4150 train_time:355918ms step_avg:176.81ms
+step:2014/4150 train_time:356152ms step_avg:176.84ms
+step:2015/4150 train_time:356387ms step_avg:176.87ms
+step:2016/4150 train_time:356624ms step_avg:176.90ms
+step:2017/4150 train_time:356857ms step_avg:176.92ms
+step:2018/4150 train_time:357092ms step_avg:176.95ms
+step:2019/4150 train_time:357325ms step_avg:176.98ms
+step:2020/4150 train_time:357564ms step_avg:177.01ms
+step:2021/4150 train_time:357796ms step_avg:177.04ms
+step:2022/4150 train_time:358031ms step_avg:177.07ms
+step:2023/4150 train_time:358264ms step_avg:177.10ms
+step:2024/4150 train_time:358503ms step_avg:177.13ms
+step:2025/4150 train_time:358736ms step_avg:177.15ms
+step:2026/4150 train_time:358971ms step_avg:177.18ms
+step:2027/4150 train_time:359205ms step_avg:177.21ms
+step:2028/4150 train_time:359442ms step_avg:177.24ms
+step:2029/4150 train_time:359676ms step_avg:177.27ms
+step:2030/4150 train_time:359909ms step_avg:177.30ms
+step:2031/4150 train_time:360144ms step_avg:177.32ms
+step:2032/4150 train_time:360381ms step_avg:177.35ms
+step:2033/4150 train_time:360613ms step_avg:177.38ms
+step:2034/4150 train_time:360851ms step_avg:177.41ms
+step:2035/4150 train_time:361084ms step_avg:177.44ms
+step:2036/4150 train_time:361319ms step_avg:177.47ms
+step:2037/4150 train_time:361550ms step_avg:177.49ms
+step:2038/4150 train_time:361786ms step_avg:177.52ms
+step:2039/4150 train_time:362018ms step_avg:177.55ms
+step:2040/4150 train_time:362254ms step_avg:177.58ms
+step:2041/4150 train_time:362487ms step_avg:177.60ms
+step:2042/4150 train_time:362723ms step_avg:177.63ms
+step:2043/4150 train_time:362953ms step_avg:177.66ms
+step:2044/4150 train_time:363190ms step_avg:177.69ms
+step:2045/4150 train_time:363425ms step_avg:177.71ms
+step:2046/4150 train_time:363660ms step_avg:177.74ms
+step:2047/4150 train_time:363891ms step_avg:177.77ms
+step:2048/4150 train_time:364126ms step_avg:177.80ms
+step:2049/4150 train_time:364359ms step_avg:177.82ms
+step:2050/4150 train_time:364595ms step_avg:177.85ms
+step:2051/4150 train_time:364829ms step_avg:177.88ms
+step:2052/4150 train_time:365067ms step_avg:177.91ms
+step:2053/4150 train_time:365300ms step_avg:177.93ms
+step:2054/4150 train_time:365537ms step_avg:177.96ms
+step:2055/4150 train_time:365769ms step_avg:177.99ms
+step:2056/4150 train_time:366004ms step_avg:178.02ms
+step:2057/4150 train_time:366237ms step_avg:178.04ms
+step:2058/4150 train_time:366474ms step_avg:178.07ms
+step:2059/4150 train_time:366706ms step_avg:178.10ms
+step:2060/4150 train_time:366944ms step_avg:178.13ms
+step:2061/4150 train_time:367178ms step_avg:178.16ms
+step:2062/4150 train_time:367413ms step_avg:178.18ms
+step:2063/4150 train_time:367646ms step_avg:178.21ms
+step:2064/4150 train_time:367882ms step_avg:178.24ms
+step:2065/4150 train_time:368115ms step_avg:178.26ms
+step:2066/4150 train_time:368352ms step_avg:178.29ms
+step:2067/4150 train_time:368585ms step_avg:178.32ms
+step:2068/4150 train_time:368821ms step_avg:178.35ms
+step:2069/4150 train_time:369055ms step_avg:178.37ms
+step:2070/4150 train_time:369291ms step_avg:178.40ms
+step:2071/4150 train_time:369524ms step_avg:178.43ms
+step:2072/4150 train_time:369762ms step_avg:178.46ms
+step:2073/4150 train_time:369995ms step_avg:178.48ms
+step:2074/4150 train_time:370233ms step_avg:178.51ms
+step:2075/4150 train_time:370466ms step_avg:178.54ms
+step:2076/4150 train_time:370703ms step_avg:178.57ms
+step:2077/4150 train_time:370938ms step_avg:178.59ms
+step:2078/4150 train_time:371173ms step_avg:178.62ms
+step:2079/4150 train_time:371407ms step_avg:178.65ms
+step:2080/4150 train_time:371643ms step_avg:178.67ms
+step:2081/4150 train_time:371875ms step_avg:178.70ms
+step:2082/4150 train_time:372110ms step_avg:178.73ms
+step:2083/4150 train_time:372344ms step_avg:178.75ms
+step:2084/4150 train_time:372581ms step_avg:178.78ms
+step:2085/4150 train_time:372816ms step_avg:178.81ms
+step:2086/4150 train_time:373051ms step_avg:178.84ms
+step:2087/4150 train_time:373283ms step_avg:178.86ms
+step:2088/4150 train_time:373519ms step_avg:178.89ms
+step:2089/4150 train_time:373750ms step_avg:178.91ms
+step:2090/4150 train_time:373986ms step_avg:178.94ms
+step:2091/4150 train_time:374219ms step_avg:178.97ms
+step:2092/4150 train_time:374459ms step_avg:179.00ms
+step:2093/4150 train_time:374692ms step_avg:179.02ms
+step:2094/4150 train_time:374929ms step_avg:179.05ms
+step:2095/4150 train_time:375161ms step_avg:179.07ms
+step:2096/4150 train_time:375399ms step_avg:179.10ms
+step:2097/4150 train_time:375630ms step_avg:179.13ms
+step:2098/4150 train_time:375867ms step_avg:179.15ms
+step:2099/4150 train_time:376100ms step_avg:179.18ms
+step:2100/4150 train_time:376337ms step_avg:179.21ms
+step:2101/4150 train_time:376570ms step_avg:179.23ms
+step:2102/4150 train_time:376807ms step_avg:179.26ms
+step:2103/4150 train_time:377040ms step_avg:179.29ms
+step:2104/4150 train_time:377277ms step_avg:179.31ms
+step:2105/4150 train_time:377512ms step_avg:179.34ms
+step:2106/4150 train_time:377751ms step_avg:179.37ms
+step:2107/4150 train_time:377984ms step_avg:179.39ms
+step:2108/4150 train_time:378222ms step_avg:179.42ms
+step:2109/4150 train_time:378456ms step_avg:179.45ms
+step:2110/4150 train_time:378694ms step_avg:179.48ms
+step:2111/4150 train_time:378927ms step_avg:179.50ms
+step:2112/4150 train_time:379169ms step_avg:179.53ms
+step:2113/4150 train_time:379400ms step_avg:179.56ms
+step:2114/4150 train_time:379637ms step_avg:179.58ms
+step:2115/4150 train_time:379869ms step_avg:179.61ms
+step:2116/4150 train_time:380107ms step_avg:179.63ms
+step:2117/4150 train_time:380340ms step_avg:179.66ms
+step:2118/4150 train_time:380576ms step_avg:179.69ms
+step:2119/4150 train_time:380812ms step_avg:179.71ms
+step:2120/4150 train_time:381045ms step_avg:179.74ms
+step:2121/4150 train_time:381278ms step_avg:179.76ms
+step:2122/4150 train_time:381515ms step_avg:179.79ms
+step:2123/4150 train_time:381748ms step_avg:179.82ms
+step:2124/4150 train_time:381985ms step_avg:179.84ms
+step:2125/4150 train_time:382219ms step_avg:179.87ms
+step:2126/4150 train_time:382455ms step_avg:179.89ms
+step:2127/4150 train_time:382692ms step_avg:179.92ms
+step:2128/4150 train_time:382928ms step_avg:179.95ms
+step:2129/4150 train_time:383160ms step_avg:179.97ms
+step:2130/4150 train_time:383396ms step_avg:180.00ms
+step:2131/4150 train_time:383630ms step_avg:180.02ms
+step:2132/4150 train_time:383867ms step_avg:180.05ms
+step:2133/4150 train_time:384100ms step_avg:180.08ms
+step:2134/4150 train_time:384337ms step_avg:180.10ms
+step:2135/4150 train_time:384574ms step_avg:180.13ms
+step:2136/4150 train_time:384809ms step_avg:180.15ms
+step:2137/4150 train_time:385043ms step_avg:180.18ms
+step:2138/4150 train_time:385280ms step_avg:180.21ms
+step:2139/4150 train_time:385512ms step_avg:180.23ms
+step:2140/4150 train_time:385748ms step_avg:180.26ms
+step:2141/4150 train_time:385984ms step_avg:180.28ms
+step:2142/4150 train_time:386219ms step_avg:180.31ms
+step:2143/4150 train_time:386450ms step_avg:180.33ms
+step:2144/4150 train_time:386686ms step_avg:180.36ms
+step:2145/4150 train_time:386919ms step_avg:180.38ms
+step:2146/4150 train_time:387157ms step_avg:180.41ms
+step:2147/4150 train_time:387390ms step_avg:180.43ms
+step:2148/4150 train_time:387628ms step_avg:180.46ms
+step:2149/4150 train_time:387862ms step_avg:180.48ms
+step:2150/4150 train_time:388100ms step_avg:180.51ms
+step:2151/4150 train_time:388333ms step_avg:180.54ms
+step:2152/4150 train_time:388568ms step_avg:180.56ms
+step:2153/4150 train_time:388804ms step_avg:180.59ms
+step:2154/4150 train_time:389041ms step_avg:180.61ms
+step:2155/4150 train_time:389273ms step_avg:180.64ms
+step:2156/4150 train_time:389507ms step_avg:180.66ms
+step:2157/4150 train_time:389741ms step_avg:180.69ms
+step:2158/4150 train_time:389980ms step_avg:180.71ms
+step:2159/4150 train_time:390212ms step_avg:180.74ms
+step:2160/4150 train_time:390450ms step_avg:180.76ms
+step:2161/4150 train_time:390686ms step_avg:180.79ms
+step:2162/4150 train_time:390923ms step_avg:180.82ms
+step:2163/4150 train_time:391154ms step_avg:180.84ms
+step:2164/4150 train_time:391388ms step_avg:180.86ms
+step:2165/4150 train_time:391622ms step_avg:180.89ms
+step:2166/4150 train_time:391857ms step_avg:180.91ms
+step:2167/4150 train_time:392089ms step_avg:180.94ms
+step:2168/4150 train_time:392324ms step_avg:180.96ms
+step:2169/4150 train_time:392559ms step_avg:180.99ms
+step:2170/4150 train_time:392796ms step_avg:181.01ms
+step:2171/4150 train_time:393034ms step_avg:181.04ms
+step:2172/4150 train_time:393271ms step_avg:181.06ms
+step:2173/4150 train_time:393508ms step_avg:181.09ms
+step:2174/4150 train_time:393748ms step_avg:181.12ms
+step:2175/4150 train_time:393983ms step_avg:181.14ms
+step:2176/4150 train_time:394217ms step_avg:181.17ms
+step:2177/4150 train_time:394449ms step_avg:181.19ms
+step:2178/4150 train_time:394687ms step_avg:181.22ms
+step:2179/4150 train_time:394918ms step_avg:181.24ms
+step:2180/4150 train_time:395156ms step_avg:181.26ms
+step:2181/4150 train_time:395388ms step_avg:181.29ms
+step:2182/4150 train_time:395627ms step_avg:181.31ms
+step:2183/4150 train_time:395858ms step_avg:181.34ms
+step:2184/4150 train_time:396097ms step_avg:181.36ms
+step:2185/4150 train_time:396328ms step_avg:181.39ms
+step:2186/4150 train_time:396564ms step_avg:181.41ms
+step:2187/4150 train_time:396796ms step_avg:181.43ms
+step:2188/4150 train_time:397034ms step_avg:181.46ms
+step:2189/4150 train_time:397265ms step_avg:181.48ms
+step:2190/4150 train_time:397501ms step_avg:181.51ms
+step:2191/4150 train_time:397735ms step_avg:181.53ms
+step:2192/4150 train_time:397975ms step_avg:181.56ms
+step:2193/4150 train_time:398212ms step_avg:181.58ms
+step:2194/4150 train_time:398449ms step_avg:181.61ms
+step:2195/4150 train_time:398683ms step_avg:181.63ms
+step:2196/4150 train_time:398918ms step_avg:181.66ms
+step:2197/4150 train_time:399153ms step_avg:181.68ms
+step:2198/4150 train_time:399388ms step_avg:181.71ms
+step:2199/4150 train_time:399621ms step_avg:181.73ms
+step:2200/4150 train_time:399855ms step_avg:181.75ms
+step:2201/4150 train_time:400089ms step_avg:181.78ms
+step:2202/4150 train_time:400327ms step_avg:181.80ms
+step:2203/4150 train_time:400558ms step_avg:181.82ms
+step:2204/4150 train_time:400793ms step_avg:181.85ms
+step:2205/4150 train_time:401026ms step_avg:181.87ms
+step:2206/4150 train_time:401267ms step_avg:181.90ms
+step:2207/4150 train_time:401500ms step_avg:181.92ms
+step:2208/4150 train_time:401734ms step_avg:181.94ms
+step:2209/4150 train_time:401967ms step_avg:181.97ms
+step:2210/4150 train_time:402204ms step_avg:181.99ms
+step:2211/4150 train_time:402438ms step_avg:182.02ms
+step:2212/4150 train_time:402674ms step_avg:182.04ms
+step:2213/4150 train_time:402908ms step_avg:182.06ms
+step:2214/4150 train_time:403144ms step_avg:182.09ms
+step:2215/4150 train_time:403379ms step_avg:182.11ms
+step:2216/4150 train_time:403613ms step_avg:182.14ms
+step:2217/4150 train_time:403845ms step_avg:182.16ms
+step:2218/4150 train_time:404083ms step_avg:182.18ms
+step:2219/4150 train_time:404317ms step_avg:182.21ms
+step:2220/4150 train_time:404554ms step_avg:182.23ms
+step:2221/4150 train_time:404790ms step_avg:182.26ms
+step:2222/4150 train_time:405026ms step_avg:182.28ms
+step:2223/4150 train_time:405261ms step_avg:182.30ms
+step:2224/4150 train_time:405498ms step_avg:182.33ms
+step:2225/4150 train_time:405731ms step_avg:182.35ms
+step:2226/4150 train_time:405968ms step_avg:182.38ms
+step:2227/4150 train_time:406201ms step_avg:182.40ms
+step:2228/4150 train_time:406435ms step_avg:182.42ms
+step:2229/4150 train_time:406668ms step_avg:182.44ms
+step:2230/4150 train_time:406904ms step_avg:182.47ms
+step:2231/4150 train_time:407137ms step_avg:182.49ms
+step:2232/4150 train_time:407375ms step_avg:182.52ms
+step:2233/4150 train_time:407610ms step_avg:182.54ms
+step:2234/4150 train_time:407847ms step_avg:182.56ms
+step:2235/4150 train_time:408080ms step_avg:182.59ms
+step:2236/4150 train_time:408320ms step_avg:182.61ms
+step:2237/4150 train_time:408556ms step_avg:182.64ms
+step:2238/4150 train_time:408793ms step_avg:182.66ms
+step:2239/4150 train_time:409029ms step_avg:182.68ms
+step:2240/4150 train_time:409263ms step_avg:182.71ms
+step:2241/4150 train_time:409497ms step_avg:182.73ms
+step:2242/4150 train_time:409732ms step_avg:182.75ms
+step:2243/4150 train_time:409965ms step_avg:182.78ms
+step:2244/4150 train_time:410203ms step_avg:182.80ms
+step:2245/4150 train_time:410434ms step_avg:182.82ms
+step:2246/4150 train_time:410668ms step_avg:182.84ms
+step:2247/4150 train_time:410902ms step_avg:182.87ms
+step:2248/4150 train_time:411139ms step_avg:182.89ms
+step:2249/4150 train_time:411375ms step_avg:182.91ms
+step:2250/4150 train_time:411613ms step_avg:182.94ms
+step:2250/4150 val_loss:3.1440 train_time:411830ms step_avg:183.04ms
+step:2251/4150 train_time:411854ms step_avg:182.96ms
+step:2252/4150 train_time:412094ms step_avg:182.99ms
+step:2253/4150 train_time:412333ms step_avg:183.02ms
+step:2254/4150 train_time:412567ms step_avg:183.04ms
+step:2255/4150 train_time:412799ms step_avg:183.06ms
+step:2256/4150 train_time:413034ms step_avg:183.08ms
+step:2257/4150 train_time:413274ms step_avg:183.11ms
+step:2258/4150 train_time:413513ms step_avg:183.13ms
+step:2259/4150 train_time:413743ms step_avg:183.15ms
+step:2260/4150 train_time:413976ms step_avg:183.18ms
+step:2261/4150 train_time:414213ms step_avg:183.20ms
+step:2262/4150 train_time:414454ms step_avg:183.22ms
+step:2263/4150 train_time:414683ms step_avg:183.24ms
+step:2264/4150 train_time:414915ms step_avg:183.27ms
+step:2265/4150 train_time:415151ms step_avg:183.29ms
+step:2266/4150 train_time:415389ms step_avg:183.31ms
+step:2267/4150 train_time:415621ms step_avg:183.34ms
+step:2268/4150 train_time:415854ms step_avg:183.36ms
+step:2269/4150 train_time:416091ms step_avg:183.38ms
+step:2270/4150 train_time:416327ms step_avg:183.40ms
+step:2271/4150 train_time:416561ms step_avg:183.43ms
+step:2272/4150 train_time:416795ms step_avg:183.45ms
+step:2273/4150 train_time:417028ms step_avg:183.47ms
+step:2274/4150 train_time:417267ms step_avg:183.49ms
+step:2275/4150 train_time:417498ms step_avg:183.52ms
+step:2276/4150 train_time:417736ms step_avg:183.54ms
+step:2277/4150 train_time:417968ms step_avg:183.56ms
+step:2278/4150 train_time:418203ms step_avg:183.58ms
+step:2279/4150 train_time:418436ms step_avg:183.60ms
+step:2280/4150 train_time:418670ms step_avg:183.63ms
+step:2281/4150 train_time:418904ms step_avg:183.65ms
+step:2282/4150 train_time:419138ms step_avg:183.67ms
+step:2283/4150 train_time:419373ms step_avg:183.69ms
+step:2284/4150 train_time:419610ms step_avg:183.72ms
+step:2285/4150 train_time:419841ms step_avg:183.74ms
+step:2286/4150 train_time:420076ms step_avg:183.76ms
+step:2287/4150 train_time:420310ms step_avg:183.78ms
+step:2288/4150 train_time:420548ms step_avg:183.81ms
+step:2289/4150 train_time:420779ms step_avg:183.83ms
+step:2290/4150 train_time:421015ms step_avg:183.85ms
+step:2291/4150 train_time:421246ms step_avg:183.87ms
+step:2292/4150 train_time:421485ms step_avg:183.89ms
+step:2293/4150 train_time:421718ms step_avg:183.92ms
+step:2294/4150 train_time:421955ms step_avg:183.94ms
+step:2295/4150 train_time:422192ms step_avg:183.96ms
+step:2296/4150 train_time:422427ms step_avg:183.98ms
+step:2297/4150 train_time:422659ms step_avg:184.00ms
+step:2298/4150 train_time:422895ms step_avg:184.03ms
+step:2299/4150 train_time:423128ms step_avg:184.05ms
+step:2300/4150 train_time:423364ms step_avg:184.07ms
+step:2301/4150 train_time:423599ms step_avg:184.09ms
+step:2302/4150 train_time:423835ms step_avg:184.12ms
+step:2303/4150 train_time:424066ms step_avg:184.14ms
+step:2304/4150 train_time:424303ms step_avg:184.16ms
+step:2305/4150 train_time:424538ms step_avg:184.18ms
+step:2306/4150 train_time:424772ms step_avg:184.20ms
+step:2307/4150 train_time:425010ms step_avg:184.23ms
+step:2308/4150 train_time:425247ms step_avg:184.25ms
+step:2309/4150 train_time:425483ms step_avg:184.27ms
+step:2310/4150 train_time:425717ms step_avg:184.29ms
+step:2311/4150 train_time:425950ms step_avg:184.31ms
+step:2312/4150 train_time:426188ms step_avg:184.34ms
+step:2313/4150 train_time:426419ms step_avg:184.36ms
+step:2314/4150 train_time:426657ms step_avg:184.38ms
+step:2315/4150 train_time:426891ms step_avg:184.40ms
+step:2316/4150 train_time:427130ms step_avg:184.43ms
+step:2317/4150 train_time:427363ms step_avg:184.45ms
+step:2318/4150 train_time:427597ms step_avg:184.47ms
+step:2319/4150 train_time:427834ms step_avg:184.49ms
+step:2320/4150 train_time:428070ms step_avg:184.51ms
+step:2321/4150 train_time:428304ms step_avg:184.53ms
+step:2322/4150 train_time:428542ms step_avg:184.56ms
+step:2323/4150 train_time:428780ms step_avg:184.58ms
+step:2324/4150 train_time:429017ms step_avg:184.60ms
+step:2325/4150 train_time:429251ms step_avg:184.62ms
+step:2326/4150 train_time:429488ms step_avg:184.65ms
+step:2327/4150 train_time:429718ms step_avg:184.67ms
+step:2328/4150 train_time:429955ms step_avg:184.69ms
+step:2329/4150 train_time:430188ms step_avg:184.71ms
+step:2330/4150 train_time:430425ms step_avg:184.73ms
+step:2331/4150 train_time:430656ms step_avg:184.75ms
+step:2332/4150 train_time:430893ms step_avg:184.77ms
+step:2333/4150 train_time:431128ms step_avg:184.80ms
+step:2334/4150 train_time:431363ms step_avg:184.82ms
+step:2335/4150 train_time:431595ms step_avg:184.84ms
+step:2336/4150 train_time:431831ms step_avg:184.86ms
+step:2337/4150 train_time:432063ms step_avg:184.88ms
+step:2338/4150 train_time:432299ms step_avg:184.90ms
+step:2339/4150 train_time:432532ms step_avg:184.92ms
+step:2340/4150 train_time:432768ms step_avg:184.94ms
+step:2341/4150 train_time:433002ms step_avg:184.96ms
+step:2342/4150 train_time:433237ms step_avg:184.99ms
+step:2343/4150 train_time:433471ms step_avg:185.01ms
+step:2344/4150 train_time:433708ms step_avg:185.03ms
+step:2345/4150 train_time:433942ms step_avg:185.05ms
+step:2346/4150 train_time:434179ms step_avg:185.07ms
+step:2347/4150 train_time:434414ms step_avg:185.09ms
+step:2348/4150 train_time:434651ms step_avg:185.12ms
+step:2349/4150 train_time:434884ms step_avg:185.14ms
+step:2350/4150 train_time:435122ms step_avg:185.16ms
+step:2351/4150 train_time:435356ms step_avg:185.18ms
+step:2352/4150 train_time:435595ms step_avg:185.20ms
+step:2353/4150 train_time:435829ms step_avg:185.22ms
+step:2354/4150 train_time:436069ms step_avg:185.25ms
+step:2355/4150 train_time:436301ms step_avg:185.27ms
+step:2356/4150 train_time:436537ms step_avg:185.29ms
+step:2357/4150 train_time:436772ms step_avg:185.31ms
+step:2358/4150 train_time:437009ms step_avg:185.33ms
+step:2359/4150 train_time:437241ms step_avg:185.35ms
+step:2360/4150 train_time:437476ms step_avg:185.37ms
+step:2361/4150 train_time:437708ms step_avg:185.39ms
+step:2362/4150 train_time:437943ms step_avg:185.41ms
+step:2363/4150 train_time:438180ms step_avg:185.43ms
+step:2364/4150 train_time:438417ms step_avg:185.46ms
+step:2365/4150 train_time:438650ms step_avg:185.48ms
+step:2366/4150 train_time:438885ms step_avg:185.50ms
+step:2367/4150 train_time:439119ms step_avg:185.52ms
+step:2368/4150 train_time:439357ms step_avg:185.54ms
+step:2369/4150 train_time:439591ms step_avg:185.56ms
+step:2370/4150 train_time:439826ms step_avg:185.58ms
+step:2371/4150 train_time:440059ms step_avg:185.60ms
+step:2372/4150 train_time:440296ms step_avg:185.62ms
+step:2373/4150 train_time:440529ms step_avg:185.64ms
+step:2374/4150 train_time:440766ms step_avg:185.66ms
+step:2375/4150 train_time:440999ms step_avg:185.68ms
+step:2376/4150 train_time:441234ms step_avg:185.70ms
+step:2377/4150 train_time:441468ms step_avg:185.73ms
+step:2378/4150 train_time:441706ms step_avg:185.75ms
+step:2379/4150 train_time:441938ms step_avg:185.77ms
+step:2380/4150 train_time:442173ms step_avg:185.79ms
+step:2381/4150 train_time:442409ms step_avg:185.81ms
+step:2382/4150 train_time:442648ms step_avg:185.83ms
+step:2383/4150 train_time:442882ms step_avg:185.85ms
+step:2384/4150 train_time:443117ms step_avg:185.87ms
+step:2385/4150 train_time:443349ms step_avg:185.89ms
+step:2386/4150 train_time:443585ms step_avg:185.91ms
+step:2387/4150 train_time:443817ms step_avg:185.93ms
+step:2388/4150 train_time:444053ms step_avg:185.95ms
+step:2389/4150 train_time:444286ms step_avg:185.97ms
+step:2390/4150 train_time:444522ms step_avg:185.99ms
+step:2391/4150 train_time:444754ms step_avg:186.01ms
+step:2392/4150 train_time:444987ms step_avg:186.03ms
+step:2393/4150 train_time:445220ms step_avg:186.05ms
+step:2394/4150 train_time:445456ms step_avg:186.07ms
+step:2395/4150 train_time:445690ms step_avg:186.09ms
+step:2396/4150 train_time:445927ms step_avg:186.11ms
+step:2397/4150 train_time:446158ms step_avg:186.13ms
+step:2398/4150 train_time:446395ms step_avg:186.15ms
+step:2399/4150 train_time:446629ms step_avg:186.17ms
+step:2400/4150 train_time:446863ms step_avg:186.19ms
+step:2401/4150 train_time:447096ms step_avg:186.21ms
+step:2402/4150 train_time:447331ms step_avg:186.23ms
+step:2403/4150 train_time:447563ms step_avg:186.25ms
+step:2404/4150 train_time:447800ms step_avg:186.27ms
+step:2405/4150 train_time:448034ms step_avg:186.29ms
+step:2406/4150 train_time:448270ms step_avg:186.31ms
+step:2407/4150 train_time:448504ms step_avg:186.33ms
+step:2408/4150 train_time:448740ms step_avg:186.35ms
+step:2409/4150 train_time:448973ms step_avg:186.37ms
+step:2410/4150 train_time:449213ms step_avg:186.40ms
+step:2411/4150 train_time:449447ms step_avg:186.42ms
+step:2412/4150 train_time:449684ms step_avg:186.44ms
+step:2413/4150 train_time:449919ms step_avg:186.46ms
+step:2414/4150 train_time:450153ms step_avg:186.48ms
+step:2415/4150 train_time:450388ms step_avg:186.50ms
+step:2416/4150 train_time:450625ms step_avg:186.52ms
+step:2417/4150 train_time:450862ms step_avg:186.54ms
+step:2418/4150 train_time:451100ms step_avg:186.56ms
+step:2419/4150 train_time:451332ms step_avg:186.58ms
+step:2420/4150 train_time:451569ms step_avg:186.60ms
+step:2421/4150 train_time:451804ms step_avg:186.62ms
+step:2422/4150 train_time:452044ms step_avg:186.64ms
+step:2423/4150 train_time:452277ms step_avg:186.66ms
+step:2424/4150 train_time:452513ms step_avg:186.68ms
+step:2425/4150 train_time:452748ms step_avg:186.70ms
+step:2426/4150 train_time:452983ms step_avg:186.72ms
+step:2427/4150 train_time:453215ms step_avg:186.74ms
+step:2428/4150 train_time:453454ms step_avg:186.76ms
+step:2429/4150 train_time:453693ms step_avg:186.78ms
+step:2430/4150 train_time:453930ms step_avg:186.80ms
+step:2431/4150 train_time:454165ms step_avg:186.82ms
+step:2432/4150 train_time:454401ms step_avg:186.84ms
+step:2433/4150 train_time:454634ms step_avg:186.86ms
+step:2434/4150 train_time:454872ms step_avg:186.88ms
+step:2435/4150 train_time:455104ms step_avg:186.90ms
+step:2436/4150 train_time:455340ms step_avg:186.92ms
+step:2437/4150 train_time:455574ms step_avg:186.94ms
+step:2438/4150 train_time:455814ms step_avg:186.96ms
+step:2439/4150 train_time:456049ms step_avg:186.98ms
+step:2440/4150 train_time:456285ms step_avg:187.00ms
+step:2441/4150 train_time:456518ms step_avg:187.02ms
+step:2442/4150 train_time:456760ms step_avg:187.04ms
+step:2443/4150 train_time:456993ms step_avg:187.06ms
+step:2444/4150 train_time:457228ms step_avg:187.08ms
+step:2445/4150 train_time:457459ms step_avg:187.10ms
+step:2446/4150 train_time:457696ms step_avg:187.12ms
+step:2447/4150 train_time:457929ms step_avg:187.14ms
+step:2448/4150 train_time:458167ms step_avg:187.16ms
+step:2449/4150 train_time:458399ms step_avg:187.18ms
+step:2450/4150 train_time:458638ms step_avg:187.20ms
+step:2451/4150 train_time:458874ms step_avg:187.22ms
+step:2452/4150 train_time:459113ms step_avg:187.24ms
+step:2453/4150 train_time:459347ms step_avg:187.26ms
+step:2454/4150 train_time:459584ms step_avg:187.28ms
+step:2455/4150 train_time:459819ms step_avg:187.30ms
+step:2456/4150 train_time:460059ms step_avg:187.32ms
+step:2457/4150 train_time:460294ms step_avg:187.34ms
+step:2458/4150 train_time:460528ms step_avg:187.36ms
+step:2459/4150 train_time:460762ms step_avg:187.38ms
+step:2460/4150 train_time:460999ms step_avg:187.40ms
+step:2461/4150 train_time:461236ms step_avg:187.42ms
+step:2462/4150 train_time:461474ms step_avg:187.44ms
+step:2463/4150 train_time:461709ms step_avg:187.46ms
+step:2464/4150 train_time:461945ms step_avg:187.48ms
+step:2465/4150 train_time:462181ms step_avg:187.50ms
+step:2466/4150 train_time:462421ms step_avg:187.52ms
+step:2467/4150 train_time:462654ms step_avg:187.54ms
+step:2468/4150 train_time:462892ms step_avg:187.56ms
+step:2469/4150 train_time:463128ms step_avg:187.58ms
+step:2470/4150 train_time:463365ms step_avg:187.60ms
+step:2471/4150 train_time:463601ms step_avg:187.62ms
+step:2472/4150 train_time:463835ms step_avg:187.64ms
+step:2473/4150 train_time:464069ms step_avg:187.65ms
+step:2474/4150 train_time:464308ms step_avg:187.67ms
+step:2475/4150 train_time:464542ms step_avg:187.69ms
+step:2476/4150 train_time:464779ms step_avg:187.71ms
+step:2477/4150 train_time:465016ms step_avg:187.73ms
+step:2478/4150 train_time:465254ms step_avg:187.75ms
+step:2479/4150 train_time:465486ms step_avg:187.77ms
+step:2480/4150 train_time:465721ms step_avg:187.79ms
+step:2481/4150 train_time:465953ms step_avg:187.81ms
+step:2482/4150 train_time:466192ms step_avg:187.83ms
+step:2483/4150 train_time:466425ms step_avg:187.85ms
+step:2484/4150 train_time:466662ms step_avg:187.87ms
+step:2485/4150 train_time:466897ms step_avg:187.89ms
+step:2486/4150 train_time:467133ms step_avg:187.91ms
+step:2487/4150 train_time:467367ms step_avg:187.92ms
+step:2488/4150 train_time:467608ms step_avg:187.95ms
+step:2489/4150 train_time:467841ms step_avg:187.96ms
+step:2490/4150 train_time:468077ms step_avg:187.98ms
+step:2491/4150 train_time:468311ms step_avg:188.00ms
+step:2492/4150 train_time:468547ms step_avg:188.02ms
+step:2493/4150 train_time:468781ms step_avg:188.04ms
+step:2494/4150 train_time:469016ms step_avg:188.06ms
+step:2495/4150 train_time:469251ms step_avg:188.08ms
+step:2496/4150 train_time:469488ms step_avg:188.10ms
+step:2497/4150 train_time:469718ms step_avg:188.11ms
+step:2498/4150 train_time:469955ms step_avg:188.13ms
+step:2499/4150 train_time:470186ms step_avg:188.15ms
+step:2500/4150 train_time:470423ms step_avg:188.17ms
+step:2500/4150 val_loss:3.1097 train_time:470639ms step_avg:188.26ms
+step:2501/4150 train_time:470662ms step_avg:188.19ms
+step:2502/4150 train_time:470900ms step_avg:188.21ms
+step:2503/4150 train_time:471136ms step_avg:188.23ms
+step:2504/4150 train_time:471369ms step_avg:188.25ms
+step:2505/4150 train_time:471601ms step_avg:188.26ms
+step:2506/4150 train_time:471838ms step_avg:188.28ms
+step:2507/4150 train_time:472075ms step_avg:188.30ms
+step:2508/4150 train_time:472310ms step_avg:188.32ms
+step:2509/4150 train_time:472542ms step_avg:188.34ms
+step:2510/4150 train_time:472780ms step_avg:188.36ms
+step:2511/4150 train_time:473016ms step_avg:188.38ms
+step:2512/4150 train_time:473250ms step_avg:188.40ms
+step:2513/4150 train_time:473482ms step_avg:188.41ms
+step:2514/4150 train_time:473719ms step_avg:188.43ms
+step:2515/4150 train_time:473955ms step_avg:188.45ms
+step:2516/4150 train_time:474192ms step_avg:188.47ms
+step:2517/4150 train_time:474424ms step_avg:188.49ms
+step:2518/4150 train_time:474663ms step_avg:188.51ms
+step:2519/4150 train_time:474898ms step_avg:188.53ms
+step:2520/4150 train_time:475136ms step_avg:188.55ms
+step:2521/4150 train_time:475371ms step_avg:188.56ms
+step:2522/4150 train_time:475607ms step_avg:188.58ms
+step:2523/4150 train_time:475843ms step_avg:188.60ms
+step:2524/4150 train_time:476082ms step_avg:188.62ms
+step:2525/4150 train_time:476317ms step_avg:188.64ms
+step:2526/4150 train_time:476551ms step_avg:188.66ms
+step:2527/4150 train_time:476787ms step_avg:188.68ms
+step:2528/4150 train_time:477022ms step_avg:188.70ms
+step:2529/4150 train_time:477254ms step_avg:188.71ms
+step:2530/4150 train_time:477492ms step_avg:188.73ms
+step:2531/4150 train_time:477726ms step_avg:188.75ms
+step:2532/4150 train_time:477963ms step_avg:188.77ms
+step:2533/4150 train_time:478197ms step_avg:188.79ms
+step:2534/4150 train_time:478435ms step_avg:188.81ms
+step:2535/4150 train_time:478668ms step_avg:188.82ms
+step:2536/4150 train_time:478905ms step_avg:188.84ms
+step:2537/4150 train_time:479139ms step_avg:188.86ms
+step:2538/4150 train_time:479375ms step_avg:188.88ms
+step:2539/4150 train_time:479607ms step_avg:188.90ms
+step:2540/4150 train_time:479845ms step_avg:188.92ms
+step:2541/4150 train_time:480078ms step_avg:188.93ms
+step:2542/4150 train_time:480314ms step_avg:188.95ms
+step:2543/4150 train_time:480546ms step_avg:188.97ms
+step:2544/4150 train_time:480785ms step_avg:188.99ms
+step:2545/4150 train_time:481017ms step_avg:189.00ms
+step:2546/4150 train_time:481255ms step_avg:189.02ms
+step:2547/4150 train_time:481491ms step_avg:189.04ms
+step:2548/4150 train_time:481731ms step_avg:189.06ms
+step:2549/4150 train_time:481967ms step_avg:189.08ms
+step:2550/4150 train_time:482202ms step_avg:189.10ms
+step:2551/4150 train_time:482434ms step_avg:189.12ms
+step:2552/4150 train_time:482672ms step_avg:189.13ms
+step:2553/4150 train_time:482910ms step_avg:189.15ms
+step:2554/4150 train_time:483146ms step_avg:189.17ms
+step:2555/4150 train_time:483380ms step_avg:189.19ms
+step:2556/4150 train_time:483616ms step_avg:189.21ms
+step:2557/4150 train_time:483852ms step_avg:189.23ms
+step:2558/4150 train_time:484091ms step_avg:189.25ms
+step:2559/4150 train_time:484327ms step_avg:189.26ms
+step:2560/4150 train_time:484565ms step_avg:189.28ms
+step:2561/4150 train_time:484801ms step_avg:189.30ms
+step:2562/4150 train_time:485037ms step_avg:189.32ms
+step:2563/4150 train_time:485272ms step_avg:189.34ms
+step:2564/4150 train_time:485509ms step_avg:189.36ms
+step:2565/4150 train_time:485746ms step_avg:189.37ms
+step:2566/4150 train_time:485982ms step_avg:189.39ms
+step:2567/4150 train_time:486217ms step_avg:189.41ms
+step:2568/4150 train_time:486454ms step_avg:189.43ms
+step:2569/4150 train_time:486690ms step_avg:189.45ms
+step:2570/4150 train_time:486926ms step_avg:189.47ms
+step:2571/4150 train_time:487159ms step_avg:189.48ms
+step:2572/4150 train_time:487397ms step_avg:189.50ms
+step:2573/4150 train_time:487629ms step_avg:189.52ms
+step:2574/4150 train_time:487866ms step_avg:189.54ms
+step:2575/4150 train_time:488101ms step_avg:189.55ms
+step:2576/4150 train_time:488338ms step_avg:189.57ms
+step:2577/4150 train_time:488573ms step_avg:189.59ms
+step:2578/4150 train_time:488810ms step_avg:189.61ms
+step:2579/4150 train_time:489044ms step_avg:189.63ms
+step:2580/4150 train_time:489280ms step_avg:189.64ms
+step:2581/4150 train_time:489513ms step_avg:189.66ms
+step:2582/4150 train_time:489752ms step_avg:189.68ms
+step:2583/4150 train_time:489984ms step_avg:189.70ms
+step:2584/4150 train_time:490219ms step_avg:189.71ms
+step:2585/4150 train_time:490450ms step_avg:189.73ms
+step:2586/4150 train_time:490690ms step_avg:189.75ms
+step:2587/4150 train_time:490922ms step_avg:189.76ms
+step:2588/4150 train_time:491159ms step_avg:189.78ms
+step:2589/4150 train_time:491392ms step_avg:189.80ms
+step:2590/4150 train_time:491631ms step_avg:189.82ms
+step:2591/4150 train_time:491867ms step_avg:189.84ms
+step:2592/4150 train_time:492103ms step_avg:189.85ms
+step:2593/4150 train_time:492338ms step_avg:189.87ms
+step:2594/4150 train_time:492574ms step_avg:189.89ms
+step:2595/4150 train_time:492811ms step_avg:189.91ms
+step:2596/4150 train_time:493052ms step_avg:189.93ms
+step:2597/4150 train_time:493287ms step_avg:189.94ms
+step:2598/4150 train_time:493524ms step_avg:189.96ms
+step:2599/4150 train_time:493755ms step_avg:189.98ms
+step:2600/4150 train_time:493993ms step_avg:190.00ms
+step:2601/4150 train_time:494228ms step_avg:190.01ms
+step:2602/4150 train_time:494465ms step_avg:190.03ms
+step:2603/4150 train_time:494699ms step_avg:190.05ms
+step:2604/4150 train_time:494934ms step_avg:190.07ms
+step:2605/4150 train_time:495167ms step_avg:190.08ms
+step:2606/4150 train_time:495407ms step_avg:190.10ms
+step:2607/4150 train_time:495639ms step_avg:190.12ms
+step:2608/4150 train_time:495875ms step_avg:190.14ms
+step:2609/4150 train_time:496108ms step_avg:190.15ms
+step:2610/4150 train_time:496344ms step_avg:190.17ms
+step:2611/4150 train_time:496577ms step_avg:190.19ms
+step:2612/4150 train_time:496812ms step_avg:190.20ms
+step:2613/4150 train_time:497045ms step_avg:190.22ms
+step:2614/4150 train_time:497280ms step_avg:190.24ms
+step:2615/4150 train_time:497515ms step_avg:190.25ms
+step:2616/4150 train_time:497751ms step_avg:190.27ms
+step:2617/4150 train_time:497984ms step_avg:190.29ms
+step:2618/4150 train_time:498221ms step_avg:190.31ms
+step:2619/4150 train_time:498452ms step_avg:190.32ms
+step:2620/4150 train_time:498689ms step_avg:190.34ms
+step:2621/4150 train_time:498922ms step_avg:190.36ms
+step:2622/4150 train_time:499160ms step_avg:190.37ms
+step:2623/4150 train_time:499392ms step_avg:190.39ms
+step:2624/4150 train_time:499636ms step_avg:190.41ms
+step:2625/4150 train_time:499870ms step_avg:190.43ms
+step:2626/4150 train_time:500112ms step_avg:190.45ms
+step:2627/4150 train_time:500346ms step_avg:190.46ms
+step:2628/4150 train_time:500583ms step_avg:190.48ms
+step:2629/4150 train_time:500817ms step_avg:190.50ms
+step:2630/4150 train_time:501053ms step_avg:190.51ms
+step:2631/4150 train_time:501286ms step_avg:190.53ms
+step:2632/4150 train_time:501523ms step_avg:190.55ms
+step:2633/4150 train_time:501757ms step_avg:190.56ms
+step:2634/4150 train_time:501992ms step_avg:190.58ms
+step:2635/4150 train_time:502225ms step_avg:190.60ms
+step:2636/4150 train_time:502462ms step_avg:190.62ms
+step:2637/4150 train_time:502696ms step_avg:190.63ms
+step:2638/4150 train_time:502933ms step_avg:190.65ms
+step:2639/4150 train_time:503168ms step_avg:190.67ms
+step:2640/4150 train_time:503408ms step_avg:190.69ms
+step:2641/4150 train_time:503642ms step_avg:190.70ms
+step:2642/4150 train_time:503881ms step_avg:190.72ms
+step:2643/4150 train_time:504113ms step_avg:190.74ms
+step:2644/4150 train_time:504351ms step_avg:190.75ms
+step:2645/4150 train_time:504587ms step_avg:190.77ms
+step:2646/4150 train_time:504825ms step_avg:190.79ms
+step:2647/4150 train_time:505059ms step_avg:190.80ms
+step:2648/4150 train_time:505297ms step_avg:190.82ms
+step:2649/4150 train_time:505532ms step_avg:190.84ms
+step:2650/4150 train_time:505768ms step_avg:190.86ms
+step:2651/4150 train_time:506000ms step_avg:190.87ms
+step:2652/4150 train_time:506237ms step_avg:190.89ms
+step:2653/4150 train_time:506475ms step_avg:190.91ms
+step:2654/4150 train_time:506710ms step_avg:190.92ms
+step:2655/4150 train_time:506943ms step_avg:190.94ms
+step:2656/4150 train_time:507181ms step_avg:190.96ms
+step:2657/4150 train_time:507414ms step_avg:190.97ms
+step:2658/4150 train_time:507651ms step_avg:190.99ms
+step:2659/4150 train_time:507885ms step_avg:191.01ms
+step:2660/4150 train_time:508122ms step_avg:191.02ms
+step:2661/4150 train_time:508355ms step_avg:191.04ms
+step:2662/4150 train_time:508592ms step_avg:191.06ms
+step:2663/4150 train_time:508828ms step_avg:191.07ms
+step:2664/4150 train_time:509065ms step_avg:191.09ms
+step:2665/4150 train_time:509297ms step_avg:191.11ms
+step:2666/4150 train_time:509533ms step_avg:191.12ms
+step:2667/4150 train_time:509767ms step_avg:191.14ms
+step:2668/4150 train_time:510007ms step_avg:191.16ms
+step:2669/4150 train_time:510241ms step_avg:191.17ms
+step:2670/4150 train_time:510475ms step_avg:191.19ms
+step:2671/4150 train_time:510707ms step_avg:191.20ms
+step:2672/4150 train_time:510946ms step_avg:191.22ms
+step:2673/4150 train_time:511182ms step_avg:191.24ms
+step:2674/4150 train_time:511416ms step_avg:191.26ms
+step:2675/4150 train_time:511649ms step_avg:191.27ms
+step:2676/4150 train_time:511888ms step_avg:191.29ms
+step:2677/4150 train_time:512124ms step_avg:191.31ms
+step:2678/4150 train_time:512359ms step_avg:191.32ms
+step:2679/4150 train_time:512592ms step_avg:191.34ms
+step:2680/4150 train_time:512833ms step_avg:191.36ms
+step:2681/4150 train_time:513069ms step_avg:191.37ms
+step:2682/4150 train_time:513306ms step_avg:191.39ms
+step:2683/4150 train_time:513537ms step_avg:191.40ms
+step:2684/4150 train_time:513774ms step_avg:191.42ms
+step:2685/4150 train_time:514012ms step_avg:191.44ms
+step:2686/4150 train_time:514250ms step_avg:191.46ms
+step:2687/4150 train_time:514486ms step_avg:191.47ms
+step:2688/4150 train_time:514721ms step_avg:191.49ms
+step:2689/4150 train_time:514959ms step_avg:191.51ms
+step:2690/4150 train_time:515196ms step_avg:191.52ms
+step:2691/4150 train_time:515431ms step_avg:191.54ms
+step:2692/4150 train_time:515666ms step_avg:191.55ms
+step:2693/4150 train_time:515900ms step_avg:191.57ms
+step:2694/4150 train_time:516140ms step_avg:191.59ms
+step:2695/4150 train_time:516375ms step_avg:191.60ms
+step:2696/4150 train_time:516611ms step_avg:191.62ms
+step:2697/4150 train_time:516846ms step_avg:191.64ms
+step:2698/4150 train_time:517086ms step_avg:191.66ms
+step:2699/4150 train_time:517322ms step_avg:191.67ms
+step:2700/4150 train_time:517556ms step_avg:191.69ms
+step:2701/4150 train_time:517788ms step_avg:191.70ms
+step:2702/4150 train_time:518028ms step_avg:191.72ms
+step:2703/4150 train_time:518264ms step_avg:191.74ms
+step:2704/4150 train_time:518501ms step_avg:191.75ms
+step:2705/4150 train_time:518736ms step_avg:191.77ms
+step:2706/4150 train_time:518975ms step_avg:191.79ms
+step:2707/4150 train_time:519211ms step_avg:191.80ms
+step:2708/4150 train_time:519450ms step_avg:191.82ms
+step:2709/4150 train_time:519682ms step_avg:191.84ms
+step:2710/4150 train_time:519920ms step_avg:191.85ms
+step:2711/4150 train_time:520151ms step_avg:191.87ms
+step:2712/4150 train_time:520388ms step_avg:191.88ms
+step:2713/4150 train_time:520622ms step_avg:191.90ms
+step:2714/4150 train_time:520859ms step_avg:191.92ms
+step:2715/4150 train_time:521092ms step_avg:191.93ms
+step:2716/4150 train_time:521333ms step_avg:191.95ms
+step:2717/4150 train_time:521564ms step_avg:191.96ms
+step:2718/4150 train_time:521800ms step_avg:191.98ms
+step:2719/4150 train_time:522031ms step_avg:191.99ms
+step:2720/4150 train_time:522270ms step_avg:192.01ms
+step:2721/4150 train_time:522503ms step_avg:192.03ms
+step:2722/4150 train_time:522739ms step_avg:192.04ms
+step:2723/4150 train_time:522971ms step_avg:192.06ms
+step:2724/4150 train_time:523211ms step_avg:192.07ms
+step:2725/4150 train_time:523445ms step_avg:192.09ms
+step:2726/4150 train_time:523684ms step_avg:192.11ms
+step:2727/4150 train_time:523919ms step_avg:192.12ms
+step:2728/4150 train_time:524155ms step_avg:192.14ms
+step:2729/4150 train_time:524390ms step_avg:192.15ms
+step:2730/4150 train_time:524631ms step_avg:192.17ms
+step:2731/4150 train_time:524866ms step_avg:192.19ms
+step:2732/4150 train_time:525101ms step_avg:192.20ms
+step:2733/4150 train_time:525337ms step_avg:192.22ms
+step:2734/4150 train_time:525574ms step_avg:192.24ms
+step:2735/4150 train_time:525807ms step_avg:192.25ms
+step:2736/4150 train_time:526043ms step_avg:192.27ms
+step:2737/4150 train_time:526275ms step_avg:192.28ms
+step:2738/4150 train_time:526511ms step_avg:192.30ms
+step:2739/4150 train_time:526751ms step_avg:192.32ms
+step:2740/4150 train_time:526992ms step_avg:192.33ms
+step:2741/4150 train_time:527227ms step_avg:192.35ms
+step:2742/4150 train_time:527463ms step_avg:192.36ms
+step:2743/4150 train_time:527698ms step_avg:192.38ms
+step:2744/4150 train_time:527936ms step_avg:192.40ms
+step:2745/4150 train_time:528168ms step_avg:192.41ms
+step:2746/4150 train_time:528408ms step_avg:192.43ms
+step:2747/4150 train_time:528641ms step_avg:192.44ms
+step:2748/4150 train_time:528878ms step_avg:192.46ms
+step:2749/4150 train_time:529115ms step_avg:192.48ms
+step:2750/4150 train_time:529354ms step_avg:192.49ms
+step:2750/4150 val_loss:3.0735 train_time:529572ms step_avg:192.57ms
+step:2751/4150 train_time:529598ms step_avg:192.51ms
+step:2752/4150 train_time:529835ms step_avg:192.53ms
+step:2753/4150 train_time:530071ms step_avg:192.54ms
+step:2754/4150 train_time:530304ms step_avg:192.56ms
+step:2755/4150 train_time:530535ms step_avg:192.57ms
+step:2756/4150 train_time:530773ms step_avg:192.59ms
+step:2757/4150 train_time:531007ms step_avg:192.60ms
+step:2758/4150 train_time:531243ms step_avg:192.62ms
+step:2759/4150 train_time:531475ms step_avg:192.63ms
+step:2760/4150 train_time:531713ms step_avg:192.65ms
+step:2761/4150 train_time:531949ms step_avg:192.67ms
+step:2762/4150 train_time:532187ms step_avg:192.68ms
+step:2763/4150 train_time:532418ms step_avg:192.70ms
+step:2764/4150 train_time:532656ms step_avg:192.71ms
+step:2765/4150 train_time:532892ms step_avg:192.73ms
+step:2766/4150 train_time:533130ms step_avg:192.74ms
+step:2767/4150 train_time:533366ms step_avg:192.76ms
+step:2768/4150 train_time:533601ms step_avg:192.77ms
+step:2769/4150 train_time:533836ms step_avg:192.79ms
+step:2770/4150 train_time:534073ms step_avg:192.81ms
+step:2771/4150 train_time:534308ms step_avg:192.82ms
+step:2772/4150 train_time:534543ms step_avg:192.84ms
+step:2773/4150 train_time:534776ms step_avg:192.85ms
+step:2774/4150 train_time:535014ms step_avg:192.87ms
+step:2775/4150 train_time:535248ms step_avg:192.88ms
+step:2776/4150 train_time:535487ms step_avg:192.90ms
+step:2777/4150 train_time:535723ms step_avg:192.91ms
+step:2778/4150 train_time:535962ms step_avg:192.93ms
+step:2779/4150 train_time:536199ms step_avg:192.95ms
+step:2780/4150 train_time:536437ms step_avg:192.96ms
+step:2781/4150 train_time:536670ms step_avg:192.98ms
+step:2782/4150 train_time:536905ms step_avg:192.99ms
+step:2783/4150 train_time:537138ms step_avg:193.01ms
+step:2784/4150 train_time:537377ms step_avg:193.02ms
+step:2785/4150 train_time:537610ms step_avg:193.04ms
+step:2786/4150 train_time:537848ms step_avg:193.05ms
+step:2787/4150 train_time:538086ms step_avg:193.07ms
+step:2788/4150 train_time:538327ms step_avg:193.09ms
+step:2789/4150 train_time:538559ms step_avg:193.10ms
+step:2790/4150 train_time:538796ms step_avg:193.12ms
+step:2791/4150 train_time:539032ms step_avg:193.13ms
+step:2792/4150 train_time:539268ms step_avg:193.15ms
+step:2793/4150 train_time:539503ms step_avg:193.16ms
+step:2794/4150 train_time:539738ms step_avg:193.18ms
+step:2795/4150 train_time:539977ms step_avg:193.19ms
+step:2796/4150 train_time:540215ms step_avg:193.21ms
+step:2797/4150 train_time:540446ms step_avg:193.22ms
+step:2798/4150 train_time:540683ms step_avg:193.24ms
+step:2799/4150 train_time:540918ms step_avg:193.25ms
+step:2800/4150 train_time:541157ms step_avg:193.27ms
+step:2801/4150 train_time:541391ms step_avg:193.29ms
+step:2802/4150 train_time:541627ms step_avg:193.30ms
+step:2803/4150 train_time:541861ms step_avg:193.31ms
+step:2804/4150 train_time:542096ms step_avg:193.33ms
+step:2805/4150 train_time:542329ms step_avg:193.34ms
+step:2806/4150 train_time:542564ms step_avg:193.36ms
+step:2807/4150 train_time:542798ms step_avg:193.37ms
+step:2808/4150 train_time:543034ms step_avg:193.39ms
+step:2809/4150 train_time:543269ms step_avg:193.40ms
+step:2810/4150 train_time:543508ms step_avg:193.42ms
+step:2811/4150 train_time:543742ms step_avg:193.43ms
+step:2812/4150 train_time:543979ms step_avg:193.45ms
+step:2813/4150 train_time:544212ms step_avg:193.46ms
+step:2814/4150 train_time:544450ms step_avg:193.48ms
+step:2815/4150 train_time:544688ms step_avg:193.49ms
+step:2816/4150 train_time:544929ms step_avg:193.51ms
+step:2817/4150 train_time:545163ms step_avg:193.53ms
+step:2818/4150 train_time:545402ms step_avg:193.54ms
+step:2819/4150 train_time:545634ms step_avg:193.56ms
+step:2820/4150 train_time:545873ms step_avg:193.57ms
+step:2821/4150 train_time:546107ms step_avg:193.59ms
+step:2822/4150 train_time:546345ms step_avg:193.60ms
+step:2823/4150 train_time:546578ms step_avg:193.62ms
+step:2824/4150 train_time:546815ms step_avg:193.63ms
+step:2825/4150 train_time:547051ms step_avg:193.65ms
+step:2826/4150 train_time:547287ms step_avg:193.66ms
+step:2827/4150 train_time:547521ms step_avg:193.68ms
+step:2828/4150 train_time:547758ms step_avg:193.69ms
+step:2829/4150 train_time:547990ms step_avg:193.70ms
+step:2830/4150 train_time:548229ms step_avg:193.72ms
+step:2831/4150 train_time:548467ms step_avg:193.74ms
+step:2832/4150 train_time:548706ms step_avg:193.75ms
+step:2833/4150 train_time:548941ms step_avg:193.77ms
+step:2834/4150 train_time:549177ms step_avg:193.78ms
+step:2835/4150 train_time:549412ms step_avg:193.80ms
+step:2836/4150 train_time:549649ms step_avg:193.81ms
+step:2837/4150 train_time:549883ms step_avg:193.83ms
+step:2838/4150 train_time:550123ms step_avg:193.84ms
+step:2839/4150 train_time:550358ms step_avg:193.86ms
+step:2840/4150 train_time:550597ms step_avg:193.87ms
+step:2841/4150 train_time:550831ms step_avg:193.89ms
+step:2842/4150 train_time:551066ms step_avg:193.90ms
+step:2843/4150 train_time:551301ms step_avg:193.92ms
+step:2844/4150 train_time:551540ms step_avg:193.93ms
+step:2845/4150 train_time:551773ms step_avg:193.94ms
+step:2846/4150 train_time:552010ms step_avg:193.96ms
+step:2847/4150 train_time:552247ms step_avg:193.97ms
+step:2848/4150 train_time:552484ms step_avg:193.99ms
+step:2849/4150 train_time:552718ms step_avg:194.00ms
+step:2850/4150 train_time:552956ms step_avg:194.02ms
+step:2851/4150 train_time:553188ms step_avg:194.03ms
+step:2852/4150 train_time:553425ms step_avg:194.05ms
+step:2853/4150 train_time:553660ms step_avg:194.06ms
+step:2854/4150 train_time:553897ms step_avg:194.08ms
+step:2855/4150 train_time:554132ms step_avg:194.09ms
+step:2856/4150 train_time:554370ms step_avg:194.11ms
+step:2857/4150 train_time:554607ms step_avg:194.12ms
+step:2858/4150 train_time:554844ms step_avg:194.14ms
+step:2859/4150 train_time:555077ms step_avg:194.15ms
+step:2860/4150 train_time:555317ms step_avg:194.17ms
+step:2861/4150 train_time:555552ms step_avg:194.18ms
+step:2862/4150 train_time:555790ms step_avg:194.20ms
+step:2863/4150 train_time:556025ms step_avg:194.21ms
+step:2864/4150 train_time:556263ms step_avg:194.23ms
+step:2865/4150 train_time:556497ms step_avg:194.24ms
+step:2866/4150 train_time:556734ms step_avg:194.25ms
+step:2867/4150 train_time:556967ms step_avg:194.27ms
+step:2868/4150 train_time:557202ms step_avg:194.28ms
+step:2869/4150 train_time:557435ms step_avg:194.30ms
+step:2870/4150 train_time:557672ms step_avg:194.31ms
+step:2871/4150 train_time:557906ms step_avg:194.32ms
+step:2872/4150 train_time:558142ms step_avg:194.34ms
+step:2873/4150 train_time:558376ms step_avg:194.35ms
+step:2874/4150 train_time:558614ms step_avg:194.37ms
+step:2875/4150 train_time:558848ms step_avg:194.38ms
+step:2876/4150 train_time:559085ms step_avg:194.40ms
+step:2877/4150 train_time:559319ms step_avg:194.41ms
+step:2878/4150 train_time:559562ms step_avg:194.43ms
+step:2879/4150 train_time:559795ms step_avg:194.44ms
+step:2880/4150 train_time:560034ms step_avg:194.46ms
+step:2881/4150 train_time:560267ms step_avg:194.47ms
+step:2882/4150 train_time:560504ms step_avg:194.48ms
+step:2883/4150 train_time:560740ms step_avg:194.50ms
+step:2884/4150 train_time:560979ms step_avg:194.51ms
+step:2885/4150 train_time:561211ms step_avg:194.53ms
+step:2886/4150 train_time:561447ms step_avg:194.54ms
+step:2887/4150 train_time:561683ms step_avg:194.56ms
+step:2888/4150 train_time:561922ms step_avg:194.57ms
+step:2889/4150 train_time:562155ms step_avg:194.58ms
+step:2890/4150 train_time:562391ms step_avg:194.60ms
+step:2891/4150 train_time:562626ms step_avg:194.61ms
+step:2892/4150 train_time:562866ms step_avg:194.63ms
+step:2893/4150 train_time:563100ms step_avg:194.64ms
+step:2894/4150 train_time:563336ms step_avg:194.66ms
+step:2895/4150 train_time:563571ms step_avg:194.67ms
+step:2896/4150 train_time:563807ms step_avg:194.68ms
+step:2897/4150 train_time:564043ms step_avg:194.70ms
+step:2898/4150 train_time:564278ms step_avg:194.71ms
+step:2899/4150 train_time:564514ms step_avg:194.73ms
+step:2900/4150 train_time:564750ms step_avg:194.74ms
+step:2901/4150 train_time:564986ms step_avg:194.76ms
+step:2902/4150 train_time:565222ms step_avg:194.77ms
+step:2903/4150 train_time:565455ms step_avg:194.78ms
+step:2904/4150 train_time:565692ms step_avg:194.80ms
+step:2905/4150 train_time:565928ms step_avg:194.81ms
+step:2906/4150 train_time:566164ms step_avg:194.83ms
+step:2907/4150 train_time:566396ms step_avg:194.84ms
+step:2908/4150 train_time:566634ms step_avg:194.85ms
+step:2909/4150 train_time:566871ms step_avg:194.87ms
+step:2910/4150 train_time:567110ms step_avg:194.88ms
+step:2911/4150 train_time:567346ms step_avg:194.90ms
+step:2912/4150 train_time:567581ms step_avg:194.91ms
+step:2913/4150 train_time:567814ms step_avg:194.92ms
+step:2914/4150 train_time:568052ms step_avg:194.94ms
+step:2915/4150 train_time:568286ms step_avg:194.95ms
+step:2916/4150 train_time:568523ms step_avg:194.97ms
+step:2917/4150 train_time:568756ms step_avg:194.98ms
+step:2918/4150 train_time:568995ms step_avg:194.99ms
+step:2919/4150 train_time:569229ms step_avg:195.01ms
+step:2920/4150 train_time:569464ms step_avg:195.02ms
+step:2921/4150 train_time:569701ms step_avg:195.04ms
+step:2922/4150 train_time:569939ms step_avg:195.05ms
+step:2923/4150 train_time:570173ms step_avg:195.06ms
+step:2924/4150 train_time:570412ms step_avg:195.08ms
+step:2925/4150 train_time:570646ms step_avg:195.09ms
+step:2926/4150 train_time:570883ms step_avg:195.11ms
+step:2927/4150 train_time:571115ms step_avg:195.12ms
+step:2928/4150 train_time:571353ms step_avg:195.13ms
+step:2929/4150 train_time:571589ms step_avg:195.15ms
+step:2930/4150 train_time:571829ms step_avg:195.16ms
+step:2931/4150 train_time:572065ms step_avg:195.18ms
+step:2932/4150 train_time:572304ms step_avg:195.19ms
+step:2933/4150 train_time:572537ms step_avg:195.21ms
+step:2934/4150 train_time:572776ms step_avg:195.22ms
+step:2935/4150 train_time:573009ms step_avg:195.23ms
+step:2936/4150 train_time:573248ms step_avg:195.25ms
+step:2937/4150 train_time:573484ms step_avg:195.26ms
+step:2938/4150 train_time:573719ms step_avg:195.28ms
+step:2939/4150 train_time:573955ms step_avg:195.29ms
+step:2940/4150 train_time:574192ms step_avg:195.30ms
+step:2941/4150 train_time:574428ms step_avg:195.32ms
+step:2942/4150 train_time:574663ms step_avg:195.33ms
+step:2943/4150 train_time:574898ms step_avg:195.34ms
+step:2944/4150 train_time:575136ms step_avg:195.36ms
+step:2945/4150 train_time:575370ms step_avg:195.37ms
+step:2946/4150 train_time:575608ms step_avg:195.39ms
+step:2947/4150 train_time:575840ms step_avg:195.40ms
+step:2948/4150 train_time:576077ms step_avg:195.41ms
+step:2949/4150 train_time:576310ms step_avg:195.43ms
+step:2950/4150 train_time:576549ms step_avg:195.44ms
+step:2951/4150 train_time:576783ms step_avg:195.45ms
+step:2952/4150 train_time:577019ms step_avg:195.47ms
+step:2953/4150 train_time:577257ms step_avg:195.48ms
+step:2954/4150 train_time:577496ms step_avg:195.50ms
+step:2955/4150 train_time:577732ms step_avg:195.51ms
+step:2956/4150 train_time:577971ms step_avg:195.52ms
+step:2957/4150 train_time:578205ms step_avg:195.54ms
+step:2958/4150 train_time:578441ms step_avg:195.55ms
+step:2959/4150 train_time:578682ms step_avg:195.57ms
+step:2960/4150 train_time:578917ms step_avg:195.58ms
+step:2961/4150 train_time:579151ms step_avg:195.59ms
+step:2962/4150 train_time:579389ms step_avg:195.61ms
+step:2963/4150 train_time:579620ms step_avg:195.62ms
+step:2964/4150 train_time:579860ms step_avg:195.63ms
+step:2965/4150 train_time:580094ms step_avg:195.65ms
+step:2966/4150 train_time:580329ms step_avg:195.66ms
+step:2967/4150 train_time:580564ms step_avg:195.67ms
+step:2968/4150 train_time:580803ms step_avg:195.69ms
+step:2969/4150 train_time:581040ms step_avg:195.70ms
+step:2970/4150 train_time:581279ms step_avg:195.72ms
+step:2971/4150 train_time:581510ms step_avg:195.73ms
+step:2972/4150 train_time:581747ms step_avg:195.74ms
+step:2973/4150 train_time:581979ms step_avg:195.75ms
+step:2974/4150 train_time:582217ms step_avg:195.77ms
+step:2975/4150 train_time:582452ms step_avg:195.78ms
+step:2976/4150 train_time:582690ms step_avg:195.80ms
+step:2977/4150 train_time:582927ms step_avg:195.81ms
+step:2978/4150 train_time:583162ms step_avg:195.82ms
+step:2979/4150 train_time:583394ms step_avg:195.84ms
+step:2980/4150 train_time:583631ms step_avg:195.85ms
+step:2981/4150 train_time:583868ms step_avg:195.86ms
+step:2982/4150 train_time:584105ms step_avg:195.88ms
+step:2983/4150 train_time:584339ms step_avg:195.89ms
+step:2984/4150 train_time:584579ms step_avg:195.90ms
+step:2985/4150 train_time:584815ms step_avg:195.92ms
+step:2986/4150 train_time:585053ms step_avg:195.93ms
+step:2987/4150 train_time:585288ms step_avg:195.95ms
+step:2988/4150 train_time:585527ms step_avg:195.96ms
+step:2989/4150 train_time:585760ms step_avg:195.97ms
+step:2990/4150 train_time:585999ms step_avg:195.99ms
+step:2991/4150 train_time:586234ms step_avg:196.00ms
+step:2992/4150 train_time:586472ms step_avg:196.01ms
+step:2993/4150 train_time:586703ms step_avg:196.03ms
+step:2994/4150 train_time:586941ms step_avg:196.04ms
+step:2995/4150 train_time:587174ms step_avg:196.05ms
+step:2996/4150 train_time:587409ms step_avg:196.06ms
+step:2997/4150 train_time:587644ms step_avg:196.08ms
+step:2998/4150 train_time:587882ms step_avg:196.09ms
+step:2999/4150 train_time:588118ms step_avg:196.10ms
+step:3000/4150 train_time:588356ms step_avg:196.12ms
+step:3000/4150 val_loss:3.0411 train_time:588571ms step_avg:196.19ms
+step:3001/4150 train_time:588594ms step_avg:196.13ms
+step:3002/4150 train_time:588830ms step_avg:196.15ms
+step:3003/4150 train_time:589067ms step_avg:196.16ms
+step:3004/4150 train_time:589302ms step_avg:196.17ms
+step:3005/4150 train_time:589533ms step_avg:196.18ms
+step:3006/4150 train_time:589770ms step_avg:196.20ms
+step:3007/4150 train_time:590008ms step_avg:196.21ms
+step:3008/4150 train_time:590248ms step_avg:196.23ms
+step:3009/4150 train_time:590480ms step_avg:196.24ms
+step:3010/4150 train_time:590716ms step_avg:196.25ms
+step:3011/4150 train_time:590952ms step_avg:196.26ms
+step:3012/4150 train_time:591189ms step_avg:196.28ms
+step:3013/4150 train_time:591423ms step_avg:196.29ms
+step:3014/4150 train_time:591662ms step_avg:196.30ms
+step:3015/4150 train_time:591900ms step_avg:196.32ms
+step:3016/4150 train_time:592138ms step_avg:196.33ms
+step:3017/4150 train_time:592372ms step_avg:196.34ms
+step:3018/4150 train_time:592606ms step_avg:196.36ms
+step:3019/4150 train_time:592842ms step_avg:196.37ms
+step:3020/4150 train_time:593084ms step_avg:196.39ms
+step:3021/4150 train_time:593317ms step_avg:196.40ms
+step:3022/4150 train_time:593554ms step_avg:196.41ms
+step:3023/4150 train_time:593791ms step_avg:196.42ms
+step:3024/4150 train_time:594029ms step_avg:196.44ms
+step:3025/4150 train_time:594260ms step_avg:196.45ms
+step:3026/4150 train_time:594497ms step_avg:196.46ms
+step:3027/4150 train_time:594730ms step_avg:196.47ms
+step:3028/4150 train_time:594966ms step_avg:196.49ms
+step:3029/4150 train_time:595201ms step_avg:196.50ms
+step:3030/4150 train_time:595442ms step_avg:196.52ms
+step:3031/4150 train_time:595676ms step_avg:196.53ms
+step:3032/4150 train_time:595913ms step_avg:196.54ms
+step:3033/4150 train_time:596147ms step_avg:196.55ms
+step:3034/4150 train_time:596386ms step_avg:196.57ms
+step:3035/4150 train_time:596624ms step_avg:196.58ms
+step:3036/4150 train_time:596858ms step_avg:196.59ms
+step:3037/4150 train_time:597094ms step_avg:196.61ms
+step:3038/4150 train_time:597330ms step_avg:196.62ms
+step:3039/4150 train_time:597563ms step_avg:196.63ms
+step:3040/4150 train_time:597802ms step_avg:196.65ms
+step:3041/4150 train_time:598036ms step_avg:196.66ms
+step:3042/4150 train_time:598274ms step_avg:196.67ms
+step:3043/4150 train_time:598509ms step_avg:196.68ms
+step:3044/4150 train_time:598746ms step_avg:196.70ms
+step:3045/4150 train_time:598984ms step_avg:196.71ms
+step:3046/4150 train_time:599223ms step_avg:196.72ms
+step:3047/4150 train_time:599458ms step_avg:196.74ms
+step:3048/4150 train_time:599697ms step_avg:196.75ms
+step:3049/4150 train_time:599931ms step_avg:196.76ms
+step:3050/4150 train_time:600167ms step_avg:196.78ms
+step:3051/4150 train_time:600403ms step_avg:196.79ms
+step:3052/4150 train_time:600642ms step_avg:196.80ms
+step:3053/4150 train_time:600878ms step_avg:196.82ms
+step:3054/4150 train_time:601113ms step_avg:196.83ms
+step:3055/4150 train_time:601344ms step_avg:196.84ms
+step:3056/4150 train_time:601580ms step_avg:196.85ms
+step:3057/4150 train_time:601815ms step_avg:196.86ms
+step:3058/4150 train_time:602053ms step_avg:196.88ms
+step:3059/4150 train_time:602289ms step_avg:196.89ms
+step:3060/4150 train_time:602527ms step_avg:196.90ms
+step:3061/4150 train_time:602763ms step_avg:196.92ms
+step:3062/4150 train_time:603002ms step_avg:196.93ms
+step:3063/4150 train_time:603238ms step_avg:196.94ms
+step:3064/4150 train_time:603477ms step_avg:196.96ms
+step:3065/4150 train_time:603711ms step_avg:196.97ms
+step:3066/4150 train_time:603949ms step_avg:196.98ms
+step:3067/4150 train_time:604184ms step_avg:197.00ms
+step:3068/4150 train_time:604420ms step_avg:197.01ms
+step:3069/4150 train_time:604654ms step_avg:197.02ms
+step:3070/4150 train_time:604889ms step_avg:197.03ms
+step:3071/4150 train_time:605124ms step_avg:197.04ms
+step:3072/4150 train_time:605360ms step_avg:197.06ms
+step:3073/4150 train_time:605595ms step_avg:197.07ms
+step:3074/4150 train_time:605830ms step_avg:197.08ms
+step:3075/4150 train_time:606067ms step_avg:197.09ms
+step:3076/4150 train_time:606304ms step_avg:197.11ms
+step:3077/4150 train_time:606537ms step_avg:197.12ms
+step:3078/4150 train_time:606777ms step_avg:197.13ms
+step:3079/4150 train_time:607011ms step_avg:197.15ms
+step:3080/4150 train_time:607247ms step_avg:197.16ms
+step:3081/4150 train_time:607481ms step_avg:197.17ms
+step:3082/4150 train_time:607720ms step_avg:197.18ms
+step:3083/4150 train_time:607954ms step_avg:197.20ms
+step:3084/4150 train_time:608193ms step_avg:197.21ms
+step:3085/4150 train_time:608426ms step_avg:197.22ms
+step:3086/4150 train_time:608664ms step_avg:197.23ms
+step:3087/4150 train_time:608899ms step_avg:197.25ms
+step:3088/4150 train_time:609137ms step_avg:197.26ms
+step:3089/4150 train_time:609370ms step_avg:197.27ms
+step:3090/4150 train_time:609607ms step_avg:197.28ms
+step:3091/4150 train_time:609842ms step_avg:197.30ms
+step:3092/4150 train_time:610080ms step_avg:197.31ms
+step:3093/4150 train_time:610315ms step_avg:197.32ms
+step:3094/4150 train_time:610552ms step_avg:197.33ms
+step:3095/4150 train_time:610785ms step_avg:197.35ms
+step:3096/4150 train_time:611021ms step_avg:197.36ms
+step:3097/4150 train_time:611258ms step_avg:197.37ms
+step:3098/4150 train_time:611496ms step_avg:197.38ms
+step:3099/4150 train_time:611730ms step_avg:197.40ms
+step:3100/4150 train_time:611964ms step_avg:197.41ms
+step:3101/4150 train_time:612197ms step_avg:197.42ms
+step:3102/4150 train_time:612434ms step_avg:197.43ms
+step:3103/4150 train_time:612667ms step_avg:197.44ms
+step:3104/4150 train_time:612905ms step_avg:197.46ms
+step:3105/4150 train_time:613139ms step_avg:197.47ms
+step:3106/4150 train_time:613376ms step_avg:197.48ms
+step:3107/4150 train_time:613612ms step_avg:197.49ms
+step:3108/4150 train_time:613849ms step_avg:197.51ms
+step:3109/4150 train_time:614085ms step_avg:197.52ms
+step:3110/4150 train_time:614325ms step_avg:197.53ms
+step:3111/4150 train_time:614561ms step_avg:197.54ms
+step:3112/4150 train_time:614799ms step_avg:197.56ms
+step:3113/4150 train_time:615034ms step_avg:197.57ms
+step:3114/4150 train_time:615274ms step_avg:197.58ms
+step:3115/4150 train_time:615508ms step_avg:197.59ms
+step:3116/4150 train_time:615746ms step_avg:197.61ms
+step:3117/4150 train_time:615980ms step_avg:197.62ms
+step:3118/4150 train_time:616218ms step_avg:197.63ms
+step:3119/4150 train_time:616451ms step_avg:197.64ms
+step:3120/4150 train_time:616693ms step_avg:197.66ms
+step:3121/4150 train_time:616929ms step_avg:197.67ms
+step:3122/4150 train_time:617169ms step_avg:197.68ms
+step:3123/4150 train_time:617403ms step_avg:197.70ms
+step:3124/4150 train_time:617639ms step_avg:197.71ms
+step:3125/4150 train_time:617873ms step_avg:197.72ms
+step:3126/4150 train_time:618108ms step_avg:197.73ms
+step:3127/4150 train_time:618341ms step_avg:197.74ms
+step:3128/4150 train_time:618580ms step_avg:197.76ms
+step:3129/4150 train_time:618813ms step_avg:197.77ms
+step:3130/4150 train_time:619052ms step_avg:197.78ms
+step:3131/4150 train_time:619286ms step_avg:197.79ms
+step:3132/4150 train_time:619521ms step_avg:197.80ms
+step:3133/4150 train_time:619756ms step_avg:197.82ms
+step:3134/4150 train_time:619994ms step_avg:197.83ms
+step:3135/4150 train_time:620230ms step_avg:197.84ms
+step:3136/4150 train_time:620468ms step_avg:197.85ms
+step:3137/4150 train_time:620704ms step_avg:197.87ms
+step:3138/4150 train_time:620943ms step_avg:197.88ms
+step:3139/4150 train_time:621181ms step_avg:197.89ms
+step:3140/4150 train_time:621419ms step_avg:197.90ms
+step:3141/4150 train_time:621655ms step_avg:197.92ms
+step:3142/4150 train_time:621894ms step_avg:197.93ms
+step:3143/4150 train_time:622127ms step_avg:197.94ms
+step:3144/4150 train_time:622367ms step_avg:197.95ms
+step:3145/4150 train_time:622603ms step_avg:197.97ms
+step:3146/4150 train_time:622841ms step_avg:197.98ms
+step:3147/4150 train_time:623074ms step_avg:197.99ms
+step:3148/4150 train_time:623312ms step_avg:198.00ms
+step:3149/4150 train_time:623545ms step_avg:198.01ms
+step:3150/4150 train_time:623785ms step_avg:198.03ms
+step:3151/4150 train_time:624019ms step_avg:198.04ms
+step:3152/4150 train_time:624258ms step_avg:198.05ms
+step:3153/4150 train_time:624492ms step_avg:198.06ms
+step:3154/4150 train_time:624730ms step_avg:198.08ms
+step:3155/4150 train_time:624966ms step_avg:198.09ms
+step:3156/4150 train_time:625205ms step_avg:198.10ms
+step:3157/4150 train_time:625442ms step_avg:198.11ms
+step:3158/4150 train_time:625682ms step_avg:198.13ms
+step:3159/4150 train_time:625917ms step_avg:198.14ms
+step:3160/4150 train_time:626159ms step_avg:198.15ms
+step:3161/4150 train_time:626394ms step_avg:198.16ms
+step:3162/4150 train_time:626631ms step_avg:198.18ms
+step:3163/4150 train_time:626866ms step_avg:198.19ms
+step:3164/4150 train_time:627105ms step_avg:198.20ms
+step:3165/4150 train_time:627340ms step_avg:198.21ms
+step:3166/4150 train_time:627575ms step_avg:198.22ms
+step:3167/4150 train_time:627808ms step_avg:198.23ms
+step:3168/4150 train_time:628045ms step_avg:198.25ms
+step:3169/4150 train_time:628278ms step_avg:198.26ms
+step:3170/4150 train_time:628515ms step_avg:198.27ms
+step:3171/4150 train_time:628749ms step_avg:198.28ms
+step:3172/4150 train_time:628986ms step_avg:198.29ms
+step:3173/4150 train_time:629223ms step_avg:198.31ms
+step:3174/4150 train_time:629461ms step_avg:198.32ms
+step:3175/4150 train_time:629697ms step_avg:198.33ms
+step:3176/4150 train_time:629937ms step_avg:198.34ms
+step:3177/4150 train_time:630171ms step_avg:198.35ms
+step:3178/4150 train_time:630406ms step_avg:198.37ms
+step:3179/4150 train_time:630643ms step_avg:198.38ms
+step:3180/4150 train_time:630882ms step_avg:198.39ms
+step:3181/4150 train_time:631115ms step_avg:198.40ms
+step:3182/4150 train_time:631354ms step_avg:198.41ms
+step:3183/4150 train_time:631590ms step_avg:198.43ms
+step:3184/4150 train_time:631825ms step_avg:198.44ms
+step:3185/4150 train_time:632059ms step_avg:198.45ms
+step:3186/4150 train_time:632296ms step_avg:198.46ms
+step:3187/4150 train_time:632531ms step_avg:198.47ms
+step:3188/4150 train_time:632768ms step_avg:198.48ms
+step:3189/4150 train_time:633003ms step_avg:198.50ms
+step:3190/4150 train_time:633239ms step_avg:198.51ms
+step:3191/4150 train_time:633475ms step_avg:198.52ms
+step:3192/4150 train_time:633711ms step_avg:198.53ms
+step:3193/4150 train_time:633945ms step_avg:198.54ms
+step:3194/4150 train_time:634180ms step_avg:198.55ms
+step:3195/4150 train_time:634417ms step_avg:198.57ms
+step:3196/4150 train_time:634653ms step_avg:198.58ms
+step:3197/4150 train_time:634886ms step_avg:198.59ms
+step:3198/4150 train_time:635122ms step_avg:198.60ms
+step:3199/4150 train_time:635358ms step_avg:198.61ms
+step:3200/4150 train_time:635596ms step_avg:198.62ms
+step:3201/4150 train_time:635830ms step_avg:198.63ms
+step:3202/4150 train_time:636067ms step_avg:198.65ms
+step:3203/4150 train_time:636301ms step_avg:198.66ms
+step:3204/4150 train_time:636540ms step_avg:198.67ms
+step:3205/4150 train_time:636776ms step_avg:198.68ms
+step:3206/4150 train_time:637013ms step_avg:198.69ms
+step:3207/4150 train_time:637245ms step_avg:198.70ms
+step:3208/4150 train_time:637482ms step_avg:198.72ms
+step:3209/4150 train_time:637719ms step_avg:198.73ms
+step:3210/4150 train_time:637955ms step_avg:198.74ms
+step:3211/4150 train_time:638192ms step_avg:198.75ms
+step:3212/4150 train_time:638429ms step_avg:198.76ms
+step:3213/4150 train_time:638663ms step_avg:198.77ms
+step:3214/4150 train_time:638900ms step_avg:198.79ms
+step:3215/4150 train_time:639134ms step_avg:198.80ms
+step:3216/4150 train_time:639370ms step_avg:198.81ms
+step:3217/4150 train_time:639607ms step_avg:198.82ms
+step:3218/4150 train_time:639842ms step_avg:198.83ms
+step:3219/4150 train_time:640078ms step_avg:198.84ms
+step:3220/4150 train_time:640314ms step_avg:198.86ms
+step:3221/4150 train_time:640547ms step_avg:198.87ms
+step:3222/4150 train_time:640782ms step_avg:198.88ms
+step:3223/4150 train_time:641017ms step_avg:198.89ms
+step:3224/4150 train_time:641257ms step_avg:198.90ms
+step:3225/4150 train_time:641491ms step_avg:198.91ms
+step:3226/4150 train_time:641728ms step_avg:198.92ms
+step:3227/4150 train_time:641962ms step_avg:198.93ms
+step:3228/4150 train_time:642201ms step_avg:198.95ms
+step:3229/4150 train_time:642434ms step_avg:198.96ms
+step:3230/4150 train_time:642670ms step_avg:198.97ms
+step:3231/4150 train_time:642904ms step_avg:198.98ms
+step:3232/4150 train_time:643142ms step_avg:198.99ms
+step:3233/4150 train_time:643376ms step_avg:199.00ms
+step:3234/4150 train_time:643613ms step_avg:199.01ms
+step:3235/4150 train_time:643847ms step_avg:199.03ms
+step:3236/4150 train_time:644083ms step_avg:199.04ms
+step:3237/4150 train_time:644315ms step_avg:199.05ms
+step:3238/4150 train_time:644555ms step_avg:199.06ms
+step:3239/4150 train_time:644791ms step_avg:199.07ms
+step:3240/4150 train_time:645026ms step_avg:199.08ms
+step:3241/4150 train_time:645263ms step_avg:199.09ms
+step:3242/4150 train_time:645505ms step_avg:199.11ms
+step:3243/4150 train_time:645737ms step_avg:199.12ms
+step:3244/4150 train_time:645975ms step_avg:199.13ms
+step:3245/4150 train_time:646212ms step_avg:199.14ms
+step:3246/4150 train_time:646450ms step_avg:199.15ms
+step:3247/4150 train_time:646685ms step_avg:199.16ms
+step:3248/4150 train_time:646923ms step_avg:199.18ms
+step:3249/4150 train_time:647161ms step_avg:199.19ms
+step:3250/4150 train_time:647396ms step_avg:199.20ms
+step:3250/4150 val_loss:3.0094 train_time:647613ms step_avg:199.27ms
+step:3251/4150 train_time:647637ms step_avg:199.21ms
+step:3252/4150 train_time:647874ms step_avg:199.22ms
+step:3253/4150 train_time:648110ms step_avg:199.23ms
+step:3254/4150 train_time:648343ms step_avg:199.25ms
+step:3255/4150 train_time:648575ms step_avg:199.26ms
+step:3256/4150 train_time:648817ms step_avg:199.27ms
+step:3257/4150 train_time:649055ms step_avg:199.28ms
+step:3258/4150 train_time:649291ms step_avg:199.29ms
+step:3259/4150 train_time:649521ms step_avg:199.30ms
+step:3260/4150 train_time:649758ms step_avg:199.31ms
+step:3261/4150 train_time:649998ms step_avg:199.32ms
+step:3262/4150 train_time:650236ms step_avg:199.34ms
+step:3263/4150 train_time:650469ms step_avg:199.35ms
+step:3264/4150 train_time:650708ms step_avg:199.36ms
+step:3265/4150 train_time:650944ms step_avg:199.37ms
+step:3266/4150 train_time:651185ms step_avg:199.38ms
+step:3267/4150 train_time:651418ms step_avg:199.39ms
+step:3268/4150 train_time:651654ms step_avg:199.40ms
+step:3269/4150 train_time:651886ms step_avg:199.41ms
+step:3270/4150 train_time:652125ms step_avg:199.43ms
+step:3271/4150 train_time:652360ms step_avg:199.44ms
+step:3272/4150 train_time:652598ms step_avg:199.45ms
+step:3273/4150 train_time:652834ms step_avg:199.46ms
+step:3274/4150 train_time:653072ms step_avg:199.47ms
+step:3275/4150 train_time:653306ms step_avg:199.48ms
+step:3276/4150 train_time:653547ms step_avg:199.50ms
+step:3277/4150 train_time:653782ms step_avg:199.51ms
+step:3278/4150 train_time:654019ms step_avg:199.52ms
+step:3279/4150 train_time:654253ms step_avg:199.53ms
+step:3280/4150 train_time:654491ms step_avg:199.54ms
+step:3281/4150 train_time:654725ms step_avg:199.55ms
+step:3282/4150 train_time:654964ms step_avg:199.56ms
+step:3283/4150 train_time:655197ms step_avg:199.57ms
+step:3284/4150 train_time:655437ms step_avg:199.58ms
+step:3285/4150 train_time:655669ms step_avg:199.59ms
+step:3286/4150 train_time:655905ms step_avg:199.61ms
+step:3287/4150 train_time:656139ms step_avg:199.62ms
+step:3288/4150 train_time:656376ms step_avg:199.63ms
+step:3289/4150 train_time:656609ms step_avg:199.64ms
+step:3290/4150 train_time:656848ms step_avg:199.65ms
+step:3291/4150 train_time:657086ms step_avg:199.66ms
+step:3292/4150 train_time:657323ms step_avg:199.67ms
+step:3293/4150 train_time:657558ms step_avg:199.68ms
+step:3294/4150 train_time:657797ms step_avg:199.70ms
+step:3295/4150 train_time:658036ms step_avg:199.71ms
+step:3296/4150 train_time:658272ms step_avg:199.72ms
+step:3297/4150 train_time:658508ms step_avg:199.73ms
+step:3298/4150 train_time:658748ms step_avg:199.74ms
+step:3299/4150 train_time:658982ms step_avg:199.75ms
+step:3300/4150 train_time:659219ms step_avg:199.76ms
+step:3301/4150 train_time:659454ms step_avg:199.77ms
+step:3302/4150 train_time:659690ms step_avg:199.79ms
+step:3303/4150 train_time:659925ms step_avg:199.80ms
+step:3304/4150 train_time:660160ms step_avg:199.81ms
+step:3305/4150 train_time:660392ms step_avg:199.82ms
+step:3306/4150 train_time:660629ms step_avg:199.83ms
+step:3307/4150 train_time:660862ms step_avg:199.84ms
+step:3308/4150 train_time:661099ms step_avg:199.85ms
+step:3309/4150 train_time:661333ms step_avg:199.86ms
+step:3310/4150 train_time:661570ms step_avg:199.87ms
+step:3311/4150 train_time:661806ms step_avg:199.88ms
+step:3312/4150 train_time:662043ms step_avg:199.89ms
+step:3313/4150 train_time:662276ms step_avg:199.90ms
+step:3314/4150 train_time:662513ms step_avg:199.91ms
+step:3315/4150 train_time:662750ms step_avg:199.92ms
+step:3316/4150 train_time:662987ms step_avg:199.94ms
+step:3317/4150 train_time:663223ms step_avg:199.95ms
+step:3318/4150 train_time:663459ms step_avg:199.96ms
+step:3319/4150 train_time:663697ms step_avg:199.97ms
+step:3320/4150 train_time:663936ms step_avg:199.98ms
+step:3321/4150 train_time:664171ms step_avg:199.99ms
+step:3322/4150 train_time:664407ms step_avg:200.00ms
+step:3323/4150 train_time:664643ms step_avg:200.01ms
+step:3324/4150 train_time:664880ms step_avg:200.02ms
+step:3325/4150 train_time:665114ms step_avg:200.03ms
+step:3326/4150 train_time:665351ms step_avg:200.05ms
+step:3327/4150 train_time:665586ms step_avg:200.06ms
+step:3328/4150 train_time:665824ms step_avg:200.07ms
+step:3329/4150 train_time:666060ms step_avg:200.08ms
+step:3330/4150 train_time:666298ms step_avg:200.09ms
+step:3331/4150 train_time:666534ms step_avg:200.10ms
+step:3332/4150 train_time:666777ms step_avg:200.11ms
+step:3333/4150 train_time:667013ms step_avg:200.12ms
+step:3334/4150 train_time:667249ms step_avg:200.13ms
+step:3335/4150 train_time:667484ms step_avg:200.15ms
+step:3336/4150 train_time:667721ms step_avg:200.16ms
+step:3337/4150 train_time:667955ms step_avg:200.17ms
+step:3338/4150 train_time:668190ms step_avg:200.18ms
+step:3339/4150 train_time:668426ms step_avg:200.19ms
+step:3340/4150 train_time:668662ms step_avg:200.20ms
+step:3341/4150 train_time:668900ms step_avg:200.21ms
+step:3342/4150 train_time:669138ms step_avg:200.22ms
+step:3343/4150 train_time:669374ms step_avg:200.23ms
+step:3344/4150 train_time:669609ms step_avg:200.24ms
+step:3345/4150 train_time:669844ms step_avg:200.25ms
+step:3346/4150 train_time:670084ms step_avg:200.26ms
+step:3347/4150 train_time:670317ms step_avg:200.27ms
+step:3348/4150 train_time:670556ms step_avg:200.29ms
+step:3349/4150 train_time:670790ms step_avg:200.30ms
+step:3350/4150 train_time:671028ms step_avg:200.31ms
+step:3351/4150 train_time:671261ms step_avg:200.32ms
+step:3352/4150 train_time:671500ms step_avg:200.33ms
+step:3353/4150 train_time:671734ms step_avg:200.34ms
+step:3354/4150 train_time:671971ms step_avg:200.35ms
+step:3355/4150 train_time:672207ms step_avg:200.36ms
+step:3356/4150 train_time:672445ms step_avg:200.37ms
+step:3357/4150 train_time:672680ms step_avg:200.38ms
+step:3358/4150 train_time:672917ms step_avg:200.39ms
+step:3359/4150 train_time:673153ms step_avg:200.40ms
+step:3360/4150 train_time:673390ms step_avg:200.41ms
+step:3361/4150 train_time:673625ms step_avg:200.42ms
+step:3362/4150 train_time:673866ms step_avg:200.44ms
+step:3363/4150 train_time:674102ms step_avg:200.45ms
+step:3364/4150 train_time:674342ms step_avg:200.46ms
+step:3365/4150 train_time:674577ms step_avg:200.47ms
+step:3366/4150 train_time:674816ms step_avg:200.48ms
+step:3367/4150 train_time:675048ms step_avg:200.49ms
+step:3368/4150 train_time:675286ms step_avg:200.50ms
+step:3369/4150 train_time:675520ms step_avg:200.51ms
+step:3370/4150 train_time:675760ms step_avg:200.52ms
+step:3371/4150 train_time:675995ms step_avg:200.53ms
+step:3372/4150 train_time:676231ms step_avg:200.54ms
+step:3373/4150 train_time:676465ms step_avg:200.55ms
+step:3374/4150 train_time:676703ms step_avg:200.56ms
+step:3375/4150 train_time:676939ms step_avg:200.57ms
+step:3376/4150 train_time:677179ms step_avg:200.59ms
+step:3377/4150 train_time:677415ms step_avg:200.60ms
+step:3378/4150 train_time:677653ms step_avg:200.61ms
+step:3379/4150 train_time:677888ms step_avg:200.62ms
+step:3380/4150 train_time:678125ms step_avg:200.63ms
+step:3381/4150 train_time:678361ms step_avg:200.64ms
+step:3382/4150 train_time:678597ms step_avg:200.65ms
+step:3383/4150 train_time:678828ms step_avg:200.66ms
+step:3384/4150 train_time:679065ms step_avg:200.67ms
+step:3385/4150 train_time:679303ms step_avg:200.68ms
+step:3386/4150 train_time:679539ms step_avg:200.69ms
+step:3387/4150 train_time:679773ms step_avg:200.70ms
+step:3388/4150 train_time:680013ms step_avg:200.71ms
+step:3389/4150 train_time:680250ms step_avg:200.72ms
+step:3390/4150 train_time:680484ms step_avg:200.73ms
+step:3391/4150 train_time:680719ms step_avg:200.74ms
+step:3392/4150 train_time:680961ms step_avg:200.75ms
+step:3393/4150 train_time:681199ms step_avg:200.77ms
+step:3394/4150 train_time:681435ms step_avg:200.78ms
+step:3395/4150 train_time:681669ms step_avg:200.79ms
+step:3396/4150 train_time:681905ms step_avg:200.80ms
+step:3397/4150 train_time:682140ms step_avg:200.81ms
+step:3398/4150 train_time:682377ms step_avg:200.82ms
+step:3399/4150 train_time:682610ms step_avg:200.83ms
+step:3400/4150 train_time:682849ms step_avg:200.84ms
+step:3401/4150 train_time:683084ms step_avg:200.85ms
+step:3402/4150 train_time:683324ms step_avg:200.86ms
+step:3403/4150 train_time:683560ms step_avg:200.87ms
+step:3404/4150 train_time:683798ms step_avg:200.88ms
+step:3405/4150 train_time:684031ms step_avg:200.89ms
+step:3406/4150 train_time:684269ms step_avg:200.90ms
+step:3407/4150 train_time:684503ms step_avg:200.91ms
+step:3408/4150 train_time:684741ms step_avg:200.92ms
+step:3409/4150 train_time:684978ms step_avg:200.93ms
+step:3410/4150 train_time:685221ms step_avg:200.94ms
+step:3411/4150 train_time:685456ms step_avg:200.95ms
+step:3412/4150 train_time:685696ms step_avg:200.97ms
+step:3413/4150 train_time:685932ms step_avg:200.98ms
+step:3414/4150 train_time:686172ms step_avg:200.99ms
+step:3415/4150 train_time:686405ms step_avg:201.00ms
+step:3416/4150 train_time:686641ms step_avg:201.01ms
+step:3417/4150 train_time:686876ms step_avg:201.02ms
+step:3418/4150 train_time:687114ms step_avg:201.03ms
+step:3419/4150 train_time:687351ms step_avg:201.04ms
+step:3420/4150 train_time:687586ms step_avg:201.05ms
+step:3421/4150 train_time:687820ms step_avg:201.06ms
+step:3422/4150 train_time:688058ms step_avg:201.07ms
+step:3423/4150 train_time:688294ms step_avg:201.08ms
+step:3424/4150 train_time:688531ms step_avg:201.09ms
+step:3425/4150 train_time:688762ms step_avg:201.10ms
+step:3426/4150 train_time:688999ms step_avg:201.11ms
+step:3427/4150 train_time:689233ms step_avg:201.12ms
+step:3428/4150 train_time:689472ms step_avg:201.13ms
+step:3429/4150 train_time:689707ms step_avg:201.14ms
+step:3430/4150 train_time:689944ms step_avg:201.15ms
+step:3431/4150 train_time:690184ms step_avg:201.16ms
+step:3432/4150 train_time:690422ms step_avg:201.17ms
+step:3433/4150 train_time:690655ms step_avg:201.18ms
+step:3434/4150 train_time:690891ms step_avg:201.19ms
+step:3435/4150 train_time:691124ms step_avg:201.20ms
+step:3436/4150 train_time:691363ms step_avg:201.21ms
+step:3437/4150 train_time:691600ms step_avg:201.22ms
+step:3438/4150 train_time:691838ms step_avg:201.23ms
+step:3439/4150 train_time:692072ms step_avg:201.24ms
+step:3440/4150 train_time:692313ms step_avg:201.25ms
+step:3441/4150 train_time:692552ms step_avg:201.26ms
+step:3442/4150 train_time:692788ms step_avg:201.27ms
+step:3443/4150 train_time:693020ms step_avg:201.28ms
+step:3444/4150 train_time:693256ms step_avg:201.29ms
+step:3445/4150 train_time:693495ms step_avg:201.30ms
+step:3446/4150 train_time:693733ms step_avg:201.32ms
+step:3447/4150 train_time:693965ms step_avg:201.32ms
+step:3448/4150 train_time:694202ms step_avg:201.33ms
+step:3449/4150 train_time:694435ms step_avg:201.34ms
+step:3450/4150 train_time:694672ms step_avg:201.35ms
+step:3451/4150 train_time:694903ms step_avg:201.36ms
+step:3452/4150 train_time:695140ms step_avg:201.37ms
+step:3453/4150 train_time:695377ms step_avg:201.38ms
+step:3454/4150 train_time:695618ms step_avg:201.39ms
+step:3455/4150 train_time:695857ms step_avg:201.41ms
+step:3456/4150 train_time:696095ms step_avg:201.42ms
+step:3457/4150 train_time:696329ms step_avg:201.43ms
+step:3458/4150 train_time:696569ms step_avg:201.44ms
+step:3459/4150 train_time:696805ms step_avg:201.45ms
+step:3460/4150 train_time:697043ms step_avg:201.46ms
+step:3461/4150 train_time:697273ms step_avg:201.47ms
+step:3462/4150 train_time:697512ms step_avg:201.48ms
+step:3463/4150 train_time:697746ms step_avg:201.49ms
+step:3464/4150 train_time:697984ms step_avg:201.50ms
+step:3465/4150 train_time:698218ms step_avg:201.51ms
+step:3466/4150 train_time:698457ms step_avg:201.52ms
+step:3467/4150 train_time:698693ms step_avg:201.53ms
+step:3468/4150 train_time:698931ms step_avg:201.54ms
+step:3469/4150 train_time:699163ms step_avg:201.55ms
+step:3470/4150 train_time:699398ms step_avg:201.56ms
+step:3471/4150 train_time:699633ms step_avg:201.57ms
+step:3472/4150 train_time:699871ms step_avg:201.58ms
+step:3473/4150 train_time:700104ms step_avg:201.58ms
+step:3474/4150 train_time:700338ms step_avg:201.59ms
+step:3475/4150 train_time:700572ms step_avg:201.60ms
+step:3476/4150 train_time:700811ms step_avg:201.61ms
+step:3477/4150 train_time:701045ms step_avg:201.62ms
+step:3478/4150 train_time:701281ms step_avg:201.63ms
+step:3479/4150 train_time:701515ms step_avg:201.64ms
+step:3480/4150 train_time:701756ms step_avg:201.65ms
+step:3481/4150 train_time:701989ms step_avg:201.66ms
+step:3482/4150 train_time:702226ms step_avg:201.67ms
+step:3483/4150 train_time:702458ms step_avg:201.68ms
+step:3484/4150 train_time:702692ms step_avg:201.69ms
+step:3485/4150 train_time:702929ms step_avg:201.70ms
+step:3486/4150 train_time:703170ms step_avg:201.71ms
+step:3487/4150 train_time:703406ms step_avg:201.72ms
+step:3488/4150 train_time:703641ms step_avg:201.73ms
+step:3489/4150 train_time:703880ms step_avg:201.74ms
+step:3490/4150 train_time:704116ms step_avg:201.75ms
+step:3491/4150 train_time:704352ms step_avg:201.76ms
+step:3492/4150 train_time:704588ms step_avg:201.77ms
+step:3493/4150 train_time:704822ms step_avg:201.78ms
+step:3494/4150 train_time:705060ms step_avg:201.79ms
+step:3495/4150 train_time:705299ms step_avg:201.80ms
+step:3496/4150 train_time:705537ms step_avg:201.81ms
+step:3497/4150 train_time:705771ms step_avg:201.82ms
+step:3498/4150 train_time:706006ms step_avg:201.83ms
+step:3499/4150 train_time:706239ms step_avg:201.84ms
+step:3500/4150 train_time:706477ms step_avg:201.85ms
+step:3500/4150 val_loss:2.9782 train_time:706693ms step_avg:201.91ms
+step:3501/4150 train_time:706718ms step_avg:201.86ms
+step:3502/4150 train_time:706957ms step_avg:201.87ms
+step:3503/4150 train_time:707195ms step_avg:201.88ms
+step:3504/4150 train_time:707429ms step_avg:201.89ms
+step:3505/4150 train_time:707659ms step_avg:201.90ms
+step:3506/4150 train_time:707899ms step_avg:201.91ms
+step:3507/4150 train_time:708137ms step_avg:201.92ms
+step:3508/4150 train_time:708375ms step_avg:201.93ms
+step:3509/4150 train_time:708605ms step_avg:201.94ms
+step:3510/4150 train_time:708845ms step_avg:201.95ms
+step:3511/4150 train_time:709086ms step_avg:201.96ms
+step:3512/4150 train_time:709322ms step_avg:201.97ms
+step:3513/4150 train_time:709556ms step_avg:201.98ms
+step:3514/4150 train_time:709792ms step_avg:201.99ms
+step:3515/4150 train_time:710029ms step_avg:202.00ms
+step:3516/4150 train_time:710268ms step_avg:202.01ms
+step:3517/4150 train_time:710503ms step_avg:202.02ms
+step:3518/4150 train_time:710738ms step_avg:202.03ms
+step:3519/4150 train_time:710972ms step_avg:202.04ms
+step:3520/4150 train_time:711209ms step_avg:202.05ms
+step:3521/4150 train_time:711443ms step_avg:202.06ms
+step:3522/4150 train_time:711680ms step_avg:202.07ms
+step:3523/4150 train_time:711918ms step_avg:202.08ms
+step:3524/4150 train_time:712154ms step_avg:202.09ms
+step:3525/4150 train_time:712386ms step_avg:202.10ms
+step:3526/4150 train_time:712621ms step_avg:202.10ms
+step:3527/4150 train_time:712857ms step_avg:202.11ms
+step:3528/4150 train_time:713096ms step_avg:202.12ms
+step:3529/4150 train_time:713332ms step_avg:202.13ms
+step:3530/4150 train_time:713566ms step_avg:202.14ms
+step:3531/4150 train_time:713799ms step_avg:202.15ms
+step:3532/4150 train_time:714038ms step_avg:202.16ms
+step:3533/4150 train_time:714272ms step_avg:202.17ms
+step:3534/4150 train_time:714511ms step_avg:202.18ms
+step:3535/4150 train_time:714744ms step_avg:202.19ms
+step:3536/4150 train_time:714983ms step_avg:202.20ms
+step:3537/4150 train_time:715219ms step_avg:202.21ms
+step:3538/4150 train_time:715456ms step_avg:202.22ms
+step:3539/4150 train_time:715691ms step_avg:202.23ms
+step:3540/4150 train_time:715930ms step_avg:202.24ms
+step:3541/4150 train_time:716165ms step_avg:202.25ms
+step:3542/4150 train_time:716402ms step_avg:202.26ms
+step:3543/4150 train_time:716636ms step_avg:202.27ms
+step:3544/4150 train_time:716873ms step_avg:202.28ms
+step:3545/4150 train_time:717109ms step_avg:202.29ms
+step:3546/4150 train_time:717347ms step_avg:202.30ms
+step:3547/4150 train_time:717581ms step_avg:202.31ms
+step:3548/4150 train_time:717818ms step_avg:202.32ms
+step:3549/4150 train_time:718052ms step_avg:202.33ms
+step:3550/4150 train_time:718287ms step_avg:202.33ms
+step:3551/4150 train_time:718522ms step_avg:202.34ms
+step:3552/4150 train_time:718759ms step_avg:202.35ms
+step:3553/4150 train_time:718993ms step_avg:202.36ms
+step:3554/4150 train_time:719231ms step_avg:202.37ms
+step:3555/4150 train_time:719470ms step_avg:202.38ms
+step:3556/4150 train_time:719705ms step_avg:202.39ms
+step:3557/4150 train_time:719938ms step_avg:202.40ms
+step:3558/4150 train_time:720177ms step_avg:202.41ms
+step:3559/4150 train_time:720413ms step_avg:202.42ms
+step:3560/4150 train_time:720650ms step_avg:202.43ms
+step:3561/4150 train_time:720885ms step_avg:202.44ms
+step:3562/4150 train_time:721123ms step_avg:202.45ms
+step:3563/4150 train_time:721359ms step_avg:202.46ms
+step:3564/4150 train_time:721595ms step_avg:202.47ms
+step:3565/4150 train_time:721832ms step_avg:202.48ms
+step:3566/4150 train_time:722070ms step_avg:202.49ms
+step:3567/4150 train_time:722305ms step_avg:202.50ms
+step:3568/4150 train_time:722543ms step_avg:202.51ms
+step:3569/4150 train_time:722776ms step_avg:202.52ms
+step:3570/4150 train_time:723013ms step_avg:202.52ms
+step:3571/4150 train_time:723246ms step_avg:202.53ms
+step:3572/4150 train_time:723482ms step_avg:202.54ms
+step:3573/4150 train_time:723717ms step_avg:202.55ms
+step:3574/4150 train_time:723956ms step_avg:202.56ms
+step:3575/4150 train_time:724189ms step_avg:202.57ms
+step:3576/4150 train_time:724427ms step_avg:202.58ms
+step:3577/4150 train_time:724660ms step_avg:202.59ms
+step:3578/4150 train_time:724896ms step_avg:202.60ms
+step:3579/4150 train_time:725131ms step_avg:202.61ms
+step:3580/4150 train_time:725370ms step_avg:202.62ms
+step:3581/4150 train_time:725608ms step_avg:202.63ms
+step:3582/4150 train_time:725845ms step_avg:202.64ms
+step:3583/4150 train_time:726080ms step_avg:202.65ms
+step:3584/4150 train_time:726317ms step_avg:202.66ms
+step:3585/4150 train_time:726554ms step_avg:202.66ms
+step:3586/4150 train_time:726790ms step_avg:202.67ms
+step:3587/4150 train_time:727023ms step_avg:202.68ms
+step:3588/4150 train_time:727261ms step_avg:202.69ms
+step:3589/4150 train_time:727498ms step_avg:202.70ms
+step:3590/4150 train_time:727735ms step_avg:202.71ms
+step:3591/4150 train_time:727973ms step_avg:202.72ms
+step:3592/4150 train_time:728214ms step_avg:202.73ms
+step:3593/4150 train_time:728451ms step_avg:202.74ms
+step:3594/4150 train_time:728687ms step_avg:202.75ms
+step:3595/4150 train_time:728921ms step_avg:202.76ms
+step:3596/4150 train_time:729158ms step_avg:202.77ms
+step:3597/4150 train_time:729393ms step_avg:202.78ms
+step:3598/4150 train_time:729631ms step_avg:202.79ms
+step:3599/4150 train_time:729862ms step_avg:202.80ms
+step:3600/4150 train_time:730099ms step_avg:202.81ms
+step:3601/4150 train_time:730333ms step_avg:202.81ms
+step:3602/4150 train_time:730573ms step_avg:202.82ms
+step:3603/4150 train_time:730809ms step_avg:202.83ms
+step:3604/4150 train_time:731050ms step_avg:202.84ms
+step:3605/4150 train_time:731284ms step_avg:202.85ms
+step:3606/4150 train_time:731523ms step_avg:202.86ms
+step:3607/4150 train_time:731758ms step_avg:202.87ms
+step:3608/4150 train_time:731996ms step_avg:202.88ms
+step:3609/4150 train_time:732231ms step_avg:202.89ms
+step:3610/4150 train_time:732471ms step_avg:202.90ms
+step:3611/4150 train_time:732704ms step_avg:202.91ms
+step:3612/4150 train_time:732941ms step_avg:202.92ms
+step:3613/4150 train_time:733175ms step_avg:202.93ms
+step:3614/4150 train_time:733414ms step_avg:202.94ms
+step:3615/4150 train_time:733646ms step_avg:202.94ms
+step:3616/4150 train_time:733884ms step_avg:202.95ms
+step:3617/4150 train_time:734119ms step_avg:202.96ms
+step:3618/4150 train_time:734356ms step_avg:202.97ms
+step:3619/4150 train_time:734593ms step_avg:202.98ms
+step:3620/4150 train_time:734829ms step_avg:202.99ms
+step:3621/4150 train_time:735067ms step_avg:203.00ms
+step:3622/4150 train_time:735304ms step_avg:203.01ms
+step:3623/4150 train_time:735539ms step_avg:203.02ms
+step:3624/4150 train_time:735776ms step_avg:203.03ms
+step:3625/4150 train_time:736009ms step_avg:203.04ms
+step:3626/4150 train_time:736246ms step_avg:203.05ms
+step:3627/4150 train_time:736479ms step_avg:203.05ms
+step:3628/4150 train_time:736716ms step_avg:203.06ms
+step:3629/4150 train_time:736951ms step_avg:203.07ms
+step:3630/4150 train_time:737188ms step_avg:203.08ms
+step:3631/4150 train_time:737421ms step_avg:203.09ms
+step:3632/4150 train_time:737661ms step_avg:203.10ms
+step:3633/4150 train_time:737894ms step_avg:203.11ms
+step:3634/4150 train_time:738128ms step_avg:203.12ms
+step:3635/4150 train_time:738363ms step_avg:203.13ms
+step:3636/4150 train_time:738602ms step_avg:203.14ms
+step:3637/4150 train_time:738835ms step_avg:203.14ms
+step:3638/4150 train_time:739071ms step_avg:203.15ms
+step:3639/4150 train_time:739305ms step_avg:203.16ms
+step:3640/4150 train_time:739543ms step_avg:203.17ms
+step:3641/4150 train_time:739777ms step_avg:203.18ms
+step:3642/4150 train_time:740014ms step_avg:203.19ms
+step:3643/4150 train_time:740247ms step_avg:203.20ms
+step:3644/4150 train_time:740490ms step_avg:203.21ms
+step:3645/4150 train_time:740723ms step_avg:203.22ms
+step:3646/4150 train_time:740962ms step_avg:203.23ms
+step:3647/4150 train_time:741194ms step_avg:203.23ms
+step:3648/4150 train_time:741431ms step_avg:203.24ms
+step:3649/4150 train_time:741665ms step_avg:203.25ms
+step:3650/4150 train_time:741903ms step_avg:203.26ms
+step:3651/4150 train_time:742136ms step_avg:203.27ms
+step:3652/4150 train_time:742374ms step_avg:203.28ms
+step:3653/4150 train_time:742607ms step_avg:203.29ms
+step:3654/4150 train_time:742846ms step_avg:203.30ms
+step:3655/4150 train_time:743079ms step_avg:203.30ms
+step:3656/4150 train_time:743315ms step_avg:203.31ms
+step:3657/4150 train_time:743553ms step_avg:203.32ms
+step:3658/4150 train_time:743791ms step_avg:203.33ms
+step:3659/4150 train_time:744024ms step_avg:203.34ms
+step:3660/4150 train_time:744262ms step_avg:203.35ms
+step:3661/4150 train_time:744495ms step_avg:203.36ms
+step:3662/4150 train_time:744732ms step_avg:203.37ms
+step:3663/4150 train_time:744965ms step_avg:203.38ms
+step:3664/4150 train_time:745204ms step_avg:203.39ms
+step:3665/4150 train_time:745438ms step_avg:203.39ms
+step:3666/4150 train_time:745675ms step_avg:203.40ms
+step:3667/4150 train_time:745912ms step_avg:203.41ms
+step:3668/4150 train_time:746150ms step_avg:203.42ms
+step:3669/4150 train_time:746387ms step_avg:203.43ms
+step:3670/4150 train_time:746625ms step_avg:203.44ms
+step:3671/4150 train_time:746859ms step_avg:203.45ms
+step:3672/4150 train_time:747096ms step_avg:203.46ms
+step:3673/4150 train_time:747331ms step_avg:203.47ms
+step:3674/4150 train_time:747571ms step_avg:203.48ms
+step:3675/4150 train_time:747808ms step_avg:203.49ms
+step:3676/4150 train_time:748045ms step_avg:203.49ms
+step:3677/4150 train_time:748279ms step_avg:203.50ms
+step:3678/4150 train_time:748517ms step_avg:203.51ms
+step:3679/4150 train_time:748754ms step_avg:203.52ms
+step:3680/4150 train_time:748987ms step_avg:203.53ms
+step:3681/4150 train_time:749219ms step_avg:203.54ms
+step:3682/4150 train_time:749457ms step_avg:203.55ms
+step:3683/4150 train_time:749693ms step_avg:203.56ms
+step:3684/4150 train_time:749933ms step_avg:203.56ms
+step:3685/4150 train_time:750167ms step_avg:203.57ms
+step:3686/4150 train_time:750402ms step_avg:203.58ms
+step:3687/4150 train_time:750637ms step_avg:203.59ms
+step:3688/4150 train_time:750873ms step_avg:203.60ms
+step:3689/4150 train_time:751107ms step_avg:203.61ms
+step:3690/4150 train_time:751348ms step_avg:203.62ms
+step:3691/4150 train_time:751583ms step_avg:203.63ms
+step:3692/4150 train_time:751819ms step_avg:203.63ms
+step:3693/4150 train_time:752052ms step_avg:203.64ms
+step:3694/4150 train_time:752290ms step_avg:203.65ms
+step:3695/4150 train_time:752523ms step_avg:203.66ms
+step:3696/4150 train_time:752762ms step_avg:203.67ms
+step:3697/4150 train_time:752994ms step_avg:203.68ms
+step:3698/4150 train_time:753233ms step_avg:203.69ms
+step:3699/4150 train_time:753467ms step_avg:203.69ms
+step:3700/4150 train_time:753704ms step_avg:203.70ms
+step:3701/4150 train_time:753939ms step_avg:203.71ms
+step:3702/4150 train_time:754178ms step_avg:203.72ms
+step:3703/4150 train_time:754409ms step_avg:203.73ms
+step:3704/4150 train_time:754648ms step_avg:203.74ms
+step:3705/4150 train_time:754882ms step_avg:203.75ms
+step:3706/4150 train_time:755120ms step_avg:203.76ms
+step:3707/4150 train_time:755351ms step_avg:203.76ms
+step:3708/4150 train_time:755590ms step_avg:203.77ms
+step:3709/4150 train_time:755823ms step_avg:203.78ms
+step:3710/4150 train_time:756061ms step_avg:203.79ms
+step:3711/4150 train_time:756295ms step_avg:203.80ms
+step:3712/4150 train_time:756533ms step_avg:203.81ms
+step:3713/4150 train_time:756766ms step_avg:203.82ms
+step:3714/4150 train_time:757002ms step_avg:203.82ms
+step:3715/4150 train_time:757238ms step_avg:203.83ms
+step:3716/4150 train_time:757475ms step_avg:203.84ms
+step:3717/4150 train_time:757712ms step_avg:203.85ms
+step:3718/4150 train_time:757947ms step_avg:203.86ms
+step:3719/4150 train_time:758182ms step_avg:203.87ms
+step:3720/4150 train_time:758422ms step_avg:203.88ms
+step:3721/4150 train_time:758656ms step_avg:203.89ms
+step:3722/4150 train_time:758894ms step_avg:203.89ms
+step:3723/4150 train_time:759126ms step_avg:203.90ms
+step:3724/4150 train_time:759365ms step_avg:203.91ms
+step:3725/4150 train_time:759602ms step_avg:203.92ms
+step:3726/4150 train_time:759838ms step_avg:203.93ms
+step:3727/4150 train_time:760072ms step_avg:203.94ms
+step:3728/4150 train_time:760311ms step_avg:203.95ms
+step:3729/4150 train_time:760551ms step_avg:203.96ms
+step:3730/4150 train_time:760786ms step_avg:203.96ms
+step:3731/4150 train_time:761020ms step_avg:203.97ms
+step:3732/4150 train_time:761259ms step_avg:203.98ms
+step:3733/4150 train_time:761494ms step_avg:203.99ms
+step:3734/4150 train_time:761732ms step_avg:204.00ms
+step:3735/4150 train_time:761968ms step_avg:204.01ms
+step:3736/4150 train_time:762204ms step_avg:204.02ms
+step:3737/4150 train_time:762437ms step_avg:204.02ms
+step:3738/4150 train_time:762679ms step_avg:204.03ms
+step:3739/4150 train_time:762914ms step_avg:204.04ms
+step:3740/4150 train_time:763154ms step_avg:204.05ms
+step:3741/4150 train_time:763392ms step_avg:204.06ms
+step:3742/4150 train_time:763626ms step_avg:204.07ms
+step:3743/4150 train_time:763860ms step_avg:204.08ms
+step:3744/4150 train_time:764095ms step_avg:204.09ms
+step:3745/4150 train_time:764334ms step_avg:204.09ms
+step:3746/4150 train_time:764570ms step_avg:204.10ms
+step:3747/4150 train_time:764805ms step_avg:204.11ms
+step:3748/4150 train_time:765041ms step_avg:204.12ms
+step:3749/4150 train_time:765275ms step_avg:204.13ms
+step:3750/4150 train_time:765511ms step_avg:204.14ms
+step:3750/4150 val_loss:2.9508 train_time:765730ms step_avg:204.19ms
+step:3751/4150 train_time:765753ms step_avg:204.15ms
+step:3752/4150 train_time:765992ms step_avg:204.16ms
+step:3753/4150 train_time:766224ms step_avg:204.16ms
+step:3754/4150 train_time:766459ms step_avg:204.17ms
+step:3755/4150 train_time:766694ms step_avg:204.18ms
+step:3756/4150 train_time:766937ms step_avg:204.19ms
+step:3757/4150 train_time:767175ms step_avg:204.20ms
+step:3758/4150 train_time:767409ms step_avg:204.21ms
+step:3759/4150 train_time:767640ms step_avg:204.21ms
+step:3760/4150 train_time:767878ms step_avg:204.22ms
+step:3761/4150 train_time:768118ms step_avg:204.23ms
+step:3762/4150 train_time:768354ms step_avg:204.24ms
+step:3763/4150 train_time:768584ms step_avg:204.25ms
+step:3764/4150 train_time:768821ms step_avg:204.26ms
+step:3765/4150 train_time:769057ms step_avg:204.26ms
+step:3766/4150 train_time:769297ms step_avg:204.27ms
+step:3767/4150 train_time:769532ms step_avg:204.28ms
+step:3768/4150 train_time:769767ms step_avg:204.29ms
+step:3769/4150 train_time:770005ms step_avg:204.30ms
+step:3770/4150 train_time:770241ms step_avg:204.31ms
+step:3771/4150 train_time:770476ms step_avg:204.32ms
+step:3772/4150 train_time:770716ms step_avg:204.33ms
+step:3773/4150 train_time:770949ms step_avg:204.33ms
+step:3774/4150 train_time:771187ms step_avg:204.34ms
+step:3775/4150 train_time:771426ms step_avg:204.35ms
+step:3776/4150 train_time:771665ms step_avg:204.36ms
+step:3777/4150 train_time:771904ms step_avg:204.37ms
+step:3778/4150 train_time:772143ms step_avg:204.38ms
+step:3779/4150 train_time:772377ms step_avg:204.39ms
+step:3780/4150 train_time:772614ms step_avg:204.40ms
+step:3781/4150 train_time:772846ms step_avg:204.40ms
+step:3782/4150 train_time:773084ms step_avg:204.41ms
+step:3783/4150 train_time:773317ms step_avg:204.42ms
+step:3784/4150 train_time:773554ms step_avg:204.43ms
+step:3785/4150 train_time:773788ms step_avg:204.44ms
+step:3786/4150 train_time:774028ms step_avg:204.44ms
+step:3787/4150 train_time:774263ms step_avg:204.45ms
+step:3788/4150 train_time:774500ms step_avg:204.46ms
+step:3789/4150 train_time:774736ms step_avg:204.47ms
+step:3790/4150 train_time:774977ms step_avg:204.48ms
+step:3791/4150 train_time:775212ms step_avg:204.49ms
+step:3792/4150 train_time:775447ms step_avg:204.50ms
+step:3793/4150 train_time:775680ms step_avg:204.50ms
+step:3794/4150 train_time:775916ms step_avg:204.51ms
+step:3795/4150 train_time:776153ms step_avg:204.52ms
+step:3796/4150 train_time:776392ms step_avg:204.53ms
+step:3797/4150 train_time:776624ms step_avg:204.54ms
+step:3798/4150 train_time:776861ms step_avg:204.54ms
+step:3799/4150 train_time:777097ms step_avg:204.55ms
+step:3800/4150 train_time:777332ms step_avg:204.56ms
+step:3801/4150 train_time:777565ms step_avg:204.57ms
+step:3802/4150 train_time:777804ms step_avg:204.58ms
+step:3803/4150 train_time:778039ms step_avg:204.59ms
+step:3804/4150 train_time:778276ms step_avg:204.59ms
+step:3805/4150 train_time:778510ms step_avg:204.60ms
+step:3806/4150 train_time:778748ms step_avg:204.61ms
+step:3807/4150 train_time:778980ms step_avg:204.62ms
+step:3808/4150 train_time:779218ms step_avg:204.63ms
+step:3809/4150 train_time:779452ms step_avg:204.63ms
+step:3810/4150 train_time:779689ms step_avg:204.64ms
+step:3811/4150 train_time:779922ms step_avg:204.65ms
+step:3812/4150 train_time:780158ms step_avg:204.66ms
+step:3813/4150 train_time:780394ms step_avg:204.67ms
+step:3814/4150 train_time:780634ms step_avg:204.68ms
+step:3815/4150 train_time:780865ms step_avg:204.68ms
+step:3816/4150 train_time:781101ms step_avg:204.69ms
+step:3817/4150 train_time:781335ms step_avg:204.70ms
+step:3818/4150 train_time:781573ms step_avg:204.71ms
+step:3819/4150 train_time:781806ms step_avg:204.71ms
+step:3820/4150 train_time:782043ms step_avg:204.72ms
+step:3821/4150 train_time:782278ms step_avg:204.73ms
+step:3822/4150 train_time:782515ms step_avg:204.74ms
+step:3823/4150 train_time:782748ms step_avg:204.75ms
+step:3824/4150 train_time:782986ms step_avg:204.76ms
+step:3825/4150 train_time:783221ms step_avg:204.76ms
+step:3826/4150 train_time:783461ms step_avg:204.77ms
+step:3827/4150 train_time:783699ms step_avg:204.78ms
+step:3828/4150 train_time:783934ms step_avg:204.79ms
+step:3829/4150 train_time:784170ms step_avg:204.80ms
+step:3830/4150 train_time:784409ms step_avg:204.81ms
+step:3831/4150 train_time:784647ms step_avg:204.82ms
+step:3832/4150 train_time:784884ms step_avg:204.82ms
+step:3833/4150 train_time:785116ms step_avg:204.83ms
+step:3834/4150 train_time:785357ms step_avg:204.84ms
+step:3835/4150 train_time:785589ms step_avg:204.85ms
+step:3836/4150 train_time:785827ms step_avg:204.86ms
+step:3837/4150 train_time:786060ms step_avg:204.86ms
+step:3838/4150 train_time:786299ms step_avg:204.87ms
+step:3839/4150 train_time:786536ms step_avg:204.88ms
+step:3840/4150 train_time:786774ms step_avg:204.89ms
+step:3841/4150 train_time:787008ms step_avg:204.90ms
+step:3842/4150 train_time:787246ms step_avg:204.91ms
+step:3843/4150 train_time:787480ms step_avg:204.91ms
+step:3844/4150 train_time:787715ms step_avg:204.92ms
+step:3845/4150 train_time:787951ms step_avg:204.93ms
+step:3846/4150 train_time:788188ms step_avg:204.94ms
+step:3847/4150 train_time:788422ms step_avg:204.94ms
+step:3848/4150 train_time:788660ms step_avg:204.95ms
+step:3849/4150 train_time:788892ms step_avg:204.96ms
+step:3850/4150 train_time:789127ms step_avg:204.97ms
+step:3851/4150 train_time:789361ms step_avg:204.98ms
+step:3852/4150 train_time:789598ms step_avg:204.98ms
+step:3853/4150 train_time:789836ms step_avg:204.99ms
+step:3854/4150 train_time:790075ms step_avg:205.00ms
+step:3855/4150 train_time:790308ms step_avg:205.01ms
+step:3856/4150 train_time:790545ms step_avg:205.02ms
+step:3857/4150 train_time:790779ms step_avg:205.02ms
+step:3858/4150 train_time:791018ms step_avg:205.03ms
+step:3859/4150 train_time:791251ms step_avg:205.04ms
+step:3860/4150 train_time:791491ms step_avg:205.05ms
+step:3861/4150 train_time:791724ms step_avg:205.06ms
+step:3862/4150 train_time:791962ms step_avg:205.07ms
+step:3863/4150 train_time:792195ms step_avg:205.07ms
+step:3864/4150 train_time:792431ms step_avg:205.08ms
+step:3865/4150 train_time:792667ms step_avg:205.09ms
+step:3866/4150 train_time:792907ms step_avg:205.10ms
+step:3867/4150 train_time:793140ms step_avg:205.10ms
+step:3868/4150 train_time:793382ms step_avg:205.11ms
+step:3869/4150 train_time:793615ms step_avg:205.12ms
+step:3870/4150 train_time:793852ms step_avg:205.13ms
+step:3871/4150 train_time:794086ms step_avg:205.14ms
+step:3872/4150 train_time:794323ms step_avg:205.15ms
+step:3873/4150 train_time:794561ms step_avg:205.15ms
+step:3874/4150 train_time:794796ms step_avg:205.16ms
+step:3875/4150 train_time:795031ms step_avg:205.17ms
+step:3876/4150 train_time:795270ms step_avg:205.18ms
+step:3877/4150 train_time:795503ms step_avg:205.19ms
+step:3878/4150 train_time:795739ms step_avg:205.19ms
+step:3879/4150 train_time:795977ms step_avg:205.20ms
+step:3880/4150 train_time:796215ms step_avg:205.21ms
+step:3881/4150 train_time:796450ms step_avg:205.22ms
+step:3882/4150 train_time:796684ms step_avg:205.23ms
+step:3883/4150 train_time:796919ms step_avg:205.23ms
+step:3884/4150 train_time:797156ms step_avg:205.24ms
+step:3885/4150 train_time:797392ms step_avg:205.25ms
+step:3886/4150 train_time:797629ms step_avg:205.26ms
+step:3887/4150 train_time:797863ms step_avg:205.26ms
+step:3888/4150 train_time:798102ms step_avg:205.27ms
+step:3889/4150 train_time:798336ms step_avg:205.28ms
+step:3890/4150 train_time:798575ms step_avg:205.29ms
+step:3891/4150 train_time:798810ms step_avg:205.30ms
+step:3892/4150 train_time:799050ms step_avg:205.31ms
+step:3893/4150 train_time:799285ms step_avg:205.31ms
+step:3894/4150 train_time:799522ms step_avg:205.32ms
+step:3895/4150 train_time:799758ms step_avg:205.33ms
+step:3896/4150 train_time:799995ms step_avg:205.34ms
+step:3897/4150 train_time:800230ms step_avg:205.35ms
+step:3898/4150 train_time:800469ms step_avg:205.35ms
+step:3899/4150 train_time:800704ms step_avg:205.36ms
+step:3900/4150 train_time:800942ms step_avg:205.37ms
+step:3901/4150 train_time:801175ms step_avg:205.38ms
+step:3902/4150 train_time:801415ms step_avg:205.39ms
+step:3903/4150 train_time:801648ms step_avg:205.39ms
+step:3904/4150 train_time:801885ms step_avg:205.40ms
+step:3905/4150 train_time:802118ms step_avg:205.41ms
+step:3906/4150 train_time:802356ms step_avg:205.42ms
+step:3907/4150 train_time:802588ms step_avg:205.42ms
+step:3908/4150 train_time:802825ms step_avg:205.43ms
+step:3909/4150 train_time:803063ms step_avg:205.44ms
+step:3910/4150 train_time:803300ms step_avg:205.45ms
+step:3911/4150 train_time:803540ms step_avg:205.46ms
+step:3912/4150 train_time:803775ms step_avg:205.46ms
+step:3913/4150 train_time:804011ms step_avg:205.47ms
+step:3914/4150 train_time:804251ms step_avg:205.48ms
+step:3915/4150 train_time:804486ms step_avg:205.49ms
+step:3916/4150 train_time:804723ms step_avg:205.50ms
+step:3917/4150 train_time:804960ms step_avg:205.50ms
+step:3918/4150 train_time:805196ms step_avg:205.51ms
+step:3919/4150 train_time:805432ms step_avg:205.52ms
+step:3920/4150 train_time:805669ms step_avg:205.53ms
+step:3921/4150 train_time:805904ms step_avg:205.54ms
+step:3922/4150 train_time:806142ms step_avg:205.54ms
+step:3923/4150 train_time:806376ms step_avg:205.55ms
+step:3924/4150 train_time:806615ms step_avg:205.56ms
+step:3925/4150 train_time:806848ms step_avg:205.57ms
+step:3926/4150 train_time:807086ms step_avg:205.57ms
+step:3927/4150 train_time:807322ms step_avg:205.58ms
+step:3928/4150 train_time:807559ms step_avg:205.59ms
+step:3929/4150 train_time:807796ms step_avg:205.60ms
+step:3930/4150 train_time:808033ms step_avg:205.61ms
+step:3931/4150 train_time:808266ms step_avg:205.61ms
+step:3932/4150 train_time:808503ms step_avg:205.62ms
+step:3933/4150 train_time:808737ms step_avg:205.63ms
+step:3934/4150 train_time:808975ms step_avg:205.64ms
+step:3935/4150 train_time:809207ms step_avg:205.64ms
+step:3936/4150 train_time:809450ms step_avg:205.65ms
+step:3937/4150 train_time:809683ms step_avg:205.66ms
+step:3938/4150 train_time:809921ms step_avg:205.67ms
+step:3939/4150 train_time:810153ms step_avg:205.67ms
+step:3940/4150 train_time:810392ms step_avg:205.68ms
+step:3941/4150 train_time:810628ms step_avg:205.69ms
+step:3942/4150 train_time:810864ms step_avg:205.70ms
+step:3943/4150 train_time:811098ms step_avg:205.71ms
+step:3944/4150 train_time:811336ms step_avg:205.71ms
+step:3945/4150 train_time:811570ms step_avg:205.72ms
+step:3946/4150 train_time:811806ms step_avg:205.73ms
+step:3947/4150 train_time:812041ms step_avg:205.74ms
+step:3948/4150 train_time:812282ms step_avg:205.75ms
+step:3949/4150 train_time:812516ms step_avg:205.75ms
+step:3950/4150 train_time:812758ms step_avg:205.76ms
+step:3951/4150 train_time:812996ms step_avg:205.77ms
+step:3952/4150 train_time:813235ms step_avg:205.78ms
+step:3953/4150 train_time:813470ms step_avg:205.79ms
+step:3954/4150 train_time:813709ms step_avg:205.79ms
+step:3955/4150 train_time:813942ms step_avg:205.80ms
+step:3956/4150 train_time:814177ms step_avg:205.81ms
+step:3957/4150 train_time:814412ms step_avg:205.82ms
+step:3958/4150 train_time:814650ms step_avg:205.82ms
+step:3959/4150 train_time:814885ms step_avg:205.83ms
+step:3960/4150 train_time:815123ms step_avg:205.84ms
+step:3961/4150 train_time:815357ms step_avg:205.85ms
+step:3962/4150 train_time:815596ms step_avg:205.85ms
+step:3963/4150 train_time:815829ms step_avg:205.86ms
+step:3964/4150 train_time:816068ms step_avg:205.87ms
+step:3965/4150 train_time:816301ms step_avg:205.88ms
+step:3966/4150 train_time:816538ms step_avg:205.88ms
+step:3967/4150 train_time:816775ms step_avg:205.89ms
+step:3968/4150 train_time:817012ms step_avg:205.90ms
+step:3969/4150 train_time:817247ms step_avg:205.91ms
+step:3970/4150 train_time:817486ms step_avg:205.92ms
+step:3971/4150 train_time:817721ms step_avg:205.92ms
+step:3972/4150 train_time:817957ms step_avg:205.93ms
+step:3973/4150 train_time:818191ms step_avg:205.94ms
+step:3974/4150 train_time:818429ms step_avg:205.95ms
+step:3975/4150 train_time:818663ms step_avg:205.95ms
+step:3976/4150 train_time:818901ms step_avg:205.96ms
+step:3977/4150 train_time:819133ms step_avg:205.97ms
+step:3978/4150 train_time:819371ms step_avg:205.98ms
+step:3979/4150 train_time:819604ms step_avg:205.98ms
+step:3980/4150 train_time:819841ms step_avg:205.99ms
+step:3981/4150 train_time:820073ms step_avg:206.00ms
+step:3982/4150 train_time:820312ms step_avg:206.01ms
+step:3983/4150 train_time:820547ms step_avg:206.01ms
+step:3984/4150 train_time:820782ms step_avg:206.02ms
+step:3985/4150 train_time:821016ms step_avg:206.03ms
+step:3986/4150 train_time:821253ms step_avg:206.03ms
+step:3987/4150 train_time:821487ms step_avg:206.04ms
+step:3988/4150 train_time:821725ms step_avg:206.05ms
+step:3989/4150 train_time:821957ms step_avg:206.06ms
+step:3990/4150 train_time:822195ms step_avg:206.06ms
+step:3991/4150 train_time:822430ms step_avg:206.07ms
+step:3992/4150 train_time:822669ms step_avg:206.08ms
+step:3993/4150 train_time:822903ms step_avg:206.09ms
+step:3994/4150 train_time:823142ms step_avg:206.09ms
+step:3995/4150 train_time:823380ms step_avg:206.10ms
+step:3996/4150 train_time:823618ms step_avg:206.11ms
+step:3997/4150 train_time:823851ms step_avg:206.12ms
+step:3998/4150 train_time:824089ms step_avg:206.13ms
+step:3999/4150 train_time:824325ms step_avg:206.13ms
+step:4000/4150 train_time:824564ms step_avg:206.14ms
+step:4000/4150 val_loss:2.9278 train_time:824780ms step_avg:206.19ms
+step:4001/4150 train_time:824802ms step_avg:206.15ms
+step:4002/4150 train_time:825044ms step_avg:206.16ms
+step:4003/4150 train_time:825279ms step_avg:206.17ms
+step:4004/4150 train_time:825514ms step_avg:206.17ms
+step:4005/4150 train_time:825749ms step_avg:206.18ms
+step:4006/4150 train_time:825994ms step_avg:206.19ms
+step:4007/4150 train_time:826231ms step_avg:206.20ms
+step:4008/4150 train_time:826467ms step_avg:206.20ms
+step:4009/4150 train_time:826699ms step_avg:206.21ms
+step:4010/4150 train_time:826939ms step_avg:206.22ms
+step:4011/4150 train_time:827176ms step_avg:206.23ms
+step:4012/4150 train_time:827413ms step_avg:206.23ms
+step:4013/4150 train_time:827648ms step_avg:206.24ms
+step:4014/4150 train_time:827885ms step_avg:206.25ms
+step:4015/4150 train_time:828121ms step_avg:206.26ms
+step:4016/4150 train_time:828359ms step_avg:206.26ms
+step:4017/4150 train_time:828590ms step_avg:206.27ms
+step:4018/4150 train_time:828827ms step_avg:206.28ms
+step:4019/4150 train_time:829065ms step_avg:206.29ms
+step:4020/4150 train_time:829302ms step_avg:206.29ms
+step:4021/4150 train_time:829536ms step_avg:206.30ms
+step:4022/4150 train_time:829772ms step_avg:206.31ms
+step:4023/4150 train_time:830007ms step_avg:206.32ms
+step:4024/4150 train_time:830247ms step_avg:206.32ms
+step:4025/4150 train_time:830483ms step_avg:206.33ms
+step:4026/4150 train_time:830717ms step_avg:206.34ms
+step:4027/4150 train_time:830953ms step_avg:206.35ms
+step:4028/4150 train_time:831189ms step_avg:206.35ms
+step:4029/4150 train_time:831425ms step_avg:206.36ms
+step:4030/4150 train_time:831664ms step_avg:206.37ms
+step:4031/4150 train_time:831898ms step_avg:206.38ms
+step:4032/4150 train_time:832136ms step_avg:206.38ms
+step:4033/4150 train_time:832372ms step_avg:206.39ms
+step:4034/4150 train_time:832609ms step_avg:206.40ms
+step:4035/4150 train_time:832841ms step_avg:206.40ms
+step:4036/4150 train_time:833075ms step_avg:206.41ms
+step:4037/4150 train_time:833310ms step_avg:206.42ms
+step:4038/4150 train_time:833550ms step_avg:206.43ms
+step:4039/4150 train_time:833783ms step_avg:206.43ms
+step:4040/4150 train_time:834020ms step_avg:206.44ms
+step:4041/4150 train_time:834254ms step_avg:206.45ms
+step:4042/4150 train_time:834490ms step_avg:206.45ms
+step:4043/4150 train_time:834722ms step_avg:206.46ms
+step:4044/4150 train_time:834959ms step_avg:206.47ms
+step:4045/4150 train_time:835193ms step_avg:206.48ms
+step:4046/4150 train_time:835429ms step_avg:206.48ms
+step:4047/4150 train_time:835661ms step_avg:206.49ms
+step:4048/4150 train_time:835897ms step_avg:206.50ms
+step:4049/4150 train_time:836130ms step_avg:206.50ms
+step:4050/4150 train_time:836372ms step_avg:206.51ms
+step:4051/4150 train_time:836608ms step_avg:206.52ms
+step:4052/4150 train_time:836844ms step_avg:206.53ms
+step:4053/4150 train_time:837080ms step_avg:206.53ms
+step:4054/4150 train_time:837317ms step_avg:206.54ms
+step:4055/4150 train_time:837551ms step_avg:206.55ms
+step:4056/4150 train_time:837787ms step_avg:206.55ms
+step:4057/4150 train_time:838021ms step_avg:206.56ms
+step:4058/4150 train_time:838258ms step_avg:206.57ms
+step:4059/4150 train_time:838494ms step_avg:206.58ms
+step:4060/4150 train_time:838731ms step_avg:206.58ms
+step:4061/4150 train_time:838970ms step_avg:206.59ms
+step:4062/4150 train_time:839205ms step_avg:206.60ms
+step:4063/4150 train_time:839438ms step_avg:206.61ms
+step:4064/4150 train_time:839676ms step_avg:206.61ms
+step:4065/4150 train_time:839915ms step_avg:206.62ms
+step:4066/4150 train_time:840149ms step_avg:206.63ms
+step:4067/4150 train_time:840383ms step_avg:206.63ms
+step:4068/4150 train_time:840622ms step_avg:206.64ms
+step:4069/4150 train_time:840857ms step_avg:206.65ms
+step:4070/4150 train_time:841096ms step_avg:206.66ms
+step:4071/4150 train_time:841327ms step_avg:206.66ms
+step:4072/4150 train_time:841565ms step_avg:206.67ms
+step:4073/4150 train_time:841802ms step_avg:206.68ms
+step:4074/4150 train_time:842039ms step_avg:206.69ms
+step:4075/4150 train_time:842274ms step_avg:206.69ms
+step:4076/4150 train_time:842512ms step_avg:206.70ms
+step:4077/4150 train_time:842748ms step_avg:206.71ms
+step:4078/4150 train_time:842984ms step_avg:206.72ms
+step:4079/4150 train_time:843218ms step_avg:206.72ms
+step:4080/4150 train_time:843454ms step_avg:206.73ms
+step:4081/4150 train_time:843689ms step_avg:206.74ms
+step:4082/4150 train_time:843932ms step_avg:206.74ms
+step:4083/4150 train_time:844166ms step_avg:206.75ms
+step:4084/4150 train_time:844406ms step_avg:206.76ms
+step:4085/4150 train_time:844641ms step_avg:206.77ms
+step:4086/4150 train_time:844879ms step_avg:206.77ms
+step:4087/4150 train_time:845112ms step_avg:206.78ms
+step:4088/4150 train_time:845349ms step_avg:206.79ms
+step:4089/4150 train_time:845584ms step_avg:206.79ms
+step:4090/4150 train_time:845826ms step_avg:206.80ms
+step:4091/4150 train_time:846060ms step_avg:206.81ms
+step:4092/4150 train_time:846297ms step_avg:206.82ms
+step:4093/4150 train_time:846532ms step_avg:206.82ms
+step:4094/4150 train_time:846769ms step_avg:206.83ms
+step:4095/4150 train_time:847003ms step_avg:206.84ms
+step:4096/4150 train_time:847239ms step_avg:206.85ms
+step:4097/4150 train_time:847472ms step_avg:206.85ms
+step:4098/4150 train_time:847709ms step_avg:206.86ms
+step:4099/4150 train_time:847945ms step_avg:206.87ms
+step:4100/4150 train_time:848184ms step_avg:206.87ms
+step:4101/4150 train_time:848419ms step_avg:206.88ms
+step:4102/4150 train_time:848658ms step_avg:206.89ms
+step:4103/4150 train_time:848890ms step_avg:206.89ms
+step:4104/4150 train_time:849129ms step_avg:206.90ms
+step:4105/4150 train_time:849362ms step_avg:206.91ms
+step:4106/4150 train_time:849599ms step_avg:206.92ms
+step:4107/4150 train_time:849831ms step_avg:206.92ms
+step:4108/4150 train_time:850070ms step_avg:206.93ms
+step:4109/4150 train_time:850305ms step_avg:206.94ms
+step:4110/4150 train_time:850541ms step_avg:206.94ms
+step:4111/4150 train_time:850775ms step_avg:206.95ms
+step:4112/4150 train_time:851013ms step_avg:206.96ms
+step:4113/4150 train_time:851245ms step_avg:206.96ms
+step:4114/4150 train_time:851483ms step_avg:206.97ms
+step:4115/4150 train_time:851717ms step_avg:206.98ms
+step:4116/4150 train_time:851954ms step_avg:206.99ms
+step:4117/4150 train_time:852190ms step_avg:206.99ms
+step:4118/4150 train_time:852426ms step_avg:207.00ms
+step:4119/4150 train_time:852661ms step_avg:207.01ms
+step:4120/4150 train_time:852898ms step_avg:207.01ms
+step:4121/4150 train_time:853133ms step_avg:207.02ms
+step:4122/4150 train_time:853369ms step_avg:207.03ms
+step:4123/4150 train_time:853603ms step_avg:207.03ms
+step:4124/4150 train_time:853841ms step_avg:207.04ms
+step:4125/4150 train_time:854075ms step_avg:207.05ms
+step:4126/4150 train_time:854311ms step_avg:207.06ms
+step:4127/4150 train_time:854544ms step_avg:207.06ms
+step:4128/4150 train_time:854783ms step_avg:207.07ms
+step:4129/4150 train_time:855017ms step_avg:207.08ms
+step:4130/4150 train_time:855253ms step_avg:207.08ms
+step:4131/4150 train_time:855490ms step_avg:207.09ms
+step:4132/4150 train_time:855730ms step_avg:207.10ms
+step:4133/4150 train_time:855965ms step_avg:207.11ms
+step:4134/4150 train_time:856205ms step_avg:207.11ms
+step:4135/4150 train_time:856439ms step_avg:207.12ms
+step:4136/4150 train_time:856675ms step_avg:207.13ms
+step:4137/4150 train_time:856908ms step_avg:207.13ms
+step:4138/4150 train_time:857145ms step_avg:207.14ms
+step:4139/4150 train_time:857382ms step_avg:207.15ms
+step:4140/4150 train_time:857619ms step_avg:207.15ms
+step:4141/4150 train_time:857852ms step_avg:207.16ms
+step:4142/4150 train_time:858090ms step_avg:207.17ms
+step:4143/4150 train_time:858323ms step_avg:207.17ms
+step:4144/4150 train_time:858563ms step_avg:207.18ms
+step:4145/4150 train_time:858798ms step_avg:207.19ms
+step:4146/4150 train_time:859035ms step_avg:207.20ms
+step:4147/4150 train_time:859271ms step_avg:207.20ms
+step:4148/4150 train_time:859508ms step_avg:207.21ms
+step:4149/4150 train_time:859744ms step_avg:207.22ms
+step:4150/4150 train_time:859980ms step_avg:207.22ms
+step:4150/4150 val_loss:2.9165 train_time:860193ms step_avg:207.28ms
+peak memory allocated: 59977 MiB reserved: 60424 MiB

--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/b5225858-1f26-4b18-bf55-27e81bc56c62.txt
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/b5225858-1f26-4b18-bf55-27e81bc56c62.txt
@@ -1,0 +1,6376 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+import numpy as np
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
+
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = False # turn off fp8 for now -> requires tuning of scales which hasnt been done on medium track
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(16, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
+
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
+        self.yarn = Yarn(head_dim, max_seq_len)
+
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+        self.embed.weight.label = 'embed'
+
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
+        self.embed2.weight.label = 'embed2'
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [2, 4, 6]
+        skip_out = [9, 10, 11]
+        backout_layer = 11
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
+            short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
+
+        skip_idx = 0
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve_list[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
+            )
+            next_ve_gate = None
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
+                skip_idx += 1
+                x = x + skip_gate_out * skip_connections.pop()
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
+            else:
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                h_backout_snap = x
+
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
+        x = norm(x)
+
+        if not self.training:
+            loss = 0
+            for i in range(4):
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
+                logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+                loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
+            return loss
+
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return min(11,args.ws_schedule[ws_idx] // 2), args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/12:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/12:
+        lr_max = 1.73  # (24/8)**0.5
+    if x > 3/12:
+        lr_max = 2.0
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
+
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / (args.num_scheduled_iterations/4)
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        # only apply yarn for first few
+        if new_ws_long != self.ws_long and new_ws_long<=13:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
+                                524288, 524288, 524288, 524288,
+                                524288, 524288, 524288, 524288
+                               )
+    train_bs_extension: int = 32 * 2048 * 8
+    train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3/4
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11, 13,
+                          15, 17, 19, 21,
+                          23, 23, 23, 23)
+    ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
+    ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=16,
+    num_heads=8,
+    head_dim=128,
+    model_dim=1024,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Mon Apr 27 07:24:42 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   46C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   39C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   45C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   39C    P0            128W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   45C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          269340      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    1   N/A  N/A          269341      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    2   N/A  N/A          269342      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    3   N/A  N/A          269343      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    4   N/A  N/A          269344      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    5   N/A  N/A          269345      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    6   N/A  N/A          269346      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    7   N/A  N/A          269347      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 343, 344, 345, 687, 688, 689, 1031, 1032, 1033, 1374, 1375, 1376, 1718, 1719, 1720, 2062, 2063, 2064, 2406, 2407, 2408, 2749, 2750, 2751] for warmup
+Resetting Model
+step:0/4150 val_loss:10.8283 train_time:0ms step_avg:0.03ms
+step:1/4150 train_time:67ms step_avg:66.59ms
+step:2/4150 train_time:113ms step_avg:56.64ms
+step:3/4150 train_time:181ms step_avg:60.47ms
+step:4/4150 train_time:247ms step_avg:61.79ms
+step:5/4150 train_time:316ms step_avg:63.21ms
+step:6/4150 train_time:382ms step_avg:63.63ms
+step:7/4150 train_time:451ms step_avg:64.36ms
+step:8/4150 train_time:516ms step_avg:64.48ms
+step:9/4150 train_time:585ms step_avg:65.03ms
+step:10/4150 train_time:651ms step_avg:65.06ms
+step:11/4150 train_time:720ms step_avg:65.43ms
+step:12/4150 train_time:785ms step_avg:65.44ms
+step:13/4150 train_time:854ms step_avg:65.72ms
+step:14/4150 train_time:920ms step_avg:65.69ms
+step:15/4150 train_time:990ms step_avg:66.01ms
+step:16/4150 train_time:1056ms step_avg:66.02ms
+step:17/4150 train_time:1127ms step_avg:66.30ms
+step:18/4150 train_time:1193ms step_avg:66.30ms
+step:19/4150 train_time:1263ms step_avg:66.50ms
+step:20/4150 train_time:1329ms step_avg:66.44ms
+step:21/4150 train_time:1398ms step_avg:66.58ms
+step:22/4150 train_time:1464ms step_avg:66.54ms
+step:23/4150 train_time:1534ms step_avg:66.69ms
+step:24/4150 train_time:1600ms step_avg:66.67ms
+step:25/4150 train_time:1669ms step_avg:66.78ms
+step:26/4150 train_time:1735ms step_avg:66.72ms
+step:27/4150 train_time:1804ms step_avg:66.81ms
+step:28/4150 train_time:1870ms step_avg:66.77ms
+step:29/4150 train_time:1938ms step_avg:66.83ms
+step:30/4150 train_time:2005ms step_avg:66.83ms
+step:31/4150 train_time:2075ms step_avg:66.93ms
+step:32/4150 train_time:2141ms step_avg:66.91ms
+step:33/4150 train_time:2212ms step_avg:67.02ms
+step:34/4150 train_time:2278ms step_avg:67.00ms
+step:35/4150 train_time:2348ms step_avg:67.10ms
+step:36/4150 train_time:2414ms step_avg:67.05ms
+step:37/4150 train_time:2484ms step_avg:67.14ms
+step:38/4150 train_time:2550ms step_avg:67.10ms
+step:39/4150 train_time:2619ms step_avg:67.16ms
+step:40/4150 train_time:2685ms step_avg:67.12ms
+step:41/4150 train_time:2754ms step_avg:67.17ms
+step:42/4150 train_time:2819ms step_avg:67.13ms
+step:43/4150 train_time:2890ms step_avg:67.21ms
+step:44/4150 train_time:2955ms step_avg:67.16ms
+step:45/4150 train_time:3025ms step_avg:67.22ms
+step:46/4150 train_time:3091ms step_avg:67.19ms
+step:47/4150 train_time:3161ms step_avg:67.26ms
+step:48/4150 train_time:3227ms step_avg:67.23ms
+step:49/4150 train_time:3297ms step_avg:67.28ms
+step:50/4150 train_time:3362ms step_avg:67.25ms
+step:51/4150 train_time:3432ms step_avg:67.30ms
+step:52/4150 train_time:3499ms step_avg:67.28ms
+step:53/4150 train_time:3568ms step_avg:67.33ms
+step:54/4150 train_time:3634ms step_avg:67.30ms
+step:55/4150 train_time:3705ms step_avg:67.36ms
+step:56/4150 train_time:3770ms step_avg:67.32ms
+step:57/4150 train_time:3839ms step_avg:67.35ms
+step:58/4150 train_time:3904ms step_avg:67.32ms
+step:59/4150 train_time:3974ms step_avg:67.36ms
+step:60/4150 train_time:4040ms step_avg:67.33ms
+step:61/4150 train_time:4109ms step_avg:67.37ms
+step:62/4150 train_time:4176ms step_avg:67.35ms
+step:63/4150 train_time:4246ms step_avg:67.40ms
+step:64/4150 train_time:4312ms step_avg:67.37ms
+step:65/4150 train_time:4382ms step_avg:67.41ms
+step:66/4150 train_time:4447ms step_avg:67.38ms
+step:67/4150 train_time:4517ms step_avg:67.42ms
+step:68/4150 train_time:4583ms step_avg:67.39ms
+step:69/4150 train_time:4652ms step_avg:67.43ms
+step:70/4150 train_time:4718ms step_avg:67.40ms
+step:71/4150 train_time:4788ms step_avg:67.43ms
+step:72/4150 train_time:4854ms step_avg:67.41ms
+step:73/4150 train_time:4924ms step_avg:67.45ms
+step:74/4150 train_time:4989ms step_avg:67.42ms
+step:75/4150 train_time:5059ms step_avg:67.45ms
+step:76/4150 train_time:5124ms step_avg:67.42ms
+step:77/4150 train_time:5194ms step_avg:67.45ms
+step:78/4150 train_time:5259ms step_avg:67.42ms
+step:79/4150 train_time:5329ms step_avg:67.46ms
+step:80/4150 train_time:5395ms step_avg:67.43ms
+step:81/4150 train_time:5464ms step_avg:67.46ms
+step:82/4150 train_time:5530ms step_avg:67.43ms
+step:83/4150 train_time:5599ms step_avg:67.46ms
+step:84/4150 train_time:5666ms step_avg:67.45ms
+step:85/4150 train_time:5736ms step_avg:67.48ms
+step:86/4150 train_time:5802ms step_avg:67.46ms
+step:87/4150 train_time:5872ms step_avg:67.49ms
+step:88/4150 train_time:5939ms step_avg:67.49ms
+step:89/4150 train_time:6007ms step_avg:67.50ms
+step:90/4150 train_time:6074ms step_avg:67.48ms
+step:91/4150 train_time:6143ms step_avg:67.51ms
+step:92/4150 train_time:6209ms step_avg:67.49ms
+step:93/4150 train_time:6279ms step_avg:67.51ms
+step:94/4150 train_time:6344ms step_avg:67.49ms
+step:95/4150 train_time:6414ms step_avg:67.52ms
+step:96/4150 train_time:6480ms step_avg:67.50ms
+step:97/4150 train_time:6549ms step_avg:67.52ms
+step:98/4150 train_time:6614ms step_avg:67.49ms
+step:99/4150 train_time:6684ms step_avg:67.52ms
+step:100/4150 train_time:6749ms step_avg:67.49ms
+step:101/4150 train_time:6819ms step_avg:67.51ms
+step:102/4150 train_time:6885ms step_avg:67.50ms
+step:103/4150 train_time:6955ms step_avg:67.52ms
+step:104/4150 train_time:7021ms step_avg:67.51ms
+step:105/4150 train_time:7090ms step_avg:67.53ms
+step:106/4150 train_time:7156ms step_avg:67.51ms
+step:107/4150 train_time:7225ms step_avg:67.52ms
+step:108/4150 train_time:7290ms step_avg:67.50ms
+step:109/4150 train_time:7359ms step_avg:67.51ms
+step:110/4150 train_time:7425ms step_avg:67.50ms
+step:111/4150 train_time:7495ms step_avg:67.52ms
+step:112/4150 train_time:7560ms step_avg:67.50ms
+step:113/4150 train_time:7631ms step_avg:67.53ms
+step:114/4150 train_time:7696ms step_avg:67.51ms
+step:115/4150 train_time:7766ms step_avg:67.53ms
+step:116/4150 train_time:7831ms step_avg:67.51ms
+step:117/4150 train_time:7901ms step_avg:67.53ms
+step:118/4150 train_time:7967ms step_avg:67.51ms
+step:119/4150 train_time:8036ms step_avg:67.53ms
+step:120/4150 train_time:8102ms step_avg:67.52ms
+step:121/4150 train_time:8172ms step_avg:67.53ms
+step:122/4150 train_time:8237ms step_avg:67.51ms
+step:123/4150 train_time:8306ms step_avg:67.53ms
+step:124/4150 train_time:8371ms step_avg:67.51ms
+step:125/4150 train_time:8440ms step_avg:67.52ms
+step:126/4150 train_time:8505ms step_avg:67.50ms
+step:127/4150 train_time:8575ms step_avg:67.52ms
+step:128/4150 train_time:8640ms step_avg:67.50ms
+step:129/4150 train_time:8710ms step_avg:67.52ms
+step:130/4150 train_time:8776ms step_avg:67.51ms
+step:131/4150 train_time:8845ms step_avg:67.52ms
+step:132/4150 train_time:8910ms step_avg:67.50ms
+step:133/4150 train_time:8980ms step_avg:67.52ms
+step:134/4150 train_time:9046ms step_avg:67.51ms
+step:135/4150 train_time:9115ms step_avg:67.52ms
+step:136/4150 train_time:9181ms step_avg:67.51ms
+step:137/4150 train_time:9250ms step_avg:67.52ms
+step:138/4150 train_time:9316ms step_avg:67.51ms
+step:139/4150 train_time:9387ms step_avg:67.53ms
+step:140/4150 train_time:9452ms step_avg:67.51ms
+step:141/4150 train_time:9521ms step_avg:67.53ms
+step:142/4150 train_time:9587ms step_avg:67.51ms
+step:143/4150 train_time:9657ms step_avg:67.53ms
+step:144/4150 train_time:9722ms step_avg:67.51ms
+step:145/4150 train_time:9793ms step_avg:67.53ms
+step:146/4150 train_time:9858ms step_avg:67.52ms
+step:147/4150 train_time:9927ms step_avg:67.53ms
+step:148/4150 train_time:9993ms step_avg:67.52ms
+step:149/4150 train_time:10062ms step_avg:67.53ms
+step:150/4150 train_time:10127ms step_avg:67.51ms
+step:151/4150 train_time:10196ms step_avg:67.53ms
+step:152/4150 train_time:10261ms step_avg:67.51ms
+step:153/4150 train_time:10331ms step_avg:67.52ms
+step:154/4150 train_time:10396ms step_avg:67.51ms
+step:155/4150 train_time:10465ms step_avg:67.52ms
+step:156/4150 train_time:10531ms step_avg:67.51ms
+step:157/4150 train_time:10601ms step_avg:67.52ms
+step:158/4150 train_time:10667ms step_avg:67.51ms
+step:159/4150 train_time:10737ms step_avg:67.53ms
+step:160/4150 train_time:10803ms step_avg:67.52ms
+step:161/4150 train_time:10872ms step_avg:67.52ms
+step:162/4150 train_time:10937ms step_avg:67.51ms
+step:163/4150 train_time:11006ms step_avg:67.52ms
+step:164/4150 train_time:11071ms step_avg:67.51ms
+step:165/4150 train_time:11140ms step_avg:67.52ms
+step:166/4150 train_time:11206ms step_avg:67.51ms
+step:167/4150 train_time:11275ms step_avg:67.52ms
+step:168/4150 train_time:11340ms step_avg:67.50ms
+step:169/4150 train_time:11410ms step_avg:67.52ms
+step:170/4150 train_time:11476ms step_avg:67.51ms
+step:171/4150 train_time:11546ms step_avg:67.52ms
+step:172/4150 train_time:11612ms step_avg:67.51ms
+step:173/4150 train_time:11682ms step_avg:67.53ms
+step:174/4150 train_time:11747ms step_avg:67.51ms
+step:175/4150 train_time:11817ms step_avg:67.52ms
+step:176/4150 train_time:11883ms step_avg:67.52ms
+step:177/4150 train_time:11951ms step_avg:67.52ms
+step:178/4150 train_time:12017ms step_avg:67.51ms
+step:179/4150 train_time:12086ms step_avg:67.52ms
+step:180/4150 train_time:12151ms step_avg:67.50ms
+step:181/4150 train_time:12220ms step_avg:67.52ms
+step:182/4150 train_time:12286ms step_avg:67.51ms
+step:183/4150 train_time:12355ms step_avg:67.51ms
+step:184/4150 train_time:12420ms step_avg:67.50ms
+step:185/4150 train_time:12490ms step_avg:67.51ms
+step:186/4150 train_time:12555ms step_avg:67.50ms
+step:187/4150 train_time:12625ms step_avg:67.52ms
+step:188/4150 train_time:12692ms step_avg:67.51ms
+step:189/4150 train_time:12760ms step_avg:67.51ms
+step:190/4150 train_time:12826ms step_avg:67.51ms
+step:191/4150 train_time:12895ms step_avg:67.51ms
+step:192/4150 train_time:12960ms step_avg:67.50ms
+step:193/4150 train_time:13030ms step_avg:67.51ms
+step:194/4150 train_time:13096ms step_avg:67.50ms
+step:195/4150 train_time:13165ms step_avg:67.51ms
+step:196/4150 train_time:13231ms step_avg:67.50ms
+step:197/4150 train_time:13300ms step_avg:67.51ms
+step:198/4150 train_time:13365ms step_avg:67.50ms
+step:199/4150 train_time:13434ms step_avg:67.51ms
+step:200/4150 train_time:13500ms step_avg:67.50ms
+step:201/4150 train_time:13569ms step_avg:67.51ms
+step:202/4150 train_time:13634ms step_avg:67.49ms
+step:203/4150 train_time:13703ms step_avg:67.50ms
+step:204/4150 train_time:13769ms step_avg:67.49ms
+step:205/4150 train_time:13838ms step_avg:67.50ms
+step:206/4150 train_time:13904ms step_avg:67.49ms
+step:207/4150 train_time:13973ms step_avg:67.50ms
+step:208/4150 train_time:14038ms step_avg:67.49ms
+step:209/4150 train_time:14107ms step_avg:67.50ms
+step:210/4150 train_time:14172ms step_avg:67.49ms
+step:211/4150 train_time:14242ms step_avg:67.50ms
+step:212/4150 train_time:14307ms step_avg:67.48ms
+step:213/4150 train_time:14376ms step_avg:67.49ms
+step:214/4150 train_time:14440ms step_avg:67.48ms
+step:215/4150 train_time:14509ms step_avg:67.48ms
+step:216/4150 train_time:14574ms step_avg:67.47ms
+step:217/4150 train_time:14643ms step_avg:67.48ms
+step:218/4150 train_time:14709ms step_avg:67.47ms
+step:219/4150 train_time:14777ms step_avg:67.48ms
+step:220/4150 train_time:14842ms step_avg:67.46ms
+step:221/4150 train_time:14911ms step_avg:67.47ms
+step:222/4150 train_time:14977ms step_avg:67.46ms
+step:223/4150 train_time:15045ms step_avg:67.47ms
+step:224/4150 train_time:15110ms step_avg:67.46ms
+step:225/4150 train_time:15180ms step_avg:67.46ms
+step:226/4150 train_time:15245ms step_avg:67.45ms
+step:227/4150 train_time:15314ms step_avg:67.46ms
+step:228/4150 train_time:15380ms step_avg:67.45ms
+step:229/4150 train_time:15449ms step_avg:67.46ms
+step:230/4150 train_time:15515ms step_avg:67.45ms
+step:231/4150 train_time:15585ms step_avg:67.47ms
+step:232/4150 train_time:15650ms step_avg:67.46ms
+step:233/4150 train_time:15720ms step_avg:67.47ms
+step:234/4150 train_time:15785ms step_avg:67.46ms
+step:235/4150 train_time:15855ms step_avg:67.47ms
+step:236/4150 train_time:15920ms step_avg:67.46ms
+step:237/4150 train_time:15989ms step_avg:67.46ms
+step:238/4150 train_time:16055ms step_avg:67.46ms
+step:239/4150 train_time:16124ms step_avg:67.46ms
+step:240/4150 train_time:16189ms step_avg:67.45ms
+step:241/4150 train_time:16258ms step_avg:67.46ms
+step:242/4150 train_time:16323ms step_avg:67.45ms
+step:243/4150 train_time:16392ms step_avg:67.46ms
+step:244/4150 train_time:16457ms step_avg:67.45ms
+step:245/4150 train_time:16526ms step_avg:67.45ms
+step:246/4150 train_time:16591ms step_avg:67.44ms
+step:247/4150 train_time:16660ms step_avg:67.45ms
+step:248/4150 train_time:16725ms step_avg:67.44ms
+step:249/4150 train_time:16795ms step_avg:67.45ms
+step:250/4150 train_time:16860ms step_avg:67.44ms
+step:250/4150 val_loss:4.4823 train_time:16925ms step_avg:67.70ms
+step:251/4150 train_time:16946ms step_avg:67.51ms
+step:252/4150 train_time:16997ms step_avg:67.45ms
+step:253/4150 train_time:17067ms step_avg:67.46ms
+step:254/4150 train_time:17133ms step_avg:67.45ms
+step:255/4150 train_time:17203ms step_avg:67.46ms
+step:256/4150 train_time:17270ms step_avg:67.46ms
+step:257/4150 train_time:17342ms step_avg:67.48ms
+step:258/4150 train_time:17407ms step_avg:67.47ms
+step:259/4150 train_time:17476ms step_avg:67.47ms
+step:260/4150 train_time:17541ms step_avg:67.47ms
+step:261/4150 train_time:17610ms step_avg:67.47ms
+step:262/4150 train_time:17675ms step_avg:67.46ms
+step:263/4150 train_time:17744ms step_avg:67.47ms
+step:264/4150 train_time:17809ms step_avg:67.46ms
+step:265/4150 train_time:17878ms step_avg:67.46ms
+step:266/4150 train_time:17943ms step_avg:67.46ms
+step:267/4150 train_time:18012ms step_avg:67.46ms
+step:268/4150 train_time:18077ms step_avg:67.45ms
+step:269/4150 train_time:18147ms step_avg:67.46ms
+step:270/4150 train_time:18212ms step_avg:67.45ms
+step:271/4150 train_time:18283ms step_avg:67.46ms
+step:272/4150 train_time:18348ms step_avg:67.46ms
+step:273/4150 train_time:18418ms step_avg:67.46ms
+step:274/4150 train_time:18483ms step_avg:67.46ms
+step:275/4150 train_time:18552ms step_avg:67.46ms
+step:276/4150 train_time:18616ms step_avg:67.45ms
+step:277/4150 train_time:18685ms step_avg:67.45ms
+step:278/4150 train_time:18750ms step_avg:67.45ms
+step:279/4150 train_time:18819ms step_avg:67.45ms
+step:280/4150 train_time:18884ms step_avg:67.44ms
+step:281/4150 train_time:18953ms step_avg:67.45ms
+step:282/4150 train_time:19018ms step_avg:67.44ms
+step:283/4150 train_time:19087ms step_avg:67.45ms
+step:284/4150 train_time:19152ms step_avg:67.44ms
+step:285/4150 train_time:19222ms step_avg:67.45ms
+step:286/4150 train_time:19287ms step_avg:67.44ms
+step:287/4150 train_time:19357ms step_avg:67.45ms
+step:288/4150 train_time:19423ms step_avg:67.44ms
+step:289/4150 train_time:19492ms step_avg:67.44ms
+step:290/4150 train_time:19557ms step_avg:67.44ms
+step:291/4150 train_time:19626ms step_avg:67.44ms
+step:292/4150 train_time:19690ms step_avg:67.43ms
+step:293/4150 train_time:19759ms step_avg:67.44ms
+step:294/4150 train_time:19824ms step_avg:67.43ms
+step:295/4150 train_time:19893ms step_avg:67.44ms
+step:296/4150 train_time:19959ms step_avg:67.43ms
+step:297/4150 train_time:20027ms step_avg:67.43ms
+step:298/4150 train_time:20092ms step_avg:67.42ms
+step:299/4150 train_time:20162ms step_avg:67.43ms
+step:300/4150 train_time:20227ms step_avg:67.42ms
+step:301/4150 train_time:20296ms step_avg:67.43ms
+step:302/4150 train_time:20361ms step_avg:67.42ms
+step:303/4150 train_time:20430ms step_avg:67.43ms
+step:304/4150 train_time:20496ms step_avg:67.42ms
+step:305/4150 train_time:20565ms step_avg:67.43ms
+step:306/4150 train_time:20630ms step_avg:67.42ms
+step:307/4150 train_time:20700ms step_avg:67.43ms
+step:308/4150 train_time:20765ms step_avg:67.42ms
+step:309/4150 train_time:20834ms step_avg:67.43ms
+step:310/4150 train_time:20899ms step_avg:67.42ms
+step:311/4150 train_time:20968ms step_avg:67.42ms
+step:312/4150 train_time:21033ms step_avg:67.41ms
+step:313/4150 train_time:21103ms step_avg:67.42ms
+step:314/4150 train_time:21168ms step_avg:67.42ms
+step:315/4150 train_time:21237ms step_avg:67.42ms
+step:316/4150 train_time:21302ms step_avg:67.41ms
+step:317/4150 train_time:21370ms step_avg:67.41ms
+step:318/4150 train_time:21436ms step_avg:67.41ms
+step:319/4150 train_time:21505ms step_avg:67.41ms
+step:320/4150 train_time:21570ms step_avg:67.41ms
+step:321/4150 train_time:21639ms step_avg:67.41ms
+step:322/4150 train_time:21704ms step_avg:67.40ms
+step:323/4150 train_time:21773ms step_avg:67.41ms
+step:324/4150 train_time:21839ms step_avg:67.41ms
+step:325/4150 train_time:21908ms step_avg:67.41ms
+step:326/4150 train_time:21974ms step_avg:67.40ms
+step:327/4150 train_time:22043ms step_avg:67.41ms
+step:328/4150 train_time:22108ms step_avg:67.40ms
+step:329/4150 train_time:22177ms step_avg:67.41ms
+step:330/4150 train_time:22242ms step_avg:67.40ms
+step:331/4150 train_time:22312ms step_avg:67.41ms
+step:332/4150 train_time:22377ms step_avg:67.40ms
+step:333/4150 train_time:22446ms step_avg:67.40ms
+step:334/4150 train_time:22510ms step_avg:67.40ms
+step:335/4150 train_time:22580ms step_avg:67.40ms
+step:336/4150 train_time:22645ms step_avg:67.40ms
+step:337/4150 train_time:22714ms step_avg:67.40ms
+step:338/4150 train_time:22780ms step_avg:67.40ms
+step:339/4150 train_time:22849ms step_avg:67.40ms
+step:340/4150 train_time:22914ms step_avg:67.39ms
+step:341/4150 train_time:22984ms step_avg:67.40ms
+step:342/4150 train_time:23049ms step_avg:67.40ms
+step:343/4150 train_time:23118ms step_avg:67.40ms
+step:344/4150 train_time:23183ms step_avg:67.39ms
+step:345/4150 train_time:23258ms step_avg:67.42ms
+step:346/4150 train_time:23381ms step_avg:67.57ms
+step:347/4150 train_time:23502ms step_avg:67.73ms
+step:348/4150 train_time:23623ms step_avg:67.88ms
+step:349/4150 train_time:23744ms step_avg:68.04ms
+step:350/4150 train_time:23865ms step_avg:68.19ms
+step:351/4150 train_time:23989ms step_avg:68.35ms
+step:352/4150 train_time:24111ms step_avg:68.50ms
+step:353/4150 train_time:24233ms step_avg:68.65ms
+step:354/4150 train_time:24354ms step_avg:68.80ms
+step:355/4150 train_time:24476ms step_avg:68.95ms
+step:356/4150 train_time:24599ms step_avg:69.10ms
+step:357/4150 train_time:24721ms step_avg:69.25ms
+step:358/4150 train_time:24841ms step_avg:69.39ms
+step:359/4150 train_time:24963ms step_avg:69.53ms
+step:360/4150 train_time:25084ms step_avg:69.68ms
+step:361/4150 train_time:25206ms step_avg:69.82ms
+step:362/4150 train_time:25327ms step_avg:69.96ms
+step:363/4150 train_time:25449ms step_avg:70.11ms
+step:364/4150 train_time:25569ms step_avg:70.25ms
+step:365/4150 train_time:25691ms step_avg:70.39ms
+step:366/4150 train_time:25812ms step_avg:70.53ms
+step:367/4150 train_time:25936ms step_avg:70.67ms
+step:368/4150 train_time:26056ms step_avg:70.81ms
+step:369/4150 train_time:26179ms step_avg:70.95ms
+step:370/4150 train_time:26300ms step_avg:71.08ms
+step:371/4150 train_time:26423ms step_avg:71.22ms
+step:372/4150 train_time:26543ms step_avg:71.35ms
+step:373/4150 train_time:26665ms step_avg:71.49ms
+step:374/4150 train_time:26785ms step_avg:71.62ms
+step:375/4150 train_time:26909ms step_avg:71.76ms
+step:376/4150 train_time:27030ms step_avg:71.89ms
+step:377/4150 train_time:27153ms step_avg:72.02ms
+step:378/4150 train_time:27273ms step_avg:72.15ms
+step:379/4150 train_time:27396ms step_avg:72.28ms
+step:380/4150 train_time:27517ms step_avg:72.41ms
+step:381/4150 train_time:27640ms step_avg:72.55ms
+step:382/4150 train_time:27760ms step_avg:72.67ms
+step:383/4150 train_time:27883ms step_avg:72.80ms
+step:384/4150 train_time:28003ms step_avg:72.92ms
+step:385/4150 train_time:28124ms step_avg:73.05ms
+step:386/4150 train_time:28245ms step_avg:73.17ms
+step:387/4150 train_time:28366ms step_avg:73.30ms
+step:388/4150 train_time:28487ms step_avg:73.42ms
+step:389/4150 train_time:28609ms step_avg:73.54ms
+step:390/4150 train_time:28729ms step_avg:73.67ms
+step:391/4150 train_time:28851ms step_avg:73.79ms
+step:392/4150 train_time:28973ms step_avg:73.91ms
+step:393/4150 train_time:29098ms step_avg:74.04ms
+step:394/4150 train_time:29218ms step_avg:74.16ms
+step:395/4150 train_time:29341ms step_avg:74.28ms
+step:396/4150 train_time:29461ms step_avg:74.40ms
+step:397/4150 train_time:29583ms step_avg:74.52ms
+step:398/4150 train_time:29703ms step_avg:74.63ms
+step:399/4150 train_time:29825ms step_avg:74.75ms
+step:400/4150 train_time:29946ms step_avg:74.86ms
+step:401/4150 train_time:30069ms step_avg:74.99ms
+step:402/4150 train_time:30190ms step_avg:75.10ms
+step:403/4150 train_time:30312ms step_avg:75.22ms
+step:404/4150 train_time:30434ms step_avg:75.33ms
+step:405/4150 train_time:30557ms step_avg:75.45ms
+step:406/4150 train_time:30678ms step_avg:75.56ms
+step:407/4150 train_time:30801ms step_avg:75.68ms
+step:408/4150 train_time:30921ms step_avg:75.79ms
+step:409/4150 train_time:31043ms step_avg:75.90ms
+step:410/4150 train_time:31163ms step_avg:76.01ms
+step:411/4150 train_time:31286ms step_avg:76.12ms
+step:412/4150 train_time:31406ms step_avg:76.23ms
+step:413/4150 train_time:31529ms step_avg:76.34ms
+step:414/4150 train_time:31649ms step_avg:76.45ms
+step:415/4150 train_time:31772ms step_avg:76.56ms
+step:416/4150 train_time:31892ms step_avg:76.66ms
+step:417/4150 train_time:32015ms step_avg:76.78ms
+step:418/4150 train_time:32137ms step_avg:76.88ms
+step:419/4150 train_time:32259ms step_avg:76.99ms
+step:420/4150 train_time:32380ms step_avg:77.10ms
+step:421/4150 train_time:32503ms step_avg:77.20ms
+step:422/4150 train_time:32623ms step_avg:77.31ms
+step:423/4150 train_time:32746ms step_avg:77.41ms
+step:424/4150 train_time:32866ms step_avg:77.51ms
+step:425/4150 train_time:32988ms step_avg:77.62ms
+step:426/4150 train_time:33108ms step_avg:77.72ms
+step:427/4150 train_time:33230ms step_avg:77.82ms
+step:428/4150 train_time:33352ms step_avg:77.92ms
+step:429/4150 train_time:33474ms step_avg:78.03ms
+step:430/4150 train_time:33595ms step_avg:78.13ms
+step:431/4150 train_time:33719ms step_avg:78.23ms
+step:432/4150 train_time:33839ms step_avg:78.33ms
+step:433/4150 train_time:33960ms step_avg:78.43ms
+step:434/4150 train_time:34080ms step_avg:78.53ms
+step:435/4150 train_time:34202ms step_avg:78.63ms
+step:436/4150 train_time:34323ms step_avg:78.72ms
+step:437/4150 train_time:34444ms step_avg:78.82ms
+step:438/4150 train_time:34566ms step_avg:78.92ms
+step:439/4150 train_time:34688ms step_avg:79.02ms
+step:440/4150 train_time:34809ms step_avg:79.11ms
+step:441/4150 train_time:34930ms step_avg:79.21ms
+step:442/4150 train_time:35052ms step_avg:79.30ms
+step:443/4150 train_time:35176ms step_avg:79.40ms
+step:444/4150 train_time:35296ms step_avg:79.50ms
+step:445/4150 train_time:35419ms step_avg:79.59ms
+step:446/4150 train_time:35539ms step_avg:79.68ms
+step:447/4150 train_time:35661ms step_avg:79.78ms
+step:448/4150 train_time:35781ms step_avg:79.87ms
+step:449/4150 train_time:35903ms step_avg:79.96ms
+step:450/4150 train_time:36024ms step_avg:80.05ms
+step:451/4150 train_time:36145ms step_avg:80.14ms
+step:452/4150 train_time:36265ms step_avg:80.23ms
+step:453/4150 train_time:36386ms step_avg:80.32ms
+step:454/4150 train_time:36507ms step_avg:80.41ms
+step:455/4150 train_time:36628ms step_avg:80.50ms
+step:456/4150 train_time:36747ms step_avg:80.59ms
+step:457/4150 train_time:36869ms step_avg:80.68ms
+step:458/4150 train_time:36990ms step_avg:80.76ms
+step:459/4150 train_time:37113ms step_avg:80.86ms
+step:460/4150 train_time:37232ms step_avg:80.94ms
+step:461/4150 train_time:37354ms step_avg:81.03ms
+step:462/4150 train_time:37476ms step_avg:81.12ms
+step:463/4150 train_time:37599ms step_avg:81.21ms
+step:464/4150 train_time:37719ms step_avg:81.29ms
+step:465/4150 train_time:37840ms step_avg:81.38ms
+step:466/4150 train_time:37960ms step_avg:81.46ms
+step:467/4150 train_time:38083ms step_avg:81.55ms
+step:468/4150 train_time:38202ms step_avg:81.63ms
+step:469/4150 train_time:38326ms step_avg:81.72ms
+step:470/4150 train_time:38446ms step_avg:81.80ms
+step:471/4150 train_time:38568ms step_avg:81.89ms
+step:472/4150 train_time:38689ms step_avg:81.97ms
+step:473/4150 train_time:38811ms step_avg:82.05ms
+step:474/4150 train_time:38933ms step_avg:82.14ms
+step:475/4150 train_time:39056ms step_avg:82.22ms
+step:476/4150 train_time:39177ms step_avg:82.30ms
+step:477/4150 train_time:39299ms step_avg:82.39ms
+step:478/4150 train_time:39419ms step_avg:82.47ms
+step:479/4150 train_time:39542ms step_avg:82.55ms
+step:480/4150 train_time:39661ms step_avg:82.63ms
+step:481/4150 train_time:39783ms step_avg:82.71ms
+step:482/4150 train_time:39904ms step_avg:82.79ms
+step:483/4150 train_time:40027ms step_avg:82.87ms
+step:484/4150 train_time:40147ms step_avg:82.95ms
+step:485/4150 train_time:40269ms step_avg:83.03ms
+step:486/4150 train_time:40389ms step_avg:83.11ms
+step:487/4150 train_time:40512ms step_avg:83.19ms
+step:488/4150 train_time:40632ms step_avg:83.26ms
+step:489/4150 train_time:40754ms step_avg:83.34ms
+step:490/4150 train_time:40875ms step_avg:83.42ms
+step:491/4150 train_time:40998ms step_avg:83.50ms
+step:492/4150 train_time:41120ms step_avg:83.58ms
+step:493/4150 train_time:41242ms step_avg:83.65ms
+step:494/4150 train_time:41361ms step_avg:83.73ms
+step:495/4150 train_time:41482ms step_avg:83.80ms
+step:496/4150 train_time:41604ms step_avg:83.88ms
+step:497/4150 train_time:41727ms step_avg:83.96ms
+step:498/4150 train_time:41847ms step_avg:84.03ms
+step:499/4150 train_time:41969ms step_avg:84.11ms
+step:500/4150 train_time:42090ms step_avg:84.18ms
+step:500/4150 val_loss:3.9134 train_time:42202ms step_avg:84.40ms
+step:501/4150 train_time:42226ms step_avg:84.28ms
+step:502/4150 train_time:42336ms step_avg:84.33ms
+step:503/4150 train_time:42460ms step_avg:84.41ms
+step:504/4150 train_time:42585ms step_avg:84.49ms
+step:505/4150 train_time:42707ms step_avg:84.57ms
+step:506/4150 train_time:42827ms step_avg:84.64ms
+step:507/4150 train_time:42947ms step_avg:84.71ms
+step:508/4150 train_time:43066ms step_avg:84.78ms
+step:509/4150 train_time:43187ms step_avg:84.85ms
+step:510/4150 train_time:43307ms step_avg:84.92ms
+step:511/4150 train_time:43429ms step_avg:84.99ms
+step:512/4150 train_time:43554ms step_avg:85.07ms
+step:513/4150 train_time:43677ms step_avg:85.14ms
+step:514/4150 train_time:43798ms step_avg:85.21ms
+step:515/4150 train_time:43919ms step_avg:85.28ms
+step:516/4150 train_time:44039ms step_avg:85.35ms
+step:517/4150 train_time:44159ms step_avg:85.41ms
+step:518/4150 train_time:44279ms step_avg:85.48ms
+step:519/4150 train_time:44400ms step_avg:85.55ms
+step:520/4150 train_time:44522ms step_avg:85.62ms
+step:521/4150 train_time:44645ms step_avg:85.69ms
+step:522/4150 train_time:44766ms step_avg:85.76ms
+step:523/4150 train_time:44887ms step_avg:85.83ms
+step:524/4150 train_time:45006ms step_avg:85.89ms
+step:525/4150 train_time:45129ms step_avg:85.96ms
+step:526/4150 train_time:45249ms step_avg:86.03ms
+step:527/4150 train_time:45370ms step_avg:86.09ms
+step:528/4150 train_time:45492ms step_avg:86.16ms
+step:529/4150 train_time:45617ms step_avg:86.23ms
+step:530/4150 train_time:45739ms step_avg:86.30ms
+step:531/4150 train_time:45860ms step_avg:86.37ms
+step:532/4150 train_time:45980ms step_avg:86.43ms
+step:533/4150 train_time:46101ms step_avg:86.49ms
+step:534/4150 train_time:46221ms step_avg:86.56ms
+step:535/4150 train_time:46343ms step_avg:86.62ms
+step:536/4150 train_time:46462ms step_avg:86.68ms
+step:537/4150 train_time:46585ms step_avg:86.75ms
+step:538/4150 train_time:46706ms step_avg:86.81ms
+step:539/4150 train_time:46828ms step_avg:86.88ms
+step:540/4150 train_time:46951ms step_avg:86.95ms
+step:541/4150 train_time:47072ms step_avg:87.01ms
+step:542/4150 train_time:47192ms step_avg:87.07ms
+step:543/4150 train_time:47312ms step_avg:87.13ms
+step:544/4150 train_time:47433ms step_avg:87.19ms
+step:545/4150 train_time:47554ms step_avg:87.26ms
+step:546/4150 train_time:47675ms step_avg:87.32ms
+step:547/4150 train_time:47797ms step_avg:87.38ms
+step:548/4150 train_time:47917ms step_avg:87.44ms
+step:549/4150 train_time:48039ms step_avg:87.50ms
+step:550/4150 train_time:48159ms step_avg:87.56ms
+step:551/4150 train_time:48280ms step_avg:87.62ms
+step:552/4150 train_time:48400ms step_avg:87.68ms
+step:553/4150 train_time:48522ms step_avg:87.74ms
+step:554/4150 train_time:48642ms step_avg:87.80ms
+step:555/4150 train_time:48764ms step_avg:87.86ms
+step:556/4150 train_time:48885ms step_avg:87.92ms
+step:557/4150 train_time:49007ms step_avg:87.98ms
+step:558/4150 train_time:49128ms step_avg:88.04ms
+step:559/4150 train_time:49250ms step_avg:88.10ms
+step:560/4150 train_time:49369ms step_avg:88.16ms
+step:561/4150 train_time:49492ms step_avg:88.22ms
+step:562/4150 train_time:49613ms step_avg:88.28ms
+step:563/4150 train_time:49734ms step_avg:88.34ms
+step:564/4150 train_time:49854ms step_avg:88.39ms
+step:565/4150 train_time:49976ms step_avg:88.45ms
+step:566/4150 train_time:50097ms step_avg:88.51ms
+step:567/4150 train_time:50219ms step_avg:88.57ms
+step:568/4150 train_time:50340ms step_avg:88.63ms
+step:569/4150 train_time:50465ms step_avg:88.69ms
+step:570/4150 train_time:50584ms step_avg:88.74ms
+step:571/4150 train_time:50707ms step_avg:88.80ms
+step:572/4150 train_time:50826ms step_avg:88.86ms
+step:573/4150 train_time:50947ms step_avg:88.91ms
+step:574/4150 train_time:51067ms step_avg:88.97ms
+step:575/4150 train_time:51188ms step_avg:89.02ms
+step:576/4150 train_time:51308ms step_avg:89.08ms
+step:577/4150 train_time:51431ms step_avg:89.13ms
+step:578/4150 train_time:51553ms step_avg:89.19ms
+step:579/4150 train_time:51675ms step_avg:89.25ms
+step:580/4150 train_time:51795ms step_avg:89.30ms
+step:581/4150 train_time:51917ms step_avg:89.36ms
+step:582/4150 train_time:52037ms step_avg:89.41ms
+step:583/4150 train_time:52159ms step_avg:89.47ms
+step:584/4150 train_time:52279ms step_avg:89.52ms
+step:585/4150 train_time:52402ms step_avg:89.58ms
+step:586/4150 train_time:52521ms step_avg:89.63ms
+step:587/4150 train_time:52644ms step_avg:89.68ms
+step:588/4150 train_time:52764ms step_avg:89.73ms
+step:589/4150 train_time:52885ms step_avg:89.79ms
+step:590/4150 train_time:53005ms step_avg:89.84ms
+step:591/4150 train_time:53127ms step_avg:89.89ms
+step:592/4150 train_time:53247ms step_avg:89.94ms
+step:593/4150 train_time:53370ms step_avg:90.00ms
+step:594/4150 train_time:53490ms step_avg:90.05ms
+step:595/4150 train_time:53612ms step_avg:90.10ms
+step:596/4150 train_time:53734ms step_avg:90.16ms
+step:597/4150 train_time:53855ms step_avg:90.21ms
+step:598/4150 train_time:53976ms step_avg:90.26ms
+step:599/4150 train_time:54098ms step_avg:90.31ms
+step:600/4150 train_time:54218ms step_avg:90.36ms
+step:601/4150 train_time:54339ms step_avg:90.41ms
+step:602/4150 train_time:54460ms step_avg:90.47ms
+step:603/4150 train_time:54582ms step_avg:90.52ms
+step:604/4150 train_time:54703ms step_avg:90.57ms
+step:605/4150 train_time:54825ms step_avg:90.62ms
+step:606/4150 train_time:54945ms step_avg:90.67ms
+step:607/4150 train_time:55065ms step_avg:90.72ms
+step:608/4150 train_time:55184ms step_avg:90.76ms
+step:609/4150 train_time:55306ms step_avg:90.81ms
+step:610/4150 train_time:55426ms step_avg:90.86ms
+step:611/4150 train_time:55549ms step_avg:90.91ms
+step:612/4150 train_time:55672ms step_avg:90.97ms
+step:613/4150 train_time:55794ms step_avg:91.02ms
+step:614/4150 train_time:55914ms step_avg:91.06ms
+step:615/4150 train_time:56036ms step_avg:91.12ms
+step:616/4150 train_time:56156ms step_avg:91.16ms
+step:617/4150 train_time:56278ms step_avg:91.21ms
+step:618/4150 train_time:56397ms step_avg:91.26ms
+step:619/4150 train_time:56518ms step_avg:91.31ms
+step:620/4150 train_time:56638ms step_avg:91.35ms
+step:621/4150 train_time:56760ms step_avg:91.40ms
+step:622/4150 train_time:56881ms step_avg:91.45ms
+step:623/4150 train_time:57002ms step_avg:91.50ms
+step:624/4150 train_time:57122ms step_avg:91.54ms
+step:625/4150 train_time:57243ms step_avg:91.59ms
+step:626/4150 train_time:57364ms step_avg:91.64ms
+step:627/4150 train_time:57484ms step_avg:91.68ms
+step:628/4150 train_time:57605ms step_avg:91.73ms
+step:629/4150 train_time:57728ms step_avg:91.78ms
+step:630/4150 train_time:57847ms step_avg:91.82ms
+step:631/4150 train_time:57969ms step_avg:91.87ms
+step:632/4150 train_time:58089ms step_avg:91.91ms
+step:633/4150 train_time:58212ms step_avg:91.96ms
+step:634/4150 train_time:58334ms step_avg:92.01ms
+step:635/4150 train_time:58455ms step_avg:92.06ms
+step:636/4150 train_time:58576ms step_avg:92.10ms
+step:637/4150 train_time:58698ms step_avg:92.15ms
+step:638/4150 train_time:58819ms step_avg:92.19ms
+step:639/4150 train_time:58941ms step_avg:92.24ms
+step:640/4150 train_time:59062ms step_avg:92.28ms
+step:641/4150 train_time:59184ms step_avg:92.33ms
+step:642/4150 train_time:59304ms step_avg:92.37ms
+step:643/4150 train_time:59426ms step_avg:92.42ms
+step:644/4150 train_time:59547ms step_avg:92.46ms
+step:645/4150 train_time:59669ms step_avg:92.51ms
+step:646/4150 train_time:59789ms step_avg:92.55ms
+step:647/4150 train_time:59909ms step_avg:92.60ms
+step:648/4150 train_time:60030ms step_avg:92.64ms
+step:649/4150 train_time:60153ms step_avg:92.69ms
+step:650/4150 train_time:60274ms step_avg:92.73ms
+step:651/4150 train_time:60396ms step_avg:92.77ms
+step:652/4150 train_time:60516ms step_avg:92.82ms
+step:653/4150 train_time:60639ms step_avg:92.86ms
+step:654/4150 train_time:60759ms step_avg:92.90ms
+step:655/4150 train_time:60880ms step_avg:92.95ms
+step:656/4150 train_time:61000ms step_avg:92.99ms
+step:657/4150 train_time:61123ms step_avg:93.03ms
+step:658/4150 train_time:61244ms step_avg:93.08ms
+step:659/4150 train_time:61366ms step_avg:93.12ms
+step:660/4150 train_time:61485ms step_avg:93.16ms
+step:661/4150 train_time:61607ms step_avg:93.20ms
+step:662/4150 train_time:61727ms step_avg:93.24ms
+step:663/4150 train_time:61848ms step_avg:93.29ms
+step:664/4150 train_time:61970ms step_avg:93.33ms
+step:665/4150 train_time:62091ms step_avg:93.37ms
+step:666/4150 train_time:62210ms step_avg:93.41ms
+step:667/4150 train_time:62332ms step_avg:93.45ms
+step:668/4150 train_time:62453ms step_avg:93.49ms
+step:669/4150 train_time:62575ms step_avg:93.54ms
+step:670/4150 train_time:62695ms step_avg:93.57ms
+step:671/4150 train_time:62817ms step_avg:93.62ms
+step:672/4150 train_time:62937ms step_avg:93.66ms
+step:673/4150 train_time:63059ms step_avg:93.70ms
+step:674/4150 train_time:63179ms step_avg:93.74ms
+step:675/4150 train_time:63302ms step_avg:93.78ms
+step:676/4150 train_time:63423ms step_avg:93.82ms
+step:677/4150 train_time:63545ms step_avg:93.86ms
+step:678/4150 train_time:63664ms step_avg:93.90ms
+step:679/4150 train_time:63786ms step_avg:93.94ms
+step:680/4150 train_time:63906ms step_avg:93.98ms
+step:681/4150 train_time:64028ms step_avg:94.02ms
+step:682/4150 train_time:64149ms step_avg:94.06ms
+step:683/4150 train_time:64271ms step_avg:94.10ms
+step:684/4150 train_time:64391ms step_avg:94.14ms
+step:685/4150 train_time:64513ms step_avg:94.18ms
+step:686/4150 train_time:64633ms step_avg:94.22ms
+step:687/4150 train_time:64755ms step_avg:94.26ms
+step:688/4150 train_time:64875ms step_avg:94.29ms
+step:689/4150 train_time:65001ms step_avg:94.34ms
+step:690/4150 train_time:65182ms step_avg:94.47ms
+step:691/4150 train_time:65362ms step_avg:94.59ms
+step:692/4150 train_time:65540ms step_avg:94.71ms
+step:693/4150 train_time:65719ms step_avg:94.83ms
+step:694/4150 train_time:65898ms step_avg:94.95ms
+step:695/4150 train_time:66078ms step_avg:95.08ms
+step:696/4150 train_time:66259ms step_avg:95.20ms
+step:697/4150 train_time:66439ms step_avg:95.32ms
+step:698/4150 train_time:66620ms step_avg:95.44ms
+step:699/4150 train_time:66801ms step_avg:95.57ms
+step:700/4150 train_time:66980ms step_avg:95.69ms
+step:701/4150 train_time:67161ms step_avg:95.81ms
+step:702/4150 train_time:67339ms step_avg:95.93ms
+step:703/4150 train_time:67519ms step_avg:96.04ms
+step:704/4150 train_time:67700ms step_avg:96.16ms
+step:705/4150 train_time:67877ms step_avg:96.28ms
+step:706/4150 train_time:68058ms step_avg:96.40ms
+step:707/4150 train_time:68236ms step_avg:96.51ms
+step:708/4150 train_time:68413ms step_avg:96.63ms
+step:709/4150 train_time:68591ms step_avg:96.74ms
+step:710/4150 train_time:68770ms step_avg:96.86ms
+step:711/4150 train_time:68948ms step_avg:96.97ms
+step:712/4150 train_time:69128ms step_avg:97.09ms
+step:713/4150 train_time:69308ms step_avg:97.21ms
+step:714/4150 train_time:69486ms step_avg:97.32ms
+step:715/4150 train_time:69665ms step_avg:97.43ms
+step:716/4150 train_time:69844ms step_avg:97.55ms
+step:717/4150 train_time:70023ms step_avg:97.66ms
+step:718/4150 train_time:70204ms step_avg:97.78ms
+step:719/4150 train_time:70381ms step_avg:97.89ms
+step:720/4150 train_time:70561ms step_avg:98.00ms
+step:721/4150 train_time:70739ms step_avg:98.11ms
+step:722/4150 train_time:70919ms step_avg:98.23ms
+step:723/4150 train_time:71098ms step_avg:98.34ms
+step:724/4150 train_time:71278ms step_avg:98.45ms
+step:725/4150 train_time:71455ms step_avg:98.56ms
+step:726/4150 train_time:71634ms step_avg:98.67ms
+step:727/4150 train_time:71813ms step_avg:98.78ms
+step:728/4150 train_time:71995ms step_avg:98.89ms
+step:729/4150 train_time:72174ms step_avg:99.00ms
+step:730/4150 train_time:72356ms step_avg:99.12ms
+step:731/4150 train_time:72533ms step_avg:99.22ms
+step:732/4150 train_time:72713ms step_avg:99.34ms
+step:733/4150 train_time:72893ms step_avg:99.44ms
+step:734/4150 train_time:73071ms step_avg:99.55ms
+step:735/4150 train_time:73249ms step_avg:99.66ms
+step:736/4150 train_time:73430ms step_avg:99.77ms
+step:737/4150 train_time:73611ms step_avg:99.88ms
+step:738/4150 train_time:73792ms step_avg:99.99ms
+step:739/4150 train_time:73970ms step_avg:100.09ms
+step:740/4150 train_time:74151ms step_avg:100.20ms
+step:741/4150 train_time:74328ms step_avg:100.31ms
+step:742/4150 train_time:74507ms step_avg:100.41ms
+step:743/4150 train_time:74686ms step_avg:100.52ms
+step:744/4150 train_time:74866ms step_avg:100.63ms
+step:745/4150 train_time:75044ms step_avg:100.73ms
+step:746/4150 train_time:75223ms step_avg:100.84ms
+step:747/4150 train_time:75401ms step_avg:100.94ms
+step:748/4150 train_time:75581ms step_avg:101.04ms
+step:749/4150 train_time:75762ms step_avg:101.15ms
+step:750/4150 train_time:75942ms step_avg:101.26ms
+step:750/4150 val_loss:3.5730 train_time:76108ms step_avg:101.48ms
+step:751/4150 train_time:76131ms step_avg:101.37ms
+step:752/4150 train_time:76306ms step_avg:101.47ms
+step:753/4150 train_time:76490ms step_avg:101.58ms
+step:754/4150 train_time:76670ms step_avg:101.68ms
+step:755/4150 train_time:76846ms step_avg:101.78ms
+step:756/4150 train_time:77023ms step_avg:101.88ms
+step:757/4150 train_time:77203ms step_avg:101.99ms
+step:758/4150 train_time:77386ms step_avg:102.09ms
+step:759/4150 train_time:77566ms step_avg:102.20ms
+step:760/4150 train_time:77746ms step_avg:102.30ms
+step:761/4150 train_time:77924ms step_avg:102.40ms
+step:762/4150 train_time:78102ms step_avg:102.50ms
+step:763/4150 train_time:78281ms step_avg:102.60ms
+step:764/4150 train_time:78465ms step_avg:102.70ms
+step:765/4150 train_time:78647ms step_avg:102.81ms
+step:766/4150 train_time:78827ms step_avg:102.91ms
+step:767/4150 train_time:79004ms step_avg:103.00ms
+step:768/4150 train_time:79181ms step_avg:103.10ms
+step:769/4150 train_time:79361ms step_avg:103.20ms
+step:770/4150 train_time:79543ms step_avg:103.30ms
+step:771/4150 train_time:79720ms step_avg:103.40ms
+step:772/4150 train_time:79900ms step_avg:103.50ms
+step:773/4150 train_time:80079ms step_avg:103.60ms
+step:774/4150 train_time:80258ms step_avg:103.69ms
+step:775/4150 train_time:80437ms step_avg:103.79ms
+step:776/4150 train_time:80619ms step_avg:103.89ms
+step:777/4150 train_time:80798ms step_avg:103.99ms
+step:778/4150 train_time:80977ms step_avg:104.08ms
+step:779/4150 train_time:81154ms step_avg:104.18ms
+step:780/4150 train_time:81331ms step_avg:104.27ms
+step:781/4150 train_time:81510ms step_avg:104.37ms
+step:782/4150 train_time:81690ms step_avg:104.46ms
+step:783/4150 train_time:81868ms step_avg:104.56ms
+step:784/4150 train_time:82046ms step_avg:104.65ms
+step:785/4150 train_time:82226ms step_avg:104.75ms
+step:786/4150 train_time:82405ms step_avg:104.84ms
+step:787/4150 train_time:82584ms step_avg:104.93ms
+step:788/4150 train_time:82763ms step_avg:105.03ms
+step:789/4150 train_time:82942ms step_avg:105.12ms
+step:790/4150 train_time:83121ms step_avg:105.22ms
+step:791/4150 train_time:83302ms step_avg:105.31ms
+step:792/4150 train_time:83484ms step_avg:105.41ms
+step:793/4150 train_time:83662ms step_avg:105.50ms
+step:794/4150 train_time:83842ms step_avg:105.59ms
+step:795/4150 train_time:84021ms step_avg:105.69ms
+step:796/4150 train_time:84202ms step_avg:105.78ms
+step:797/4150 train_time:84381ms step_avg:105.87ms
+step:798/4150 train_time:84563ms step_avg:105.97ms
+step:799/4150 train_time:84741ms step_avg:106.06ms
+step:800/4150 train_time:84921ms step_avg:106.15ms
+step:801/4150 train_time:85098ms step_avg:106.24ms
+step:802/4150 train_time:85279ms step_avg:106.33ms
+step:803/4150 train_time:85457ms step_avg:106.42ms
+step:804/4150 train_time:85636ms step_avg:106.51ms
+step:805/4150 train_time:85815ms step_avg:106.60ms
+step:806/4150 train_time:85995ms step_avg:106.69ms
+step:807/4150 train_time:86174ms step_avg:106.78ms
+step:808/4150 train_time:86355ms step_avg:106.87ms
+step:809/4150 train_time:86532ms step_avg:106.96ms
+step:810/4150 train_time:86711ms step_avg:107.05ms
+step:811/4150 train_time:86889ms step_avg:107.14ms
+step:812/4150 train_time:87069ms step_avg:107.23ms
+step:813/4150 train_time:87247ms step_avg:107.31ms
+step:814/4150 train_time:87426ms step_avg:107.40ms
+step:815/4150 train_time:87606ms step_avg:107.49ms
+step:816/4150 train_time:87783ms step_avg:107.58ms
+step:817/4150 train_time:87961ms step_avg:107.66ms
+step:818/4150 train_time:88141ms step_avg:107.75ms
+step:819/4150 train_time:88319ms step_avg:107.84ms
+step:820/4150 train_time:88499ms step_avg:107.93ms
+step:821/4150 train_time:88680ms step_avg:108.01ms
+step:822/4150 train_time:88859ms step_avg:108.10ms
+step:823/4150 train_time:89040ms step_avg:108.19ms
+step:824/4150 train_time:89220ms step_avg:108.28ms
+step:825/4150 train_time:89397ms step_avg:108.36ms
+step:826/4150 train_time:89575ms step_avg:108.44ms
+step:827/4150 train_time:89753ms step_avg:108.53ms
+step:828/4150 train_time:89932ms step_avg:108.61ms
+step:829/4150 train_time:90112ms step_avg:108.70ms
+step:830/4150 train_time:90292ms step_avg:108.79ms
+step:831/4150 train_time:90470ms step_avg:108.87ms
+step:832/4150 train_time:90650ms step_avg:108.95ms
+step:833/4150 train_time:90827ms step_avg:109.04ms
+step:834/4150 train_time:91008ms step_avg:109.12ms
+step:835/4150 train_time:91186ms step_avg:109.20ms
+step:836/4150 train_time:91366ms step_avg:109.29ms
+step:837/4150 train_time:91544ms step_avg:109.37ms
+step:838/4150 train_time:91725ms step_avg:109.46ms
+step:839/4150 train_time:91904ms step_avg:109.54ms
+step:840/4150 train_time:92086ms step_avg:109.63ms
+step:841/4150 train_time:92264ms step_avg:109.71ms
+step:842/4150 train_time:92442ms step_avg:109.79ms
+step:843/4150 train_time:92621ms step_avg:109.87ms
+step:844/4150 train_time:92800ms step_avg:109.95ms
+step:845/4150 train_time:92978ms step_avg:110.03ms
+step:846/4150 train_time:93160ms step_avg:110.12ms
+step:847/4150 train_time:93338ms step_avg:110.20ms
+step:848/4150 train_time:93521ms step_avg:110.28ms
+step:849/4150 train_time:93697ms step_avg:110.36ms
+step:850/4150 train_time:93874ms step_avg:110.44ms
+step:851/4150 train_time:94053ms step_avg:110.52ms
+step:852/4150 train_time:94238ms step_avg:110.61ms
+step:853/4150 train_time:94415ms step_avg:110.69ms
+step:854/4150 train_time:94594ms step_avg:110.77ms
+step:855/4150 train_time:94771ms step_avg:110.84ms
+step:856/4150 train_time:94951ms step_avg:110.92ms
+step:857/4150 train_time:95130ms step_avg:111.00ms
+step:858/4150 train_time:95309ms step_avg:111.08ms
+step:859/4150 train_time:95487ms step_avg:111.16ms
+step:860/4150 train_time:95666ms step_avg:111.24ms
+step:861/4150 train_time:95845ms step_avg:111.32ms
+step:862/4150 train_time:96026ms step_avg:111.40ms
+step:863/4150 train_time:96205ms step_avg:111.48ms
+step:864/4150 train_time:96384ms step_avg:111.56ms
+step:865/4150 train_time:96563ms step_avg:111.63ms
+step:866/4150 train_time:96745ms step_avg:111.71ms
+step:867/4150 train_time:96924ms step_avg:111.79ms
+step:868/4150 train_time:97105ms step_avg:111.87ms
+step:869/4150 train_time:97284ms step_avg:111.95ms
+step:870/4150 train_time:97463ms step_avg:112.03ms
+step:871/4150 train_time:97642ms step_avg:112.10ms
+step:872/4150 train_time:97822ms step_avg:112.18ms
+step:873/4150 train_time:98000ms step_avg:112.26ms
+step:874/4150 train_time:98183ms step_avg:112.34ms
+step:875/4150 train_time:98360ms step_avg:112.41ms
+step:876/4150 train_time:98539ms step_avg:112.49ms
+step:877/4150 train_time:98717ms step_avg:112.56ms
+step:878/4150 train_time:98895ms step_avg:112.64ms
+step:879/4150 train_time:99074ms step_avg:112.71ms
+step:880/4150 train_time:99254ms step_avg:112.79ms
+step:881/4150 train_time:99433ms step_avg:112.86ms
+step:882/4150 train_time:99610ms step_avg:112.94ms
+step:883/4150 train_time:99790ms step_avg:113.01ms
+step:884/4150 train_time:99971ms step_avg:113.09ms
+step:885/4150 train_time:100148ms step_avg:113.16ms
+step:886/4150 train_time:100329ms step_avg:113.24ms
+step:887/4150 train_time:100507ms step_avg:113.31ms
+step:888/4150 train_time:100686ms step_avg:113.39ms
+step:889/4150 train_time:100863ms step_avg:113.46ms
+step:890/4150 train_time:101042ms step_avg:113.53ms
+step:891/4150 train_time:101223ms step_avg:113.61ms
+step:892/4150 train_time:101404ms step_avg:113.68ms
+step:893/4150 train_time:101582ms step_avg:113.75ms
+step:894/4150 train_time:101760ms step_avg:113.83ms
+step:895/4150 train_time:101939ms step_avg:113.90ms
+step:896/4150 train_time:102121ms step_avg:113.97ms
+step:897/4150 train_time:102300ms step_avg:114.05ms
+step:898/4150 train_time:102482ms step_avg:114.12ms
+step:899/4150 train_time:102658ms step_avg:114.19ms
+step:900/4150 train_time:102836ms step_avg:114.26ms
+step:901/4150 train_time:103013ms step_avg:114.33ms
+step:902/4150 train_time:103191ms step_avg:114.40ms
+step:903/4150 train_time:103371ms step_avg:114.47ms
+step:904/4150 train_time:103550ms step_avg:114.55ms
+step:905/4150 train_time:103727ms step_avg:114.62ms
+step:906/4150 train_time:103907ms step_avg:114.69ms
+step:907/4150 train_time:104084ms step_avg:114.76ms
+step:908/4150 train_time:104264ms step_avg:114.83ms
+step:909/4150 train_time:104445ms step_avg:114.90ms
+step:910/4150 train_time:104624ms step_avg:114.97ms
+step:911/4150 train_time:104802ms step_avg:115.04ms
+step:912/4150 train_time:104980ms step_avg:115.11ms
+step:913/4150 train_time:105159ms step_avg:115.18ms
+step:914/4150 train_time:105341ms step_avg:115.25ms
+step:915/4150 train_time:105519ms step_avg:115.32ms
+step:916/4150 train_time:105701ms step_avg:115.39ms
+step:917/4150 train_time:105879ms step_avg:115.46ms
+step:918/4150 train_time:106059ms step_avg:115.53ms
+step:919/4150 train_time:106237ms step_avg:115.60ms
+step:920/4150 train_time:106419ms step_avg:115.67ms
+step:921/4150 train_time:106599ms step_avg:115.74ms
+step:922/4150 train_time:106779ms step_avg:115.81ms
+step:923/4150 train_time:106957ms step_avg:115.88ms
+step:924/4150 train_time:107138ms step_avg:115.95ms
+step:925/4150 train_time:107317ms step_avg:116.02ms
+step:926/4150 train_time:107497ms step_avg:116.09ms
+step:927/4150 train_time:107678ms step_avg:116.16ms
+step:928/4150 train_time:107860ms step_avg:116.23ms
+step:929/4150 train_time:108039ms step_avg:116.30ms
+step:930/4150 train_time:108219ms step_avg:116.36ms
+step:931/4150 train_time:108398ms step_avg:116.43ms
+step:932/4150 train_time:108579ms step_avg:116.50ms
+step:933/4150 train_time:108758ms step_avg:116.57ms
+step:934/4150 train_time:108939ms step_avg:116.64ms
+step:935/4150 train_time:109115ms step_avg:116.70ms
+step:936/4150 train_time:109294ms step_avg:116.77ms
+step:937/4150 train_time:109472ms step_avg:116.83ms
+step:938/4150 train_time:109652ms step_avg:116.90ms
+step:939/4150 train_time:109829ms step_avg:116.96ms
+step:940/4150 train_time:110011ms step_avg:117.03ms
+step:941/4150 train_time:110188ms step_avg:117.10ms
+step:942/4150 train_time:110366ms step_avg:117.16ms
+step:943/4150 train_time:110546ms step_avg:117.23ms
+step:944/4150 train_time:110727ms step_avg:117.30ms
+step:945/4150 train_time:110906ms step_avg:117.36ms
+step:946/4150 train_time:111087ms step_avg:117.43ms
+step:947/4150 train_time:111267ms step_avg:117.49ms
+step:948/4150 train_time:111445ms step_avg:117.56ms
+step:949/4150 train_time:111623ms step_avg:117.62ms
+step:950/4150 train_time:111803ms step_avg:117.69ms
+step:951/4150 train_time:111980ms step_avg:117.75ms
+step:952/4150 train_time:112161ms step_avg:117.82ms
+step:953/4150 train_time:112341ms step_avg:117.88ms
+step:954/4150 train_time:112520ms step_avg:117.95ms
+step:955/4150 train_time:112698ms step_avg:118.01ms
+step:956/4150 train_time:112879ms step_avg:118.07ms
+step:957/4150 train_time:113058ms step_avg:118.14ms
+step:958/4150 train_time:113241ms step_avg:118.21ms
+step:959/4150 train_time:113420ms step_avg:118.27ms
+step:960/4150 train_time:113603ms step_avg:118.34ms
+step:961/4150 train_time:113782ms step_avg:118.40ms
+step:962/4150 train_time:113962ms step_avg:118.46ms
+step:963/4150 train_time:114142ms step_avg:118.53ms
+step:964/4150 train_time:114323ms step_avg:118.59ms
+step:965/4150 train_time:114502ms step_avg:118.65ms
+step:966/4150 train_time:114682ms step_avg:118.72ms
+step:967/4150 train_time:114861ms step_avg:118.78ms
+step:968/4150 train_time:115041ms step_avg:118.84ms
+step:969/4150 train_time:115220ms step_avg:118.91ms
+step:970/4150 train_time:115399ms step_avg:118.97ms
+step:971/4150 train_time:115578ms step_avg:119.03ms
+step:972/4150 train_time:115756ms step_avg:119.09ms
+step:973/4150 train_time:115936ms step_avg:119.15ms
+step:974/4150 train_time:116115ms step_avg:119.21ms
+step:975/4150 train_time:116293ms step_avg:119.28ms
+step:976/4150 train_time:116471ms step_avg:119.34ms
+step:977/4150 train_time:116650ms step_avg:119.40ms
+step:978/4150 train_time:116830ms step_avg:119.46ms
+step:979/4150 train_time:117012ms step_avg:119.52ms
+step:980/4150 train_time:117191ms step_avg:119.58ms
+step:981/4150 train_time:117367ms step_avg:119.64ms
+step:982/4150 train_time:117548ms step_avg:119.70ms
+step:983/4150 train_time:117726ms step_avg:119.76ms
+step:984/4150 train_time:117906ms step_avg:119.82ms
+step:985/4150 train_time:118084ms step_avg:119.88ms
+step:986/4150 train_time:118263ms step_avg:119.94ms
+step:987/4150 train_time:118443ms step_avg:120.00ms
+step:988/4150 train_time:118623ms step_avg:120.06ms
+step:989/4150 train_time:118801ms step_avg:120.12ms
+step:990/4150 train_time:118981ms step_avg:120.18ms
+step:991/4150 train_time:119161ms step_avg:120.24ms
+step:992/4150 train_time:119345ms step_avg:120.31ms
+step:993/4150 train_time:119526ms step_avg:120.37ms
+step:994/4150 train_time:119704ms step_avg:120.43ms
+step:995/4150 train_time:119882ms step_avg:120.48ms
+step:996/4150 train_time:120062ms step_avg:120.54ms
+step:997/4150 train_time:120241ms step_avg:120.60ms
+step:998/4150 train_time:120418ms step_avg:120.66ms
+step:999/4150 train_time:120597ms step_avg:120.72ms
+step:1000/4150 train_time:120775ms step_avg:120.78ms
+step:1000/4150 val_loss:3.4410 train_time:120939ms step_avg:120.94ms
+step:1001/4150 train_time:120962ms step_avg:120.84ms
+step:1002/4150 train_time:121135ms step_avg:120.89ms
+step:1003/4150 train_time:121318ms step_avg:120.95ms
+step:1004/4150 train_time:121496ms step_avg:121.01ms
+step:1005/4150 train_time:121673ms step_avg:121.07ms
+step:1006/4150 train_time:121852ms step_avg:121.13ms
+step:1007/4150 train_time:122032ms step_avg:121.18ms
+step:1008/4150 train_time:122212ms step_avg:121.24ms
+step:1009/4150 train_time:122392ms step_avg:121.30ms
+step:1010/4150 train_time:122570ms step_avg:121.36ms
+step:1011/4150 train_time:122747ms step_avg:121.41ms
+step:1012/4150 train_time:122927ms step_avg:121.47ms
+step:1013/4150 train_time:123107ms step_avg:121.53ms
+step:1014/4150 train_time:123287ms step_avg:121.59ms
+step:1015/4150 train_time:123465ms step_avg:121.64ms
+step:1016/4150 train_time:123644ms step_avg:121.70ms
+step:1017/4150 train_time:123821ms step_avg:121.75ms
+step:1018/4150 train_time:124001ms step_avg:121.81ms
+step:1019/4150 train_time:124178ms step_avg:121.86ms
+step:1020/4150 train_time:124357ms step_avg:121.92ms
+step:1021/4150 train_time:124536ms step_avg:121.97ms
+step:1022/4150 train_time:124715ms step_avg:122.03ms
+step:1023/4150 train_time:124893ms step_avg:122.09ms
+step:1024/4150 train_time:125073ms step_avg:122.14ms
+step:1025/4150 train_time:125252ms step_avg:122.20ms
+step:1026/4150 train_time:125433ms step_avg:122.25ms
+step:1027/4150 train_time:125611ms step_avg:122.31ms
+step:1028/4150 train_time:125790ms step_avg:122.36ms
+step:1029/4150 train_time:125968ms step_avg:122.42ms
+step:1030/4150 train_time:126148ms step_avg:122.47ms
+step:1031/4150 train_time:126326ms step_avg:122.53ms
+step:1032/4150 train_time:126507ms step_avg:122.58ms
+step:1033/4150 train_time:126690ms step_avg:122.64ms
+step:1034/4150 train_time:126926ms step_avg:122.75ms
+step:1035/4150 train_time:127162ms step_avg:122.86ms
+step:1036/4150 train_time:127399ms step_avg:122.97ms
+step:1037/4150 train_time:127631ms step_avg:123.08ms
+step:1038/4150 train_time:127863ms step_avg:123.18ms
+step:1039/4150 train_time:128095ms step_avg:123.29ms
+step:1040/4150 train_time:128329ms step_avg:123.39ms
+step:1041/4150 train_time:128562ms step_avg:123.50ms
+step:1042/4150 train_time:128797ms step_avg:123.61ms
+step:1043/4150 train_time:129028ms step_avg:123.71ms
+step:1044/4150 train_time:129264ms step_avg:123.82ms
+step:1045/4150 train_time:129497ms step_avg:123.92ms
+step:1046/4150 train_time:129733ms step_avg:124.03ms
+step:1047/4150 train_time:129963ms step_avg:124.13ms
+step:1048/4150 train_time:130198ms step_avg:124.23ms
+step:1049/4150 train_time:130430ms step_avg:124.34ms
+step:1050/4150 train_time:130667ms step_avg:124.45ms
+step:1051/4150 train_time:130901ms step_avg:124.55ms
+step:1052/4150 train_time:131136ms step_avg:124.65ms
+step:1053/4150 train_time:131367ms step_avg:124.76ms
+step:1054/4150 train_time:131602ms step_avg:124.86ms
+step:1055/4150 train_time:131836ms step_avg:124.96ms
+step:1056/4150 train_time:132069ms step_avg:125.06ms
+step:1057/4150 train_time:132299ms step_avg:125.16ms
+step:1058/4150 train_time:132532ms step_avg:125.27ms
+step:1059/4150 train_time:132766ms step_avg:125.37ms
+step:1060/4150 train_time:133000ms step_avg:125.47ms
+step:1061/4150 train_time:133228ms step_avg:125.57ms
+step:1062/4150 train_time:133464ms step_avg:125.67ms
+step:1063/4150 train_time:133696ms step_avg:125.77ms
+step:1064/4150 train_time:133933ms step_avg:125.88ms
+step:1065/4150 train_time:134165ms step_avg:125.98ms
+step:1066/4150 train_time:134400ms step_avg:126.08ms
+step:1067/4150 train_time:134630ms step_avg:126.18ms
+step:1068/4150 train_time:134865ms step_avg:126.28ms
+step:1069/4150 train_time:135097ms step_avg:126.38ms
+step:1070/4150 train_time:135334ms step_avg:126.48ms
+step:1071/4150 train_time:135565ms step_avg:126.58ms
+step:1072/4150 train_time:135799ms step_avg:126.68ms
+step:1073/4150 train_time:136029ms step_avg:126.77ms
+step:1074/4150 train_time:136265ms step_avg:126.88ms
+step:1075/4150 train_time:136500ms step_avg:126.98ms
+step:1076/4150 train_time:136734ms step_avg:127.08ms
+step:1077/4150 train_time:136966ms step_avg:127.17ms
+step:1078/4150 train_time:137200ms step_avg:127.27ms
+step:1079/4150 train_time:137431ms step_avg:127.37ms
+step:1080/4150 train_time:137664ms step_avg:127.47ms
+step:1081/4150 train_time:137898ms step_avg:127.57ms
+step:1082/4150 train_time:138133ms step_avg:127.66ms
+step:1083/4150 train_time:138365ms step_avg:127.76ms
+step:1084/4150 train_time:138599ms step_avg:127.86ms
+step:1085/4150 train_time:138829ms step_avg:127.95ms
+step:1086/4150 train_time:139065ms step_avg:128.05ms
+step:1087/4150 train_time:139298ms step_avg:128.15ms
+step:1088/4150 train_time:139532ms step_avg:128.25ms
+step:1089/4150 train_time:139763ms step_avg:128.34ms
+step:1090/4150 train_time:139999ms step_avg:128.44ms
+step:1091/4150 train_time:140229ms step_avg:128.53ms
+step:1092/4150 train_time:140465ms step_avg:128.63ms
+step:1093/4150 train_time:140697ms step_avg:128.73ms
+step:1094/4150 train_time:140933ms step_avg:128.82ms
+step:1095/4150 train_time:141164ms step_avg:128.92ms
+step:1096/4150 train_time:141397ms step_avg:129.01ms
+step:1097/4150 train_time:141628ms step_avg:129.11ms
+step:1098/4150 train_time:141862ms step_avg:129.20ms
+step:1099/4150 train_time:142093ms step_avg:129.29ms
+step:1100/4150 train_time:142326ms step_avg:129.39ms
+step:1101/4150 train_time:142556ms step_avg:129.48ms
+step:1102/4150 train_time:142789ms step_avg:129.57ms
+step:1103/4150 train_time:143020ms step_avg:129.66ms
+step:1104/4150 train_time:143256ms step_avg:129.76ms
+step:1105/4150 train_time:143488ms step_avg:129.85ms
+step:1106/4150 train_time:143721ms step_avg:129.95ms
+step:1107/4150 train_time:143953ms step_avg:130.04ms
+step:1108/4150 train_time:144187ms step_avg:130.13ms
+step:1109/4150 train_time:144419ms step_avg:130.22ms
+step:1110/4150 train_time:144655ms step_avg:130.32ms
+step:1111/4150 train_time:144888ms step_avg:130.41ms
+step:1112/4150 train_time:145124ms step_avg:130.51ms
+step:1113/4150 train_time:145357ms step_avg:130.60ms
+step:1114/4150 train_time:145591ms step_avg:130.69ms
+step:1115/4150 train_time:145820ms step_avg:130.78ms
+step:1116/4150 train_time:146055ms step_avg:130.87ms
+step:1117/4150 train_time:146288ms step_avg:130.97ms
+step:1118/4150 train_time:146522ms step_avg:131.06ms
+step:1119/4150 train_time:146758ms step_avg:131.15ms
+step:1120/4150 train_time:146995ms step_avg:131.25ms
+step:1121/4150 train_time:147227ms step_avg:131.34ms
+step:1122/4150 train_time:147460ms step_avg:131.43ms
+step:1123/4150 train_time:147691ms step_avg:131.51ms
+step:1124/4150 train_time:147929ms step_avg:131.61ms
+step:1125/4150 train_time:148160ms step_avg:131.70ms
+step:1126/4150 train_time:148393ms step_avg:131.79ms
+step:1127/4150 train_time:148623ms step_avg:131.87ms
+step:1128/4150 train_time:148862ms step_avg:131.97ms
+step:1129/4150 train_time:149096ms step_avg:132.06ms
+step:1130/4150 train_time:149332ms step_avg:132.15ms
+step:1131/4150 train_time:149561ms step_avg:132.24ms
+step:1132/4150 train_time:149795ms step_avg:132.33ms
+step:1133/4150 train_time:150027ms step_avg:132.42ms
+step:1134/4150 train_time:150260ms step_avg:132.50ms
+step:1135/4150 train_time:150491ms step_avg:132.59ms
+step:1136/4150 train_time:150725ms step_avg:132.68ms
+step:1137/4150 train_time:150960ms step_avg:132.77ms
+step:1138/4150 train_time:151198ms step_avg:132.86ms
+step:1139/4150 train_time:151428ms step_avg:132.95ms
+step:1140/4150 train_time:151664ms step_avg:133.04ms
+step:1141/4150 train_time:151899ms step_avg:133.13ms
+step:1142/4150 train_time:152136ms step_avg:133.22ms
+step:1143/4150 train_time:152369ms step_avg:133.31ms
+step:1144/4150 train_time:152603ms step_avg:133.39ms
+step:1145/4150 train_time:152837ms step_avg:133.48ms
+step:1146/4150 train_time:153073ms step_avg:133.57ms
+step:1147/4150 train_time:153302ms step_avg:133.65ms
+step:1148/4150 train_time:153539ms step_avg:133.74ms
+step:1149/4150 train_time:153768ms step_avg:133.83ms
+step:1150/4150 train_time:154005ms step_avg:133.92ms
+step:1151/4150 train_time:154235ms step_avg:134.00ms
+step:1152/4150 train_time:154467ms step_avg:134.09ms
+step:1153/4150 train_time:154701ms step_avg:134.17ms
+step:1154/4150 train_time:154938ms step_avg:134.26ms
+step:1155/4150 train_time:155168ms step_avg:134.34ms
+step:1156/4150 train_time:155401ms step_avg:134.43ms
+step:1157/4150 train_time:155635ms step_avg:134.52ms
+step:1158/4150 train_time:155868ms step_avg:134.60ms
+step:1159/4150 train_time:156099ms step_avg:134.68ms
+step:1160/4150 train_time:156335ms step_avg:134.77ms
+step:1161/4150 train_time:156567ms step_avg:134.86ms
+step:1162/4150 train_time:156802ms step_avg:134.94ms
+step:1163/4150 train_time:157031ms step_avg:135.02ms
+step:1164/4150 train_time:157266ms step_avg:135.11ms
+step:1165/4150 train_time:157499ms step_avg:135.19ms
+step:1166/4150 train_time:157734ms step_avg:135.28ms
+step:1167/4150 train_time:157964ms step_avg:135.36ms
+step:1168/4150 train_time:158198ms step_avg:135.44ms
+step:1169/4150 train_time:158429ms step_avg:135.53ms
+step:1170/4150 train_time:158665ms step_avg:135.61ms
+step:1171/4150 train_time:158896ms step_avg:135.69ms
+step:1172/4150 train_time:159131ms step_avg:135.78ms
+step:1173/4150 train_time:159365ms step_avg:135.86ms
+step:1174/4150 train_time:159602ms step_avg:135.95ms
+step:1175/4150 train_time:159834ms step_avg:136.03ms
+step:1176/4150 train_time:160066ms step_avg:136.11ms
+step:1177/4150 train_time:160299ms step_avg:136.19ms
+step:1178/4150 train_time:160534ms step_avg:136.28ms
+step:1179/4150 train_time:160767ms step_avg:136.36ms
+step:1180/4150 train_time:161001ms step_avg:136.44ms
+step:1181/4150 train_time:161234ms step_avg:136.52ms
+step:1182/4150 train_time:161470ms step_avg:136.61ms
+step:1183/4150 train_time:161702ms step_avg:136.69ms
+step:1184/4150 train_time:161937ms step_avg:136.77ms
+step:1185/4150 train_time:162169ms step_avg:136.85ms
+step:1186/4150 train_time:162404ms step_avg:136.93ms
+step:1187/4150 train_time:162636ms step_avg:137.01ms
+step:1188/4150 train_time:162870ms step_avg:137.10ms
+step:1189/4150 train_time:163101ms step_avg:137.18ms
+step:1190/4150 train_time:163336ms step_avg:137.26ms
+step:1191/4150 train_time:163567ms step_avg:137.34ms
+step:1192/4150 train_time:163802ms step_avg:137.42ms
+step:1193/4150 train_time:164032ms step_avg:137.50ms
+step:1194/4150 train_time:164266ms step_avg:137.58ms
+step:1195/4150 train_time:164498ms step_avg:137.66ms
+step:1196/4150 train_time:164735ms step_avg:137.74ms
+step:1197/4150 train_time:164966ms step_avg:137.82ms
+step:1198/4150 train_time:165201ms step_avg:137.90ms
+step:1199/4150 train_time:165431ms step_avg:137.97ms
+step:1200/4150 train_time:165666ms step_avg:138.06ms
+step:1201/4150 train_time:165899ms step_avg:138.13ms
+step:1202/4150 train_time:166133ms step_avg:138.21ms
+step:1203/4150 train_time:166363ms step_avg:138.29ms
+step:1204/4150 train_time:166600ms step_avg:138.37ms
+step:1205/4150 train_time:166834ms step_avg:138.45ms
+step:1206/4150 train_time:167069ms step_avg:138.53ms
+step:1207/4150 train_time:167300ms step_avg:138.61ms
+step:1208/4150 train_time:167535ms step_avg:138.69ms
+step:1209/4150 train_time:167768ms step_avg:138.77ms
+step:1210/4150 train_time:168001ms step_avg:138.84ms
+step:1211/4150 train_time:168231ms step_avg:138.92ms
+step:1212/4150 train_time:168467ms step_avg:139.00ms
+step:1213/4150 train_time:168702ms step_avg:139.08ms
+step:1214/4150 train_time:168935ms step_avg:139.16ms
+step:1215/4150 train_time:169167ms step_avg:139.23ms
+step:1216/4150 train_time:169401ms step_avg:139.31ms
+step:1217/4150 train_time:169634ms step_avg:139.39ms
+step:1218/4150 train_time:169866ms step_avg:139.46ms
+step:1219/4150 train_time:170096ms step_avg:139.54ms
+step:1220/4150 train_time:170332ms step_avg:139.62ms
+step:1221/4150 train_time:170563ms step_avg:139.69ms
+step:1222/4150 train_time:170799ms step_avg:139.77ms
+step:1223/4150 train_time:171030ms step_avg:139.84ms
+step:1224/4150 train_time:171264ms step_avg:139.92ms
+step:1225/4150 train_time:171495ms step_avg:140.00ms
+step:1226/4150 train_time:171728ms step_avg:140.07ms
+step:1227/4150 train_time:171960ms step_avg:140.15ms
+step:1228/4150 train_time:172194ms step_avg:140.22ms
+step:1229/4150 train_time:172427ms step_avg:140.30ms
+step:1230/4150 train_time:172661ms step_avg:140.37ms
+step:1231/4150 train_time:172891ms step_avg:140.45ms
+step:1232/4150 train_time:173124ms step_avg:140.52ms
+step:1233/4150 train_time:173356ms step_avg:140.60ms
+step:1234/4150 train_time:173593ms step_avg:140.67ms
+step:1235/4150 train_time:173824ms step_avg:140.75ms
+step:1236/4150 train_time:174060ms step_avg:140.83ms
+step:1237/4150 train_time:174293ms step_avg:140.90ms
+step:1238/4150 train_time:174526ms step_avg:140.97ms
+step:1239/4150 train_time:174759ms step_avg:141.05ms
+step:1240/4150 train_time:174994ms step_avg:141.12ms
+step:1241/4150 train_time:175225ms step_avg:141.20ms
+step:1242/4150 train_time:175460ms step_avg:141.27ms
+step:1243/4150 train_time:175693ms step_avg:141.35ms
+step:1244/4150 train_time:175927ms step_avg:141.42ms
+step:1245/4150 train_time:176158ms step_avg:141.49ms
+step:1246/4150 train_time:176395ms step_avg:141.57ms
+step:1247/4150 train_time:176624ms step_avg:141.64ms
+step:1248/4150 train_time:176861ms step_avg:141.72ms
+step:1249/4150 train_time:177092ms step_avg:141.79ms
+step:1250/4150 train_time:177325ms step_avg:141.86ms
+step:1250/4150 val_loss:3.3589 train_time:177538ms step_avg:142.03ms
+step:1251/4150 train_time:177562ms step_avg:141.94ms
+step:1252/4150 train_time:177798ms step_avg:142.01ms
+step:1253/4150 train_time:178031ms step_avg:142.08ms
+step:1254/4150 train_time:178262ms step_avg:142.15ms
+step:1255/4150 train_time:178492ms step_avg:142.22ms
+step:1256/4150 train_time:178727ms step_avg:142.30ms
+step:1257/4150 train_time:178960ms step_avg:142.37ms
+step:1258/4150 train_time:179192ms step_avg:142.44ms
+step:1259/4150 train_time:179423ms step_avg:142.51ms
+step:1260/4150 train_time:179657ms step_avg:142.58ms
+step:1261/4150 train_time:179890ms step_avg:142.66ms
+step:1262/4150 train_time:180126ms step_avg:142.73ms
+step:1263/4150 train_time:180354ms step_avg:142.80ms
+step:1264/4150 train_time:180590ms step_avg:142.87ms
+step:1265/4150 train_time:180822ms step_avg:142.94ms
+step:1266/4150 train_time:181058ms step_avg:143.02ms
+step:1267/4150 train_time:181288ms step_avg:143.08ms
+step:1268/4150 train_time:181521ms step_avg:143.16ms
+step:1269/4150 train_time:181754ms step_avg:143.23ms
+step:1270/4150 train_time:181990ms step_avg:143.30ms
+step:1271/4150 train_time:182223ms step_avg:143.37ms
+step:1272/4150 train_time:182455ms step_avg:143.44ms
+step:1273/4150 train_time:182685ms step_avg:143.51ms
+step:1274/4150 train_time:182918ms step_avg:143.58ms
+step:1275/4150 train_time:183151ms step_avg:143.65ms
+step:1276/4150 train_time:183386ms step_avg:143.72ms
+step:1277/4150 train_time:183619ms step_avg:143.79ms
+step:1278/4150 train_time:183851ms step_avg:143.86ms
+step:1279/4150 train_time:184085ms step_avg:143.93ms
+step:1280/4150 train_time:184320ms step_avg:144.00ms
+step:1281/4150 train_time:184551ms step_avg:144.07ms
+step:1282/4150 train_time:184785ms step_avg:144.14ms
+step:1283/4150 train_time:185018ms step_avg:144.21ms
+step:1284/4150 train_time:185253ms step_avg:144.28ms
+step:1285/4150 train_time:185484ms step_avg:144.35ms
+step:1286/4150 train_time:185718ms step_avg:144.42ms
+step:1287/4150 train_time:185951ms step_avg:144.48ms
+step:1288/4150 train_time:186183ms step_avg:144.55ms
+step:1289/4150 train_time:186415ms step_avg:144.62ms
+step:1290/4150 train_time:186650ms step_avg:144.69ms
+step:1291/4150 train_time:186883ms step_avg:144.76ms
+step:1292/4150 train_time:187117ms step_avg:144.83ms
+step:1293/4150 train_time:187348ms step_avg:144.89ms
+step:1294/4150 train_time:187583ms step_avg:144.96ms
+step:1295/4150 train_time:187815ms step_avg:145.03ms
+step:1296/4150 train_time:188051ms step_avg:145.10ms
+step:1297/4150 train_time:188283ms step_avg:145.17ms
+step:1298/4150 train_time:188519ms step_avg:145.24ms
+step:1299/4150 train_time:188751ms step_avg:145.30ms
+step:1300/4150 train_time:188985ms step_avg:145.37ms
+step:1301/4150 train_time:189219ms step_avg:145.44ms
+step:1302/4150 train_time:189452ms step_avg:145.51ms
+step:1303/4150 train_time:189687ms step_avg:145.58ms
+step:1304/4150 train_time:189921ms step_avg:145.64ms
+step:1305/4150 train_time:190155ms step_avg:145.71ms
+step:1306/4150 train_time:190390ms step_avg:145.78ms
+step:1307/4150 train_time:190621ms step_avg:145.85ms
+step:1308/4150 train_time:190857ms step_avg:145.92ms
+step:1309/4150 train_time:191088ms step_avg:145.98ms
+step:1310/4150 train_time:191322ms step_avg:146.05ms
+step:1311/4150 train_time:191554ms step_avg:146.11ms
+step:1312/4150 train_time:191791ms step_avg:146.18ms
+step:1313/4150 train_time:192024ms step_avg:146.25ms
+step:1314/4150 train_time:192258ms step_avg:146.31ms
+step:1315/4150 train_time:192489ms step_avg:146.38ms
+step:1316/4150 train_time:192722ms step_avg:146.45ms
+step:1317/4150 train_time:192953ms step_avg:146.51ms
+step:1318/4150 train_time:193189ms step_avg:146.58ms
+step:1319/4150 train_time:193417ms step_avg:146.64ms
+step:1320/4150 train_time:193654ms step_avg:146.71ms
+step:1321/4150 train_time:193887ms step_avg:146.77ms
+step:1322/4150 train_time:194120ms step_avg:146.84ms
+step:1323/4150 train_time:194351ms step_avg:146.90ms
+step:1324/4150 train_time:194587ms step_avg:146.97ms
+step:1325/4150 train_time:194818ms step_avg:147.03ms
+step:1326/4150 train_time:195051ms step_avg:147.10ms
+step:1327/4150 train_time:195284ms step_avg:147.16ms
+step:1328/4150 train_time:195518ms step_avg:147.23ms
+step:1329/4150 train_time:195749ms step_avg:147.29ms
+step:1330/4150 train_time:195983ms step_avg:147.36ms
+step:1331/4150 train_time:196215ms step_avg:147.42ms
+step:1332/4150 train_time:196449ms step_avg:147.48ms
+step:1333/4150 train_time:196680ms step_avg:147.55ms
+step:1334/4150 train_time:196913ms step_avg:147.61ms
+step:1335/4150 train_time:197144ms step_avg:147.67ms
+step:1336/4150 train_time:197381ms step_avg:147.74ms
+step:1337/4150 train_time:197616ms step_avg:147.81ms
+step:1338/4150 train_time:197850ms step_avg:147.87ms
+step:1339/4150 train_time:198080ms step_avg:147.93ms
+step:1340/4150 train_time:198315ms step_avg:148.00ms
+step:1341/4150 train_time:198546ms step_avg:148.06ms
+step:1342/4150 train_time:198780ms step_avg:148.12ms
+step:1343/4150 train_time:199012ms step_avg:148.18ms
+step:1344/4150 train_time:199247ms step_avg:148.25ms
+step:1345/4150 train_time:199477ms step_avg:148.31ms
+step:1346/4150 train_time:199713ms step_avg:148.38ms
+step:1347/4150 train_time:199943ms step_avg:148.44ms
+step:1348/4150 train_time:200177ms step_avg:148.50ms
+step:1349/4150 train_time:200407ms step_avg:148.56ms
+step:1350/4150 train_time:200642ms step_avg:148.62ms
+step:1351/4150 train_time:200872ms step_avg:148.68ms
+step:1352/4150 train_time:201104ms step_avg:148.75ms
+step:1353/4150 train_time:201337ms step_avg:148.81ms
+step:1354/4150 train_time:201572ms step_avg:148.87ms
+step:1355/4150 train_time:201805ms step_avg:148.93ms
+step:1356/4150 train_time:202040ms step_avg:149.00ms
+step:1357/4150 train_time:202274ms step_avg:149.06ms
+step:1358/4150 train_time:202510ms step_avg:149.12ms
+step:1359/4150 train_time:202743ms step_avg:149.19ms
+step:1360/4150 train_time:202975ms step_avg:149.25ms
+step:1361/4150 train_time:203205ms step_avg:149.31ms
+step:1362/4150 train_time:203441ms step_avg:149.37ms
+step:1363/4150 train_time:203673ms step_avg:149.43ms
+step:1364/4150 train_time:203907ms step_avg:149.49ms
+step:1365/4150 train_time:204139ms step_avg:149.55ms
+step:1366/4150 train_time:204374ms step_avg:149.62ms
+step:1367/4150 train_time:204606ms step_avg:149.68ms
+step:1368/4150 train_time:204840ms step_avg:149.74ms
+step:1369/4150 train_time:205071ms step_avg:149.80ms
+step:1370/4150 train_time:205305ms step_avg:149.86ms
+step:1371/4150 train_time:205536ms step_avg:149.92ms
+step:1372/4150 train_time:205770ms step_avg:149.98ms
+step:1373/4150 train_time:206004ms step_avg:150.04ms
+step:1374/4150 train_time:206239ms step_avg:150.10ms
+step:1375/4150 train_time:206469ms step_avg:150.16ms
+step:1376/4150 train_time:206701ms step_avg:150.22ms
+step:1377/4150 train_time:206936ms step_avg:150.28ms
+step:1378/4150 train_time:207171ms step_avg:150.34ms
+step:1379/4150 train_time:207404ms step_avg:150.40ms
+step:1380/4150 train_time:207637ms step_avg:150.46ms
+step:1381/4150 train_time:207869ms step_avg:150.52ms
+step:1382/4150 train_time:208103ms step_avg:150.58ms
+step:1383/4150 train_time:208334ms step_avg:150.64ms
+step:1384/4150 train_time:208567ms step_avg:150.70ms
+step:1385/4150 train_time:208798ms step_avg:150.76ms
+step:1386/4150 train_time:209035ms step_avg:150.82ms
+step:1387/4150 train_time:209265ms step_avg:150.88ms
+step:1388/4150 train_time:209501ms step_avg:150.94ms
+step:1389/4150 train_time:209731ms step_avg:150.99ms
+step:1390/4150 train_time:209968ms step_avg:151.06ms
+step:1391/4150 train_time:210201ms step_avg:151.11ms
+step:1392/4150 train_time:210434ms step_avg:151.17ms
+step:1393/4150 train_time:210667ms step_avg:151.23ms
+step:1394/4150 train_time:210903ms step_avg:151.29ms
+step:1395/4150 train_time:211134ms step_avg:151.35ms
+step:1396/4150 train_time:211369ms step_avg:151.41ms
+step:1397/4150 train_time:211601ms step_avg:151.47ms
+step:1398/4150 train_time:211835ms step_avg:151.53ms
+step:1399/4150 train_time:212065ms step_avg:151.58ms
+step:1400/4150 train_time:212301ms step_avg:151.64ms
+step:1401/4150 train_time:212533ms step_avg:151.70ms
+step:1402/4150 train_time:212768ms step_avg:151.76ms
+step:1403/4150 train_time:213001ms step_avg:151.82ms
+step:1404/4150 train_time:213236ms step_avg:151.88ms
+step:1405/4150 train_time:213468ms step_avg:151.93ms
+step:1406/4150 train_time:213703ms step_avg:151.99ms
+step:1407/4150 train_time:213934ms step_avg:152.05ms
+step:1408/4150 train_time:214172ms step_avg:152.11ms
+step:1409/4150 train_time:214406ms step_avg:152.17ms
+step:1410/4150 train_time:214640ms step_avg:152.23ms
+step:1411/4150 train_time:214871ms step_avg:152.28ms
+step:1412/4150 train_time:215104ms step_avg:152.34ms
+step:1413/4150 train_time:215337ms step_avg:152.40ms
+step:1414/4150 train_time:215573ms step_avg:152.46ms
+step:1415/4150 train_time:215805ms step_avg:152.51ms
+step:1416/4150 train_time:216040ms step_avg:152.57ms
+step:1417/4150 train_time:216273ms step_avg:152.63ms
+step:1418/4150 train_time:216509ms step_avg:152.69ms
+step:1419/4150 train_time:216741ms step_avg:152.74ms
+step:1420/4150 train_time:216975ms step_avg:152.80ms
+step:1421/4150 train_time:217207ms step_avg:152.86ms
+step:1422/4150 train_time:217442ms step_avg:152.91ms
+step:1423/4150 train_time:217677ms step_avg:152.97ms
+step:1424/4150 train_time:217913ms step_avg:153.03ms
+step:1425/4150 train_time:218145ms step_avg:153.08ms
+step:1426/4150 train_time:218381ms step_avg:153.14ms
+step:1427/4150 train_time:218615ms step_avg:153.20ms
+step:1428/4150 train_time:218851ms step_avg:153.26ms
+step:1429/4150 train_time:219084ms step_avg:153.31ms
+step:1430/4150 train_time:219319ms step_avg:153.37ms
+step:1431/4150 train_time:219550ms step_avg:153.42ms
+step:1432/4150 train_time:219788ms step_avg:153.48ms
+step:1433/4150 train_time:220019ms step_avg:153.54ms
+step:1434/4150 train_time:220254ms step_avg:153.59ms
+step:1435/4150 train_time:220487ms step_avg:153.65ms
+step:1436/4150 train_time:220721ms step_avg:153.71ms
+step:1437/4150 train_time:220952ms step_avg:153.76ms
+step:1438/4150 train_time:221188ms step_avg:153.82ms
+step:1439/4150 train_time:221420ms step_avg:153.87ms
+step:1440/4150 train_time:221659ms step_avg:153.93ms
+step:1441/4150 train_time:221894ms step_avg:153.99ms
+step:1442/4150 train_time:222128ms step_avg:154.04ms
+step:1443/4150 train_time:222360ms step_avg:154.10ms
+step:1444/4150 train_time:222596ms step_avg:154.15ms
+step:1445/4150 train_time:222828ms step_avg:154.21ms
+step:1446/4150 train_time:223061ms step_avg:154.26ms
+step:1447/4150 train_time:223292ms step_avg:154.31ms
+step:1448/4150 train_time:223527ms step_avg:154.37ms
+step:1449/4150 train_time:223760ms step_avg:154.42ms
+step:1450/4150 train_time:223995ms step_avg:154.48ms
+step:1451/4150 train_time:224224ms step_avg:154.53ms
+step:1452/4150 train_time:224460ms step_avg:154.59ms
+step:1453/4150 train_time:224695ms step_avg:154.64ms
+step:1454/4150 train_time:224934ms step_avg:154.70ms
+step:1455/4150 train_time:225167ms step_avg:154.75ms
+step:1456/4150 train_time:225401ms step_avg:154.81ms
+step:1457/4150 train_time:225635ms step_avg:154.86ms
+step:1458/4150 train_time:225872ms step_avg:154.92ms
+step:1459/4150 train_time:226105ms step_avg:154.97ms
+step:1460/4150 train_time:226339ms step_avg:155.03ms
+step:1461/4150 train_time:226572ms step_avg:155.08ms
+step:1462/4150 train_time:226807ms step_avg:155.13ms
+step:1463/4150 train_time:227040ms step_avg:155.19ms
+step:1464/4150 train_time:227274ms step_avg:155.24ms
+step:1465/4150 train_time:227505ms step_avg:155.29ms
+step:1466/4150 train_time:227741ms step_avg:155.35ms
+step:1467/4150 train_time:227973ms step_avg:155.40ms
+step:1468/4150 train_time:228209ms step_avg:155.46ms
+step:1469/4150 train_time:228440ms step_avg:155.51ms
+step:1470/4150 train_time:228675ms step_avg:155.56ms
+step:1471/4150 train_time:228907ms step_avg:155.61ms
+step:1472/4150 train_time:229142ms step_avg:155.67ms
+step:1473/4150 train_time:229375ms step_avg:155.72ms
+step:1474/4150 train_time:229611ms step_avg:155.77ms
+step:1475/4150 train_time:229844ms step_avg:155.83ms
+step:1476/4150 train_time:230079ms step_avg:155.88ms
+step:1477/4150 train_time:230310ms step_avg:155.93ms
+step:1478/4150 train_time:230543ms step_avg:155.98ms
+step:1479/4150 train_time:230777ms step_avg:156.04ms
+step:1480/4150 train_time:231013ms step_avg:156.09ms
+step:1481/4150 train_time:231245ms step_avg:156.14ms
+step:1482/4150 train_time:231484ms step_avg:156.20ms
+step:1483/4150 train_time:231718ms step_avg:156.25ms
+step:1484/4150 train_time:231958ms step_avg:156.31ms
+step:1485/4150 train_time:232191ms step_avg:156.36ms
+step:1486/4150 train_time:232426ms step_avg:156.41ms
+step:1487/4150 train_time:232657ms step_avg:156.46ms
+step:1488/4150 train_time:232891ms step_avg:156.51ms
+step:1489/4150 train_time:233122ms step_avg:156.56ms
+step:1490/4150 train_time:233358ms step_avg:156.62ms
+step:1491/4150 train_time:233589ms step_avg:156.67ms
+step:1492/4150 train_time:233825ms step_avg:156.72ms
+step:1493/4150 train_time:234057ms step_avg:156.77ms
+step:1494/4150 train_time:234292ms step_avg:156.82ms
+step:1495/4150 train_time:234523ms step_avg:156.87ms
+step:1496/4150 train_time:234760ms step_avg:156.93ms
+step:1497/4150 train_time:234995ms step_avg:156.98ms
+step:1498/4150 train_time:235230ms step_avg:157.03ms
+step:1499/4150 train_time:235461ms step_avg:157.08ms
+step:1500/4150 train_time:235697ms step_avg:157.13ms
+step:1500/4150 val_loss:3.2862 train_time:235910ms step_avg:157.27ms
+step:1501/4150 train_time:235934ms step_avg:157.18ms
+step:1502/4150 train_time:236170ms step_avg:157.24ms
+step:1503/4150 train_time:236406ms step_avg:157.29ms
+step:1504/4150 train_time:236637ms step_avg:157.34ms
+step:1505/4150 train_time:236866ms step_avg:157.39ms
+step:1506/4150 train_time:237102ms step_avg:157.44ms
+step:1507/4150 train_time:237337ms step_avg:157.49ms
+step:1508/4150 train_time:237572ms step_avg:157.54ms
+step:1509/4150 train_time:237802ms step_avg:157.59ms
+step:1510/4150 train_time:238035ms step_avg:157.64ms
+step:1511/4150 train_time:238271ms step_avg:157.69ms
+step:1512/4150 train_time:238506ms step_avg:157.74ms
+step:1513/4150 train_time:238738ms step_avg:157.79ms
+step:1514/4150 train_time:238972ms step_avg:157.84ms
+step:1515/4150 train_time:239207ms step_avg:157.89ms
+step:1516/4150 train_time:239443ms step_avg:157.94ms
+step:1517/4150 train_time:239673ms step_avg:157.99ms
+step:1518/4150 train_time:239907ms step_avg:158.04ms
+step:1519/4150 train_time:240140ms step_avg:158.09ms
+step:1520/4150 train_time:240375ms step_avg:158.14ms
+step:1521/4150 train_time:240605ms step_avg:158.19ms
+step:1522/4150 train_time:240840ms step_avg:158.24ms
+step:1523/4150 train_time:241072ms step_avg:158.29ms
+step:1524/4150 train_time:241309ms step_avg:158.34ms
+step:1525/4150 train_time:241542ms step_avg:158.39ms
+step:1526/4150 train_time:241778ms step_avg:158.44ms
+step:1527/4150 train_time:242009ms step_avg:158.49ms
+step:1528/4150 train_time:242243ms step_avg:158.54ms
+step:1529/4150 train_time:242474ms step_avg:158.58ms
+step:1530/4150 train_time:242709ms step_avg:158.63ms
+step:1531/4150 train_time:242940ms step_avg:158.68ms
+step:1532/4150 train_time:243176ms step_avg:158.73ms
+step:1533/4150 train_time:243408ms step_avg:158.78ms
+step:1534/4150 train_time:243646ms step_avg:158.83ms
+step:1535/4150 train_time:243877ms step_avg:158.88ms
+step:1536/4150 train_time:244110ms step_avg:158.93ms
+step:1537/4150 train_time:244344ms step_avg:158.97ms
+step:1538/4150 train_time:244578ms step_avg:159.02ms
+step:1539/4150 train_time:244810ms step_avg:159.07ms
+step:1540/4150 train_time:245044ms step_avg:159.12ms
+step:1541/4150 train_time:245276ms step_avg:159.17ms
+step:1542/4150 train_time:245512ms step_avg:159.22ms
+step:1543/4150 train_time:245742ms step_avg:159.26ms
+step:1544/4150 train_time:245979ms step_avg:159.31ms
+step:1545/4150 train_time:246210ms step_avg:159.36ms
+step:1546/4150 train_time:246447ms step_avg:159.41ms
+step:1547/4150 train_time:246680ms step_avg:159.46ms
+step:1548/4150 train_time:246914ms step_avg:159.51ms
+step:1549/4150 train_time:247146ms step_avg:159.55ms
+step:1550/4150 train_time:247382ms step_avg:159.60ms
+step:1551/4150 train_time:247613ms step_avg:159.65ms
+step:1552/4150 train_time:247847ms step_avg:159.70ms
+step:1553/4150 train_time:248078ms step_avg:159.74ms
+step:1554/4150 train_time:248312ms step_avg:159.79ms
+step:1555/4150 train_time:248548ms step_avg:159.84ms
+step:1556/4150 train_time:248782ms step_avg:159.89ms
+step:1557/4150 train_time:249013ms step_avg:159.93ms
+step:1558/4150 train_time:249247ms step_avg:159.98ms
+step:1559/4150 train_time:249483ms step_avg:160.03ms
+step:1560/4150 train_time:249719ms step_avg:160.08ms
+step:1561/4150 train_time:249951ms step_avg:160.12ms
+step:1562/4150 train_time:250186ms step_avg:160.17ms
+step:1563/4150 train_time:250419ms step_avg:160.22ms
+step:1564/4150 train_time:250658ms step_avg:160.27ms
+step:1565/4150 train_time:250889ms step_avg:160.31ms
+step:1566/4150 train_time:251125ms step_avg:160.36ms
+step:1567/4150 train_time:251355ms step_avg:160.41ms
+step:1568/4150 train_time:251593ms step_avg:160.45ms
+step:1569/4150 train_time:251825ms step_avg:160.50ms
+step:1570/4150 train_time:252060ms step_avg:160.55ms
+step:1571/4150 train_time:252292ms step_avg:160.59ms
+step:1572/4150 train_time:252527ms step_avg:160.64ms
+step:1573/4150 train_time:252759ms step_avg:160.69ms
+step:1574/4150 train_time:252992ms step_avg:160.73ms
+step:1575/4150 train_time:253225ms step_avg:160.78ms
+step:1576/4150 train_time:253460ms step_avg:160.83ms
+step:1577/4150 train_time:253694ms step_avg:160.87ms
+step:1578/4150 train_time:253927ms step_avg:160.92ms
+step:1579/4150 train_time:254159ms step_avg:160.96ms
+step:1580/4150 train_time:254394ms step_avg:161.01ms
+step:1581/4150 train_time:254628ms step_avg:161.06ms
+step:1582/4150 train_time:254865ms step_avg:161.10ms
+step:1583/4150 train_time:255098ms step_avg:161.15ms
+step:1584/4150 train_time:255332ms step_avg:161.19ms
+step:1585/4150 train_time:255566ms step_avg:161.24ms
+step:1586/4150 train_time:255802ms step_avg:161.29ms
+step:1587/4150 train_time:256033ms step_avg:161.33ms
+step:1588/4150 train_time:256267ms step_avg:161.38ms
+step:1589/4150 train_time:256499ms step_avg:161.42ms
+step:1590/4150 train_time:256734ms step_avg:161.47ms
+step:1591/4150 train_time:256965ms step_avg:161.51ms
+step:1592/4150 train_time:257199ms step_avg:161.56ms
+step:1593/4150 train_time:257431ms step_avg:161.60ms
+step:1594/4150 train_time:257665ms step_avg:161.65ms
+step:1595/4150 train_time:257895ms step_avg:161.69ms
+step:1596/4150 train_time:258130ms step_avg:161.74ms
+step:1597/4150 train_time:258362ms step_avg:161.78ms
+step:1598/4150 train_time:258599ms step_avg:161.83ms
+step:1599/4150 train_time:258830ms step_avg:161.87ms
+step:1600/4150 train_time:259065ms step_avg:161.92ms
+step:1601/4150 train_time:259295ms step_avg:161.96ms
+step:1602/4150 train_time:259531ms step_avg:162.00ms
+step:1603/4150 train_time:259763ms step_avg:162.05ms
+step:1604/4150 train_time:259997ms step_avg:162.09ms
+step:1605/4150 train_time:260228ms step_avg:162.14ms
+step:1606/4150 train_time:260465ms step_avg:162.18ms
+step:1607/4150 train_time:260697ms step_avg:162.23ms
+step:1608/4150 train_time:260930ms step_avg:162.27ms
+step:1609/4150 train_time:261161ms step_avg:162.31ms
+step:1610/4150 train_time:261394ms step_avg:162.36ms
+step:1611/4150 train_time:261626ms step_avg:162.40ms
+step:1612/4150 train_time:261863ms step_avg:162.45ms
+step:1613/4150 train_time:262095ms step_avg:162.49ms
+step:1614/4150 train_time:262331ms step_avg:162.53ms
+step:1615/4150 train_time:262561ms step_avg:162.58ms
+step:1616/4150 train_time:262796ms step_avg:162.62ms
+step:1617/4150 train_time:263028ms step_avg:162.66ms
+step:1618/4150 train_time:263262ms step_avg:162.71ms
+step:1619/4150 train_time:263493ms step_avg:162.75ms
+step:1620/4150 train_time:263725ms step_avg:162.79ms
+step:1621/4150 train_time:263957ms step_avg:162.84ms
+step:1622/4150 train_time:264191ms step_avg:162.88ms
+step:1623/4150 train_time:264426ms step_avg:162.92ms
+step:1624/4150 train_time:264660ms step_avg:162.97ms
+step:1625/4150 train_time:264893ms step_avg:163.01ms
+step:1626/4150 train_time:265127ms step_avg:163.05ms
+step:1627/4150 train_time:265359ms step_avg:163.10ms
+step:1628/4150 train_time:265592ms step_avg:163.14ms
+step:1629/4150 train_time:265825ms step_avg:163.18ms
+step:1630/4150 train_time:266060ms step_avg:163.23ms
+step:1631/4150 train_time:266291ms step_avg:163.27ms
+step:1632/4150 train_time:266528ms step_avg:163.31ms
+step:1633/4150 train_time:266762ms step_avg:163.36ms
+step:1634/4150 train_time:267000ms step_avg:163.40ms
+step:1635/4150 train_time:267232ms step_avg:163.44ms
+step:1636/4150 train_time:267466ms step_avg:163.49ms
+step:1637/4150 train_time:267699ms step_avg:163.53ms
+step:1638/4150 train_time:267934ms step_avg:163.57ms
+step:1639/4150 train_time:268167ms step_avg:163.62ms
+step:1640/4150 train_time:268404ms step_avg:163.66ms
+step:1641/4150 train_time:268637ms step_avg:163.70ms
+step:1642/4150 train_time:268872ms step_avg:163.75ms
+step:1643/4150 train_time:269103ms step_avg:163.79ms
+step:1644/4150 train_time:269339ms step_avg:163.83ms
+step:1645/4150 train_time:269571ms step_avg:163.87ms
+step:1646/4150 train_time:269806ms step_avg:163.92ms
+step:1647/4150 train_time:270039ms step_avg:163.96ms
+step:1648/4150 train_time:270273ms step_avg:164.00ms
+step:1649/4150 train_time:270503ms step_avg:164.04ms
+step:1650/4150 train_time:270740ms step_avg:164.08ms
+step:1651/4150 train_time:270971ms step_avg:164.13ms
+step:1652/4150 train_time:271205ms step_avg:164.17ms
+step:1653/4150 train_time:271435ms step_avg:164.21ms
+step:1654/4150 train_time:271670ms step_avg:164.25ms
+step:1655/4150 train_time:271903ms step_avg:164.29ms
+step:1656/4150 train_time:272140ms step_avg:164.34ms
+step:1657/4150 train_time:272372ms step_avg:164.38ms
+step:1658/4150 train_time:272606ms step_avg:164.42ms
+step:1659/4150 train_time:272839ms step_avg:164.46ms
+step:1660/4150 train_time:273078ms step_avg:164.50ms
+step:1661/4150 train_time:273311ms step_avg:164.55ms
+step:1662/4150 train_time:273544ms step_avg:164.59ms
+step:1663/4150 train_time:273774ms step_avg:164.63ms
+step:1664/4150 train_time:274010ms step_avg:164.67ms
+step:1665/4150 train_time:274242ms step_avg:164.71ms
+step:1666/4150 train_time:274477ms step_avg:164.75ms
+step:1667/4150 train_time:274708ms step_avg:164.79ms
+step:1668/4150 train_time:274941ms step_avg:164.83ms
+step:1669/4150 train_time:275173ms step_avg:164.87ms
+step:1670/4150 train_time:275407ms step_avg:164.91ms
+step:1671/4150 train_time:275638ms step_avg:164.95ms
+step:1672/4150 train_time:275873ms step_avg:165.00ms
+step:1673/4150 train_time:276106ms step_avg:165.04ms
+step:1674/4150 train_time:276342ms step_avg:165.08ms
+step:1675/4150 train_time:276572ms step_avg:165.12ms
+step:1676/4150 train_time:276808ms step_avg:165.16ms
+step:1677/4150 train_time:277041ms step_avg:165.20ms
+step:1678/4150 train_time:277275ms step_avg:165.24ms
+step:1679/4150 train_time:277507ms step_avg:165.28ms
+step:1680/4150 train_time:277742ms step_avg:165.32ms
+step:1681/4150 train_time:277976ms step_avg:165.36ms
+step:1682/4150 train_time:278211ms step_avg:165.41ms
+step:1683/4150 train_time:278443ms step_avg:165.44ms
+step:1684/4150 train_time:278676ms step_avg:165.48ms
+step:1685/4150 train_time:278911ms step_avg:165.53ms
+step:1686/4150 train_time:279148ms step_avg:165.57ms
+step:1687/4150 train_time:279381ms step_avg:165.61ms
+step:1688/4150 train_time:279613ms step_avg:165.65ms
+step:1689/4150 train_time:279844ms step_avg:165.69ms
+step:1690/4150 train_time:280079ms step_avg:165.73ms
+step:1691/4150 train_time:280315ms step_avg:165.77ms
+step:1692/4150 train_time:280549ms step_avg:165.81ms
+step:1693/4150 train_time:280779ms step_avg:165.85ms
+step:1694/4150 train_time:281015ms step_avg:165.89ms
+step:1695/4150 train_time:281249ms step_avg:165.93ms
+step:1696/4150 train_time:281485ms step_avg:165.97ms
+step:1697/4150 train_time:281714ms step_avg:166.01ms
+step:1698/4150 train_time:281949ms step_avg:166.05ms
+step:1699/4150 train_time:282184ms step_avg:166.09ms
+step:1700/4150 train_time:282420ms step_avg:166.13ms
+step:1701/4150 train_time:282652ms step_avg:166.17ms
+step:1702/4150 train_time:282886ms step_avg:166.21ms
+step:1703/4150 train_time:283119ms step_avg:166.25ms
+step:1704/4150 train_time:283358ms step_avg:166.29ms
+step:1705/4150 train_time:283588ms step_avg:166.33ms
+step:1706/4150 train_time:283823ms step_avg:166.37ms
+step:1707/4150 train_time:284052ms step_avg:166.40ms
+step:1708/4150 train_time:284290ms step_avg:166.45ms
+step:1709/4150 train_time:284522ms step_avg:166.48ms
+step:1710/4150 train_time:284756ms step_avg:166.52ms
+step:1711/4150 train_time:284986ms step_avg:166.56ms
+step:1712/4150 train_time:285223ms step_avg:166.60ms
+step:1713/4150 train_time:285456ms step_avg:166.64ms
+step:1714/4150 train_time:285690ms step_avg:166.68ms
+step:1715/4150 train_time:285921ms step_avg:166.72ms
+step:1716/4150 train_time:286157ms step_avg:166.76ms
+step:1717/4150 train_time:286388ms step_avg:166.80ms
+step:1718/4150 train_time:286626ms step_avg:166.84ms
+step:1719/4150 train_time:286858ms step_avg:166.87ms
+step:1720/4150 train_time:287094ms step_avg:166.91ms
+step:1721/4150 train_time:287330ms step_avg:166.96ms
+step:1722/4150 train_time:287566ms step_avg:167.00ms
+step:1723/4150 train_time:287798ms step_avg:167.03ms
+step:1724/4150 train_time:288033ms step_avg:167.07ms
+step:1725/4150 train_time:288269ms step_avg:167.11ms
+step:1726/4150 train_time:288505ms step_avg:167.15ms
+step:1727/4150 train_time:288736ms step_avg:167.19ms
+step:1728/4150 train_time:288974ms step_avg:167.23ms
+step:1729/4150 train_time:289207ms step_avg:167.27ms
+step:1730/4150 train_time:289440ms step_avg:167.31ms
+step:1731/4150 train_time:289672ms step_avg:167.34ms
+step:1732/4150 train_time:289906ms step_avg:167.38ms
+step:1733/4150 train_time:290137ms step_avg:167.42ms
+step:1734/4150 train_time:290372ms step_avg:167.46ms
+step:1735/4150 train_time:290605ms step_avg:167.50ms
+step:1736/4150 train_time:290842ms step_avg:167.54ms
+step:1737/4150 train_time:291074ms step_avg:167.57ms
+step:1738/4150 train_time:291312ms step_avg:167.61ms
+step:1739/4150 train_time:291545ms step_avg:167.65ms
+step:1740/4150 train_time:291780ms step_avg:167.69ms
+step:1741/4150 train_time:292013ms step_avg:167.73ms
+step:1742/4150 train_time:292248ms step_avg:167.77ms
+step:1743/4150 train_time:292481ms step_avg:167.80ms
+step:1744/4150 train_time:292716ms step_avg:167.84ms
+step:1745/4150 train_time:292948ms step_avg:167.88ms
+step:1746/4150 train_time:293186ms step_avg:167.92ms
+step:1747/4150 train_time:293417ms step_avg:167.95ms
+step:1748/4150 train_time:293653ms step_avg:167.99ms
+step:1749/4150 train_time:293886ms step_avg:168.03ms
+step:1750/4150 train_time:294122ms step_avg:168.07ms
+step:1750/4150 val_loss:3.2299 train_time:294336ms step_avg:168.19ms
+step:1751/4150 train_time:294360ms step_avg:168.11ms
+step:1752/4150 train_time:294600ms step_avg:168.15ms
+step:1753/4150 train_time:294831ms step_avg:168.19ms
+step:1754/4150 train_time:295064ms step_avg:168.22ms
+step:1755/4150 train_time:295294ms step_avg:168.26ms
+step:1756/4150 train_time:295532ms step_avg:168.30ms
+step:1757/4150 train_time:295771ms step_avg:168.34ms
+step:1758/4150 train_time:296009ms step_avg:168.38ms
+step:1759/4150 train_time:296239ms step_avg:168.41ms
+step:1760/4150 train_time:296476ms step_avg:168.45ms
+step:1761/4150 train_time:296711ms step_avg:168.49ms
+step:1762/4150 train_time:296944ms step_avg:168.53ms
+step:1763/4150 train_time:297176ms step_avg:168.56ms
+step:1764/4150 train_time:297412ms step_avg:168.60ms
+step:1765/4150 train_time:297645ms step_avg:168.64ms
+step:1766/4150 train_time:297881ms step_avg:168.68ms
+step:1767/4150 train_time:298113ms step_avg:168.71ms
+step:1768/4150 train_time:298349ms step_avg:168.75ms
+step:1769/4150 train_time:298582ms step_avg:168.79ms
+step:1770/4150 train_time:298819ms step_avg:168.82ms
+step:1771/4150 train_time:299051ms step_avg:168.86ms
+step:1772/4150 train_time:299288ms step_avg:168.90ms
+step:1773/4150 train_time:299521ms step_avg:168.93ms
+step:1774/4150 train_time:299757ms step_avg:168.97ms
+step:1775/4150 train_time:299991ms step_avg:169.01ms
+step:1776/4150 train_time:300226ms step_avg:169.05ms
+step:1777/4150 train_time:300456ms step_avg:169.08ms
+step:1778/4150 train_time:300693ms step_avg:169.12ms
+step:1779/4150 train_time:300925ms step_avg:169.15ms
+step:1780/4150 train_time:301164ms step_avg:169.19ms
+step:1781/4150 train_time:301395ms step_avg:169.23ms
+step:1782/4150 train_time:301633ms step_avg:169.27ms
+step:1783/4150 train_time:301867ms step_avg:169.30ms
+step:1784/4150 train_time:302105ms step_avg:169.34ms
+step:1785/4150 train_time:302336ms step_avg:169.38ms
+step:1786/4150 train_time:302573ms step_avg:169.41ms
+step:1787/4150 train_time:302806ms step_avg:169.45ms
+step:1788/4150 train_time:303043ms step_avg:169.49ms
+step:1789/4150 train_time:303274ms step_avg:169.52ms
+step:1790/4150 train_time:303509ms step_avg:169.56ms
+step:1791/4150 train_time:303741ms step_avg:169.59ms
+step:1792/4150 train_time:303977ms step_avg:169.63ms
+step:1793/4150 train_time:304209ms step_avg:169.66ms
+step:1794/4150 train_time:304444ms step_avg:169.70ms
+step:1795/4150 train_time:304677ms step_avg:169.74ms
+step:1796/4150 train_time:304914ms step_avg:169.77ms
+step:1797/4150 train_time:305147ms step_avg:169.81ms
+step:1798/4150 train_time:305384ms step_avg:169.85ms
+step:1799/4150 train_time:305618ms step_avg:169.88ms
+step:1800/4150 train_time:305856ms step_avg:169.92ms
+step:1801/4150 train_time:306093ms step_avg:169.96ms
+step:1802/4150 train_time:306331ms step_avg:169.99ms
+step:1803/4150 train_time:306562ms step_avg:170.03ms
+step:1804/4150 train_time:306797ms step_avg:170.06ms
+step:1805/4150 train_time:307032ms step_avg:170.10ms
+step:1806/4150 train_time:307267ms step_avg:170.14ms
+step:1807/4150 train_time:307498ms step_avg:170.17ms
+step:1808/4150 train_time:307734ms step_avg:170.21ms
+step:1809/4150 train_time:307968ms step_avg:170.24ms
+step:1810/4150 train_time:308207ms step_avg:170.28ms
+step:1811/4150 train_time:308439ms step_avg:170.31ms
+step:1812/4150 train_time:308675ms step_avg:170.35ms
+step:1813/4150 train_time:308906ms step_avg:170.38ms
+step:1814/4150 train_time:309142ms step_avg:170.42ms
+step:1815/4150 train_time:309375ms step_avg:170.45ms
+step:1816/4150 train_time:309612ms step_avg:170.49ms
+step:1817/4150 train_time:309845ms step_avg:170.53ms
+step:1818/4150 train_time:310078ms step_avg:170.56ms
+step:1819/4150 train_time:310314ms step_avg:170.60ms
+step:1820/4150 train_time:310548ms step_avg:170.63ms
+step:1821/4150 train_time:310779ms step_avg:170.66ms
+step:1822/4150 train_time:311016ms step_avg:170.70ms
+step:1823/4150 train_time:311254ms step_avg:170.74ms
+step:1824/4150 train_time:311491ms step_avg:170.77ms
+step:1825/4150 train_time:311726ms step_avg:170.81ms
+step:1826/4150 train_time:311962ms step_avg:170.84ms
+step:1827/4150 train_time:312195ms step_avg:170.88ms
+step:1828/4150 train_time:312430ms step_avg:170.91ms
+step:1829/4150 train_time:312661ms step_avg:170.95ms
+step:1830/4150 train_time:312897ms step_avg:170.98ms
+step:1831/4150 train_time:313132ms step_avg:171.02ms
+step:1832/4150 train_time:313369ms step_avg:171.05ms
+step:1833/4150 train_time:313600ms step_avg:171.09ms
+step:1834/4150 train_time:313837ms step_avg:171.12ms
+step:1835/4150 train_time:314072ms step_avg:171.16ms
+step:1836/4150 train_time:314309ms step_avg:171.19ms
+step:1837/4150 train_time:314538ms step_avg:171.22ms
+step:1838/4150 train_time:314773ms step_avg:171.26ms
+step:1839/4150 train_time:315007ms step_avg:171.29ms
+step:1840/4150 train_time:315243ms step_avg:171.33ms
+step:1841/4150 train_time:315474ms step_avg:171.36ms
+step:1842/4150 train_time:315711ms step_avg:171.40ms
+step:1843/4150 train_time:315944ms step_avg:171.43ms
+step:1844/4150 train_time:316181ms step_avg:171.46ms
+step:1845/4150 train_time:316413ms step_avg:171.50ms
+step:1846/4150 train_time:316650ms step_avg:171.53ms
+step:1847/4150 train_time:316883ms step_avg:171.57ms
+step:1848/4150 train_time:317118ms step_avg:171.60ms
+step:1849/4150 train_time:317351ms step_avg:171.63ms
+step:1850/4150 train_time:317586ms step_avg:171.67ms
+step:1851/4150 train_time:317818ms step_avg:171.70ms
+step:1852/4150 train_time:318054ms step_avg:171.74ms
+step:1853/4150 train_time:318288ms step_avg:171.77ms
+step:1854/4150 train_time:318524ms step_avg:171.80ms
+step:1855/4150 train_time:318757ms step_avg:171.84ms
+step:1856/4150 train_time:318992ms step_avg:171.87ms
+step:1857/4150 train_time:319224ms step_avg:171.90ms
+step:1858/4150 train_time:319460ms step_avg:171.94ms
+step:1859/4150 train_time:319693ms step_avg:171.97ms
+step:1860/4150 train_time:319927ms step_avg:172.00ms
+step:1861/4150 train_time:320160ms step_avg:172.04ms
+step:1862/4150 train_time:320394ms step_avg:172.07ms
+step:1863/4150 train_time:320628ms step_avg:172.10ms
+step:1864/4150 train_time:320864ms step_avg:172.14ms
+step:1865/4150 train_time:321098ms step_avg:172.17ms
+step:1866/4150 train_time:321335ms step_avg:172.21ms
+step:1867/4150 train_time:321568ms step_avg:172.24ms
+step:1868/4150 train_time:321805ms step_avg:172.27ms
+step:1869/4150 train_time:322035ms step_avg:172.30ms
+step:1870/4150 train_time:322271ms step_avg:172.34ms
+step:1871/4150 train_time:322502ms step_avg:172.37ms
+step:1872/4150 train_time:322738ms step_avg:172.40ms
+step:1873/4150 train_time:322973ms step_avg:172.44ms
+step:1874/4150 train_time:323208ms step_avg:172.47ms
+step:1875/4150 train_time:323439ms step_avg:172.50ms
+step:1876/4150 train_time:323675ms step_avg:172.53ms
+step:1877/4150 train_time:323910ms step_avg:172.57ms
+step:1878/4150 train_time:324149ms step_avg:172.60ms
+step:1879/4150 train_time:324379ms step_avg:172.63ms
+step:1880/4150 train_time:324617ms step_avg:172.67ms
+step:1881/4150 train_time:324848ms step_avg:172.70ms
+step:1882/4150 train_time:325086ms step_avg:172.73ms
+step:1883/4150 train_time:325320ms step_avg:172.77ms
+step:1884/4150 train_time:325558ms step_avg:172.80ms
+step:1885/4150 train_time:325792ms step_avg:172.83ms
+step:1886/4150 train_time:326029ms step_avg:172.87ms
+step:1887/4150 train_time:326261ms step_avg:172.90ms
+step:1888/4150 train_time:326498ms step_avg:172.93ms
+step:1889/4150 train_time:326732ms step_avg:172.97ms
+step:1890/4150 train_time:326967ms step_avg:173.00ms
+step:1891/4150 train_time:327201ms step_avg:173.03ms
+step:1892/4150 train_time:327437ms step_avg:173.06ms
+step:1893/4150 train_time:327672ms step_avg:173.10ms
+step:1894/4150 train_time:327909ms step_avg:173.13ms
+step:1895/4150 train_time:328140ms step_avg:173.16ms
+step:1896/4150 train_time:328375ms step_avg:173.19ms
+step:1897/4150 train_time:328609ms step_avg:173.23ms
+step:1898/4150 train_time:328845ms step_avg:173.26ms
+step:1899/4150 train_time:329078ms step_avg:173.29ms
+step:1900/4150 train_time:329315ms step_avg:173.32ms
+step:1901/4150 train_time:329549ms step_avg:173.36ms
+step:1902/4150 train_time:329788ms step_avg:173.39ms
+step:1903/4150 train_time:330019ms step_avg:173.42ms
+step:1904/4150 train_time:330253ms step_avg:173.45ms
+step:1905/4150 train_time:330483ms step_avg:173.48ms
+step:1906/4150 train_time:330720ms step_avg:173.52ms
+step:1907/4150 train_time:330953ms step_avg:173.55ms
+step:1908/4150 train_time:331190ms step_avg:173.58ms
+step:1909/4150 train_time:331421ms step_avg:173.61ms
+step:1910/4150 train_time:331656ms step_avg:173.64ms
+step:1911/4150 train_time:331887ms step_avg:173.67ms
+step:1912/4150 train_time:332126ms step_avg:173.71ms
+step:1913/4150 train_time:332358ms step_avg:173.74ms
+step:1914/4150 train_time:332593ms step_avg:173.77ms
+step:1915/4150 train_time:332826ms step_avg:173.80ms
+step:1916/4150 train_time:333060ms step_avg:173.83ms
+step:1917/4150 train_time:333291ms step_avg:173.86ms
+step:1918/4150 train_time:333532ms step_avg:173.90ms
+step:1919/4150 train_time:333766ms step_avg:173.93ms
+step:1920/4150 train_time:334003ms step_avg:173.96ms
+step:1921/4150 train_time:334236ms step_avg:173.99ms
+step:1922/4150 train_time:334474ms step_avg:174.02ms
+step:1923/4150 train_time:334706ms step_avg:174.05ms
+step:1924/4150 train_time:334944ms step_avg:174.09ms
+step:1925/4150 train_time:335176ms step_avg:174.12ms
+step:1926/4150 train_time:335412ms step_avg:174.15ms
+step:1927/4150 train_time:335644ms step_avg:174.18ms
+step:1928/4150 train_time:335882ms step_avg:174.21ms
+step:1929/4150 train_time:336115ms step_avg:174.24ms
+step:1930/4150 train_time:336353ms step_avg:174.28ms
+step:1931/4150 train_time:336587ms step_avg:174.31ms
+step:1932/4150 train_time:336823ms step_avg:174.34ms
+step:1933/4150 train_time:337053ms step_avg:174.37ms
+step:1934/4150 train_time:337289ms step_avg:174.40ms
+step:1935/4150 train_time:337522ms step_avg:174.43ms
+step:1936/4150 train_time:337759ms step_avg:174.46ms
+step:1937/4150 train_time:337992ms step_avg:174.49ms
+step:1938/4150 train_time:338229ms step_avg:174.52ms
+step:1939/4150 train_time:338459ms step_avg:174.55ms
+step:1940/4150 train_time:338695ms step_avg:174.59ms
+step:1941/4150 train_time:338928ms step_avg:174.61ms
+step:1942/4150 train_time:339164ms step_avg:174.65ms
+step:1943/4150 train_time:339395ms step_avg:174.68ms
+step:1944/4150 train_time:339630ms step_avg:174.71ms
+step:1945/4150 train_time:339864ms step_avg:174.74ms
+step:1946/4150 train_time:340097ms step_avg:174.77ms
+step:1947/4150 train_time:340331ms step_avg:174.80ms
+step:1948/4150 train_time:340568ms step_avg:174.83ms
+step:1949/4150 train_time:340800ms step_avg:174.86ms
+step:1950/4150 train_time:341034ms step_avg:174.89ms
+step:1951/4150 train_time:341268ms step_avg:174.92ms
+step:1952/4150 train_time:341506ms step_avg:174.95ms
+step:1953/4150 train_time:341739ms step_avg:174.98ms
+step:1954/4150 train_time:341974ms step_avg:175.01ms
+step:1955/4150 train_time:342206ms step_avg:175.04ms
+step:1956/4150 train_time:342440ms step_avg:175.07ms
+step:1957/4150 train_time:342673ms step_avg:175.10ms
+step:1958/4150 train_time:342909ms step_avg:175.13ms
+step:1959/4150 train_time:343140ms step_avg:175.16ms
+step:1960/4150 train_time:343377ms step_avg:175.19ms
+step:1961/4150 train_time:343612ms step_avg:175.22ms
+step:1962/4150 train_time:343847ms step_avg:175.25ms
+step:1963/4150 train_time:344081ms step_avg:175.28ms
+step:1964/4150 train_time:344317ms step_avg:175.31ms
+step:1965/4150 train_time:344551ms step_avg:175.34ms
+step:1966/4150 train_time:344789ms step_avg:175.38ms
+step:1967/4150 train_time:345021ms step_avg:175.40ms
+step:1968/4150 train_time:345259ms step_avg:175.44ms
+step:1969/4150 train_time:345492ms step_avg:175.47ms
+step:1970/4150 train_time:345732ms step_avg:175.50ms
+step:1971/4150 train_time:345964ms step_avg:175.53ms
+step:1972/4150 train_time:346199ms step_avg:175.56ms
+step:1973/4150 train_time:346433ms step_avg:175.59ms
+step:1974/4150 train_time:346666ms step_avg:175.62ms
+step:1975/4150 train_time:346899ms step_avg:175.65ms
+step:1976/4150 train_time:347134ms step_avg:175.68ms
+step:1977/4150 train_time:347367ms step_avg:175.70ms
+step:1978/4150 train_time:347603ms step_avg:175.73ms
+step:1979/4150 train_time:347835ms step_avg:175.76ms
+step:1980/4150 train_time:348070ms step_avg:175.79ms
+step:1981/4150 train_time:348304ms step_avg:175.82ms
+step:1982/4150 train_time:348537ms step_avg:175.85ms
+step:1983/4150 train_time:348771ms step_avg:175.88ms
+step:1984/4150 train_time:349004ms step_avg:175.91ms
+step:1985/4150 train_time:349235ms step_avg:175.94ms
+step:1986/4150 train_time:349471ms step_avg:175.97ms
+step:1987/4150 train_time:349704ms step_avg:176.00ms
+step:1988/4150 train_time:349940ms step_avg:176.03ms
+step:1989/4150 train_time:350174ms step_avg:176.06ms
+step:1990/4150 train_time:350410ms step_avg:176.09ms
+step:1991/4150 train_time:350639ms step_avg:176.11ms
+step:1992/4150 train_time:350877ms step_avg:176.14ms
+step:1993/4150 train_time:351109ms step_avg:176.17ms
+step:1994/4150 train_time:351345ms step_avg:176.20ms
+step:1995/4150 train_time:351578ms step_avg:176.23ms
+step:1996/4150 train_time:351811ms step_avg:176.26ms
+step:1997/4150 train_time:352045ms step_avg:176.29ms
+step:1998/4150 train_time:352282ms step_avg:176.32ms
+step:1999/4150 train_time:352513ms step_avg:176.34ms
+step:2000/4150 train_time:352748ms step_avg:176.37ms
+step:2000/4150 val_loss:3.1834 train_time:352961ms step_avg:176.48ms
+step:2001/4150 train_time:352983ms step_avg:176.40ms
+step:2002/4150 train_time:353220ms step_avg:176.43ms
+step:2003/4150 train_time:353453ms step_avg:176.46ms
+step:2004/4150 train_time:353686ms step_avg:176.49ms
+step:2005/4150 train_time:353918ms step_avg:176.52ms
+step:2006/4150 train_time:354155ms step_avg:176.55ms
+step:2007/4150 train_time:354387ms step_avg:176.58ms
+step:2008/4150 train_time:354624ms step_avg:176.61ms
+step:2009/4150 train_time:354856ms step_avg:176.63ms
+step:2010/4150 train_time:355092ms step_avg:176.66ms
+step:2011/4150 train_time:355325ms step_avg:176.69ms
+step:2012/4150 train_time:355561ms step_avg:176.72ms
+step:2013/4150 train_time:355791ms step_avg:176.75ms
+step:2014/4150 train_time:356026ms step_avg:176.78ms
+step:2015/4150 train_time:356262ms step_avg:176.80ms
+step:2016/4150 train_time:356500ms step_avg:176.84ms
+step:2017/4150 train_time:356734ms step_avg:176.86ms
+step:2018/4150 train_time:356969ms step_avg:176.89ms
+step:2019/4150 train_time:357201ms step_avg:176.92ms
+step:2020/4150 train_time:357438ms step_avg:176.95ms
+step:2021/4150 train_time:357670ms step_avg:176.98ms
+step:2022/4150 train_time:357905ms step_avg:177.01ms
+step:2023/4150 train_time:358137ms step_avg:177.03ms
+step:2024/4150 train_time:358375ms step_avg:177.06ms
+step:2025/4150 train_time:358608ms step_avg:177.09ms
+step:2026/4150 train_time:358844ms step_avg:177.12ms
+step:2027/4150 train_time:359077ms step_avg:177.15ms
+step:2028/4150 train_time:359315ms step_avg:177.18ms
+step:2029/4150 train_time:359547ms step_avg:177.20ms
+step:2030/4150 train_time:359782ms step_avg:177.23ms
+step:2031/4150 train_time:360015ms step_avg:177.26ms
+step:2032/4150 train_time:360252ms step_avg:177.29ms
+step:2033/4150 train_time:360484ms step_avg:177.32ms
+step:2034/4150 train_time:360723ms step_avg:177.35ms
+step:2035/4150 train_time:360956ms step_avg:177.37ms
+step:2036/4150 train_time:361190ms step_avg:177.40ms
+step:2037/4150 train_time:361423ms step_avg:177.43ms
+step:2038/4150 train_time:361659ms step_avg:177.46ms
+step:2039/4150 train_time:361893ms step_avg:177.49ms
+step:2040/4150 train_time:362131ms step_avg:177.51ms
+step:2041/4150 train_time:362363ms step_avg:177.54ms
+step:2042/4150 train_time:362597ms step_avg:177.57ms
+step:2043/4150 train_time:362827ms step_avg:177.60ms
+step:2044/4150 train_time:363064ms step_avg:177.62ms
+step:2045/4150 train_time:363298ms step_avg:177.65ms
+step:2046/4150 train_time:363533ms step_avg:177.68ms
+step:2047/4150 train_time:363764ms step_avg:177.71ms
+step:2048/4150 train_time:364000ms step_avg:177.73ms
+step:2049/4150 train_time:364235ms step_avg:177.76ms
+step:2050/4150 train_time:364469ms step_avg:177.79ms
+step:2051/4150 train_time:364703ms step_avg:177.82ms
+step:2052/4150 train_time:364940ms step_avg:177.85ms
+step:2053/4150 train_time:365176ms step_avg:177.87ms
+step:2054/4150 train_time:365416ms step_avg:177.90ms
+step:2055/4150 train_time:365646ms step_avg:177.93ms
+step:2056/4150 train_time:365880ms step_avg:177.96ms
+step:2057/4150 train_time:366113ms step_avg:177.98ms
+step:2058/4150 train_time:366350ms step_avg:178.01ms
+step:2059/4150 train_time:366582ms step_avg:178.04ms
+step:2060/4150 train_time:366820ms step_avg:178.07ms
+step:2061/4150 train_time:367053ms step_avg:178.09ms
+step:2062/4150 train_time:367288ms step_avg:178.12ms
+step:2063/4150 train_time:367520ms step_avg:178.15ms
+step:2064/4150 train_time:367755ms step_avg:178.18ms
+step:2065/4150 train_time:367988ms step_avg:178.20ms
+step:2066/4150 train_time:368224ms step_avg:178.23ms
+step:2067/4150 train_time:368455ms step_avg:178.26ms
+step:2068/4150 train_time:368690ms step_avg:178.28ms
+step:2069/4150 train_time:368924ms step_avg:178.31ms
+step:2070/4150 train_time:369161ms step_avg:178.34ms
+step:2071/4150 train_time:369393ms step_avg:178.36ms
+step:2072/4150 train_time:369630ms step_avg:178.39ms
+step:2073/4150 train_time:369864ms step_avg:178.42ms
+step:2074/4150 train_time:370100ms step_avg:178.45ms
+step:2075/4150 train_time:370336ms step_avg:178.48ms
+step:2076/4150 train_time:370571ms step_avg:178.50ms
+step:2077/4150 train_time:370807ms step_avg:178.53ms
+step:2078/4150 train_time:371043ms step_avg:178.56ms
+step:2079/4150 train_time:371276ms step_avg:178.58ms
+step:2080/4150 train_time:371513ms step_avg:178.61ms
+step:2081/4150 train_time:371745ms step_avg:178.64ms
+step:2082/4150 train_time:371980ms step_avg:178.66ms
+step:2083/4150 train_time:372214ms step_avg:178.69ms
+step:2084/4150 train_time:372451ms step_avg:178.72ms
+step:2085/4150 train_time:372685ms step_avg:178.75ms
+step:2086/4150 train_time:372923ms step_avg:178.77ms
+step:2087/4150 train_time:373156ms step_avg:178.80ms
+step:2088/4150 train_time:373390ms step_avg:178.83ms
+step:2089/4150 train_time:373623ms step_avg:178.85ms
+step:2090/4150 train_time:373859ms step_avg:178.88ms
+step:2091/4150 train_time:374093ms step_avg:178.91ms
+step:2092/4150 train_time:374331ms step_avg:178.93ms
+step:2093/4150 train_time:374565ms step_avg:178.96ms
+step:2094/4150 train_time:374805ms step_avg:178.99ms
+step:2095/4150 train_time:375039ms step_avg:179.02ms
+step:2096/4150 train_time:375274ms step_avg:179.04ms
+step:2097/4150 train_time:375506ms step_avg:179.07ms
+step:2098/4150 train_time:375741ms step_avg:179.09ms
+step:2099/4150 train_time:375976ms step_avg:179.12ms
+step:2100/4150 train_time:376214ms step_avg:179.15ms
+step:2101/4150 train_time:376445ms step_avg:179.17ms
+step:2102/4150 train_time:376681ms step_avg:179.20ms
+step:2103/4150 train_time:376913ms step_avg:179.23ms
+step:2104/4150 train_time:377150ms step_avg:179.25ms
+step:2105/4150 train_time:377385ms step_avg:179.28ms
+step:2106/4150 train_time:377624ms step_avg:179.31ms
+step:2107/4150 train_time:377861ms step_avg:179.34ms
+step:2108/4150 train_time:378098ms step_avg:179.36ms
+step:2109/4150 train_time:378333ms step_avg:179.39ms
+step:2110/4150 train_time:378571ms step_avg:179.42ms
+step:2111/4150 train_time:378805ms step_avg:179.44ms
+step:2112/4150 train_time:379046ms step_avg:179.47ms
+step:2113/4150 train_time:379278ms step_avg:179.50ms
+step:2114/4150 train_time:379514ms step_avg:179.52ms
+step:2115/4150 train_time:379745ms step_avg:179.55ms
+step:2116/4150 train_time:379981ms step_avg:179.58ms
+step:2117/4150 train_time:380216ms step_avg:179.60ms
+step:2118/4150 train_time:380454ms step_avg:179.63ms
+step:2119/4150 train_time:380688ms step_avg:179.65ms
+step:2120/4150 train_time:380925ms step_avg:179.68ms
+step:2121/4150 train_time:381157ms step_avg:179.71ms
+step:2122/4150 train_time:381392ms step_avg:179.73ms
+step:2123/4150 train_time:381627ms step_avg:179.76ms
+step:2124/4150 train_time:381862ms step_avg:179.78ms
+step:2125/4150 train_time:382096ms step_avg:179.81ms
+step:2126/4150 train_time:382333ms step_avg:179.84ms
+step:2127/4150 train_time:382568ms step_avg:179.86ms
+step:2128/4150 train_time:382805ms step_avg:179.89ms
+step:2129/4150 train_time:383037ms step_avg:179.91ms
+step:2130/4150 train_time:383271ms step_avg:179.94ms
+step:2131/4150 train_time:383507ms step_avg:179.97ms
+step:2132/4150 train_time:383745ms step_avg:179.99ms
+step:2133/4150 train_time:383978ms step_avg:180.02ms
+step:2134/4150 train_time:384214ms step_avg:180.04ms
+step:2135/4150 train_time:384449ms step_avg:180.07ms
+step:2136/4150 train_time:384686ms step_avg:180.10ms
+step:2137/4150 train_time:384921ms step_avg:180.12ms
+step:2138/4150 train_time:385157ms step_avg:180.15ms
+step:2139/4150 train_time:385387ms step_avg:180.17ms
+step:2140/4150 train_time:385624ms step_avg:180.20ms
+step:2141/4150 train_time:385861ms step_avg:180.22ms
+step:2142/4150 train_time:386098ms step_avg:180.25ms
+step:2143/4150 train_time:386330ms step_avg:180.28ms
+step:2144/4150 train_time:386564ms step_avg:180.30ms
+step:2145/4150 train_time:386798ms step_avg:180.33ms
+step:2146/4150 train_time:387034ms step_avg:180.35ms
+step:2147/4150 train_time:387267ms step_avg:180.38ms
+step:2148/4150 train_time:387502ms step_avg:180.40ms
+step:2149/4150 train_time:387736ms step_avg:180.43ms
+step:2150/4150 train_time:387972ms step_avg:180.45ms
+step:2151/4150 train_time:388207ms step_avg:180.48ms
+step:2152/4150 train_time:388442ms step_avg:180.50ms
+step:2153/4150 train_time:388679ms step_avg:180.53ms
+step:2154/4150 train_time:388917ms step_avg:180.56ms
+step:2155/4150 train_time:389151ms step_avg:180.58ms
+step:2156/4150 train_time:389384ms step_avg:180.60ms
+step:2157/4150 train_time:389618ms step_avg:180.63ms
+step:2158/4150 train_time:389859ms step_avg:180.66ms
+step:2159/4150 train_time:390093ms step_avg:180.68ms
+step:2160/4150 train_time:390332ms step_avg:180.71ms
+step:2161/4150 train_time:390565ms step_avg:180.73ms
+step:2162/4150 train_time:390802ms step_avg:180.76ms
+step:2163/4150 train_time:391038ms step_avg:180.78ms
+step:2164/4150 train_time:391275ms step_avg:180.81ms
+step:2165/4150 train_time:391506ms step_avg:180.83ms
+step:2166/4150 train_time:391741ms step_avg:180.86ms
+step:2167/4150 train_time:391973ms step_avg:180.88ms
+step:2168/4150 train_time:392209ms step_avg:180.91ms
+step:2169/4150 train_time:392443ms step_avg:180.93ms
+step:2170/4150 train_time:392679ms step_avg:180.96ms
+step:2171/4150 train_time:392913ms step_avg:180.98ms
+step:2172/4150 train_time:393151ms step_avg:181.01ms
+step:2173/4150 train_time:393384ms step_avg:181.03ms
+step:2174/4150 train_time:393625ms step_avg:181.06ms
+step:2175/4150 train_time:393858ms step_avg:181.08ms
+step:2176/4150 train_time:394096ms step_avg:181.11ms
+step:2177/4150 train_time:394327ms step_avg:181.13ms
+step:2178/4150 train_time:394563ms step_avg:181.16ms
+step:2179/4150 train_time:394796ms step_avg:181.18ms
+step:2180/4150 train_time:395033ms step_avg:181.21ms
+step:2181/4150 train_time:395266ms step_avg:181.23ms
+step:2182/4150 train_time:395504ms step_avg:181.26ms
+step:2183/4150 train_time:395736ms step_avg:181.28ms
+step:2184/4150 train_time:395976ms step_avg:181.31ms
+step:2185/4150 train_time:396208ms step_avg:181.33ms
+step:2186/4150 train_time:396444ms step_avg:181.36ms
+step:2187/4150 train_time:396675ms step_avg:181.38ms
+step:2188/4150 train_time:396912ms step_avg:181.40ms
+step:2189/4150 train_time:397145ms step_avg:181.43ms
+step:2190/4150 train_time:397382ms step_avg:181.45ms
+step:2191/4150 train_time:397618ms step_avg:181.48ms
+step:2192/4150 train_time:397857ms step_avg:181.50ms
+step:2193/4150 train_time:398089ms step_avg:181.53ms
+step:2194/4150 train_time:398325ms step_avg:181.55ms
+step:2195/4150 train_time:398563ms step_avg:181.58ms
+step:2196/4150 train_time:398801ms step_avg:181.60ms
+step:2197/4150 train_time:399033ms step_avg:181.63ms
+step:2198/4150 train_time:399268ms step_avg:181.65ms
+step:2199/4150 train_time:399501ms step_avg:181.67ms
+step:2200/4150 train_time:399738ms step_avg:181.70ms
+step:2201/4150 train_time:399974ms step_avg:181.72ms
+step:2202/4150 train_time:400208ms step_avg:181.75ms
+step:2203/4150 train_time:400439ms step_avg:181.77ms
+step:2204/4150 train_time:400676ms step_avg:181.79ms
+step:2205/4150 train_time:400908ms step_avg:181.82ms
+step:2206/4150 train_time:401146ms step_avg:181.84ms
+step:2207/4150 train_time:401380ms step_avg:181.87ms
+step:2208/4150 train_time:401616ms step_avg:181.89ms
+step:2209/4150 train_time:401846ms step_avg:181.91ms
+step:2210/4150 train_time:402083ms step_avg:181.94ms
+step:2211/4150 train_time:402316ms step_avg:181.96ms
+step:2212/4150 train_time:402555ms step_avg:181.99ms
+step:2213/4150 train_time:402788ms step_avg:182.01ms
+step:2214/4150 train_time:403025ms step_avg:182.03ms
+step:2215/4150 train_time:403258ms step_avg:182.06ms
+step:2216/4150 train_time:403495ms step_avg:182.08ms
+step:2217/4150 train_time:403725ms step_avg:182.10ms
+step:2218/4150 train_time:403961ms step_avg:182.13ms
+step:2219/4150 train_time:404198ms step_avg:182.15ms
+step:2220/4150 train_time:404438ms step_avg:182.18ms
+step:2221/4150 train_time:404672ms step_avg:182.20ms
+step:2222/4150 train_time:404907ms step_avg:182.23ms
+step:2223/4150 train_time:405142ms step_avg:182.25ms
+step:2224/4150 train_time:405381ms step_avg:182.28ms
+step:2225/4150 train_time:405613ms step_avg:182.30ms
+step:2226/4150 train_time:405846ms step_avg:182.32ms
+step:2227/4150 train_time:406080ms step_avg:182.34ms
+step:2228/4150 train_time:406318ms step_avg:182.37ms
+step:2229/4150 train_time:406551ms step_avg:182.39ms
+step:2230/4150 train_time:406787ms step_avg:182.42ms
+step:2231/4150 train_time:407019ms step_avg:182.44ms
+step:2232/4150 train_time:407257ms step_avg:182.46ms
+step:2233/4150 train_time:407490ms step_avg:182.49ms
+step:2234/4150 train_time:407726ms step_avg:182.51ms
+step:2235/4150 train_time:407959ms step_avg:182.53ms
+step:2236/4150 train_time:408196ms step_avg:182.56ms
+step:2237/4150 train_time:408431ms step_avg:182.58ms
+step:2238/4150 train_time:408666ms step_avg:182.60ms
+step:2239/4150 train_time:408900ms step_avg:182.63ms
+step:2240/4150 train_time:409133ms step_avg:182.65ms
+step:2241/4150 train_time:409368ms step_avg:182.67ms
+step:2242/4150 train_time:409604ms step_avg:182.70ms
+step:2243/4150 train_time:409838ms step_avg:182.72ms
+step:2244/4150 train_time:410072ms step_avg:182.74ms
+step:2245/4150 train_time:410303ms step_avg:182.76ms
+step:2246/4150 train_time:410538ms step_avg:182.79ms
+step:2247/4150 train_time:410773ms step_avg:182.81ms
+step:2248/4150 train_time:411010ms step_avg:182.83ms
+step:2249/4150 train_time:411243ms step_avg:182.86ms
+step:2250/4150 train_time:411481ms step_avg:182.88ms
+step:2250/4150 val_loss:3.1436 train_time:411696ms step_avg:182.98ms
+step:2251/4150 train_time:411719ms step_avg:182.91ms
+step:2252/4150 train_time:411954ms step_avg:182.93ms
+step:2253/4150 train_time:412189ms step_avg:182.95ms
+step:2254/4150 train_time:412424ms step_avg:182.97ms
+step:2255/4150 train_time:412658ms step_avg:183.00ms
+step:2256/4150 train_time:412892ms step_avg:183.02ms
+step:2257/4150 train_time:413129ms step_avg:183.04ms
+step:2258/4150 train_time:413365ms step_avg:183.07ms
+step:2259/4150 train_time:413598ms step_avg:183.09ms
+step:2260/4150 train_time:413834ms step_avg:183.11ms
+step:2261/4150 train_time:414069ms step_avg:183.14ms
+step:2262/4150 train_time:414305ms step_avg:183.16ms
+step:2263/4150 train_time:414536ms step_avg:183.18ms
+step:2264/4150 train_time:414772ms step_avg:183.20ms
+step:2265/4150 train_time:415006ms step_avg:183.23ms
+step:2266/4150 train_time:415242ms step_avg:183.25ms
+step:2267/4150 train_time:415474ms step_avg:183.27ms
+step:2268/4150 train_time:415710ms step_avg:183.29ms
+step:2269/4150 train_time:415945ms step_avg:183.32ms
+step:2270/4150 train_time:416181ms step_avg:183.34ms
+step:2271/4150 train_time:416415ms step_avg:183.36ms
+step:2272/4150 train_time:416649ms step_avg:183.38ms
+step:2273/4150 train_time:416882ms step_avg:183.41ms
+step:2274/4150 train_time:417121ms step_avg:183.43ms
+step:2275/4150 train_time:417355ms step_avg:183.45ms
+step:2276/4150 train_time:417596ms step_avg:183.48ms
+step:2277/4150 train_time:417828ms step_avg:183.50ms
+step:2278/4150 train_time:418064ms step_avg:183.52ms
+step:2279/4150 train_time:418298ms step_avg:183.54ms
+step:2280/4150 train_time:418535ms step_avg:183.57ms
+step:2281/4150 train_time:418766ms step_avg:183.59ms
+step:2282/4150 train_time:419000ms step_avg:183.61ms
+step:2283/4150 train_time:419237ms step_avg:183.63ms
+step:2284/4150 train_time:419472ms step_avg:183.66ms
+step:2285/4150 train_time:419704ms step_avg:183.68ms
+step:2286/4150 train_time:419938ms step_avg:183.70ms
+step:2287/4150 train_time:420172ms step_avg:183.72ms
+step:2288/4150 train_time:420409ms step_avg:183.75ms
+step:2289/4150 train_time:420640ms step_avg:183.77ms
+step:2290/4150 train_time:420878ms step_avg:183.79ms
+step:2291/4150 train_time:421112ms step_avg:183.81ms
+step:2292/4150 train_time:421347ms step_avg:183.83ms
+step:2293/4150 train_time:421580ms step_avg:183.86ms
+step:2294/4150 train_time:421817ms step_avg:183.88ms
+step:2295/4150 train_time:422054ms step_avg:183.90ms
+step:2296/4150 train_time:422288ms step_avg:183.92ms
+step:2297/4150 train_time:422520ms step_avg:183.94ms
+step:2298/4150 train_time:422756ms step_avg:183.97ms
+step:2299/4150 train_time:422988ms step_avg:183.99ms
+step:2300/4150 train_time:423224ms step_avg:184.01ms
+step:2301/4150 train_time:423458ms step_avg:184.03ms
+step:2302/4150 train_time:423696ms step_avg:184.06ms
+step:2303/4150 train_time:423928ms step_avg:184.08ms
+step:2304/4150 train_time:424165ms step_avg:184.10ms
+step:2305/4150 train_time:424400ms step_avg:184.12ms
+step:2306/4150 train_time:424636ms step_avg:184.14ms
+step:2307/4150 train_time:424867ms step_avg:184.16ms
+step:2308/4150 train_time:425104ms step_avg:184.19ms
+step:2309/4150 train_time:425342ms step_avg:184.21ms
+step:2310/4150 train_time:425576ms step_avg:184.23ms
+step:2311/4150 train_time:425808ms step_avg:184.25ms
+step:2312/4150 train_time:426045ms step_avg:184.28ms
+step:2313/4150 train_time:426279ms step_avg:184.30ms
+step:2314/4150 train_time:426515ms step_avg:184.32ms
+step:2315/4150 train_time:426747ms step_avg:184.34ms
+step:2316/4150 train_time:426984ms step_avg:184.36ms
+step:2317/4150 train_time:427219ms step_avg:184.38ms
+step:2318/4150 train_time:427452ms step_avg:184.41ms
+step:2319/4150 train_time:427686ms step_avg:184.43ms
+step:2320/4150 train_time:427923ms step_avg:184.45ms
+step:2321/4150 train_time:428158ms step_avg:184.47ms
+step:2322/4150 train_time:428398ms step_avg:184.50ms
+step:2323/4150 train_time:428634ms step_avg:184.52ms
+step:2324/4150 train_time:428870ms step_avg:184.54ms
+step:2325/4150 train_time:429104ms step_avg:184.56ms
+step:2326/4150 train_time:429342ms step_avg:184.58ms
+step:2327/4150 train_time:429573ms step_avg:184.60ms
+step:2328/4150 train_time:429810ms step_avg:184.63ms
+step:2329/4150 train_time:430043ms step_avg:184.65ms
+step:2330/4150 train_time:430280ms step_avg:184.67ms
+step:2331/4150 train_time:430513ms step_avg:184.69ms
+step:2332/4150 train_time:430749ms step_avg:184.71ms
+step:2333/4150 train_time:430984ms step_avg:184.73ms
+step:2334/4150 train_time:431219ms step_avg:184.76ms
+step:2335/4150 train_time:431451ms step_avg:184.78ms
+step:2336/4150 train_time:431687ms step_avg:184.80ms
+step:2337/4150 train_time:431919ms step_avg:184.82ms
+step:2338/4150 train_time:432154ms step_avg:184.84ms
+step:2339/4150 train_time:432386ms step_avg:184.86ms
+step:2340/4150 train_time:432622ms step_avg:184.88ms
+step:2341/4150 train_time:432857ms step_avg:184.90ms
+step:2342/4150 train_time:433093ms step_avg:184.92ms
+step:2343/4150 train_time:433326ms step_avg:184.94ms
+step:2344/4150 train_time:433563ms step_avg:184.97ms
+step:2345/4150 train_time:433796ms step_avg:184.99ms
+step:2346/4150 train_time:434034ms step_avg:185.01ms
+step:2347/4150 train_time:434265ms step_avg:185.03ms
+step:2348/4150 train_time:434504ms step_avg:185.05ms
+step:2349/4150 train_time:434735ms step_avg:185.07ms
+step:2350/4150 train_time:434975ms step_avg:185.10ms
+step:2351/4150 train_time:435207ms step_avg:185.12ms
+step:2352/4150 train_time:435443ms step_avg:185.14ms
+step:2353/4150 train_time:435678ms step_avg:185.16ms
+step:2354/4150 train_time:435917ms step_avg:185.18ms
+step:2355/4150 train_time:436149ms step_avg:185.20ms
+step:2356/4150 train_time:436386ms step_avg:185.22ms
+step:2357/4150 train_time:436622ms step_avg:185.24ms
+step:2358/4150 train_time:436858ms step_avg:185.27ms
+step:2359/4150 train_time:437089ms step_avg:185.29ms
+step:2360/4150 train_time:437325ms step_avg:185.31ms
+step:2361/4150 train_time:437559ms step_avg:185.33ms
+step:2362/4150 train_time:437797ms step_avg:185.35ms
+step:2363/4150 train_time:438034ms step_avg:185.37ms
+step:2364/4150 train_time:438272ms step_avg:185.39ms
+step:2365/4150 train_time:438505ms step_avg:185.41ms
+step:2366/4150 train_time:438742ms step_avg:185.44ms
+step:2367/4150 train_time:438975ms step_avg:185.46ms
+step:2368/4150 train_time:439213ms step_avg:185.48ms
+step:2369/4150 train_time:439446ms step_avg:185.50ms
+step:2370/4150 train_time:439683ms step_avg:185.52ms
+step:2371/4150 train_time:439919ms step_avg:185.54ms
+step:2372/4150 train_time:440155ms step_avg:185.56ms
+step:2373/4150 train_time:440387ms step_avg:185.58ms
+step:2374/4150 train_time:440626ms step_avg:185.60ms
+step:2375/4150 train_time:440860ms step_avg:185.63ms
+step:2376/4150 train_time:441095ms step_avg:185.65ms
+step:2377/4150 train_time:441328ms step_avg:185.67ms
+step:2378/4150 train_time:441566ms step_avg:185.69ms
+step:2379/4150 train_time:441800ms step_avg:185.71ms
+step:2380/4150 train_time:442036ms step_avg:185.73ms
+step:2381/4150 train_time:442269ms step_avg:185.75ms
+step:2382/4150 train_time:442507ms step_avg:185.77ms
+step:2383/4150 train_time:442743ms step_avg:185.79ms
+step:2384/4150 train_time:442981ms step_avg:185.81ms
+step:2385/4150 train_time:443213ms step_avg:185.83ms
+step:2386/4150 train_time:443451ms step_avg:185.86ms
+step:2387/4150 train_time:443685ms step_avg:185.88ms
+step:2388/4150 train_time:443920ms step_avg:185.90ms
+step:2389/4150 train_time:444152ms step_avg:185.92ms
+step:2390/4150 train_time:444388ms step_avg:185.94ms
+step:2391/4150 train_time:444620ms step_avg:185.96ms
+step:2392/4150 train_time:444854ms step_avg:185.98ms
+step:2393/4150 train_time:445088ms step_avg:186.00ms
+step:2394/4150 train_time:445324ms step_avg:186.02ms
+step:2395/4150 train_time:445558ms step_avg:186.04ms
+step:2396/4150 train_time:445797ms step_avg:186.06ms
+step:2397/4150 train_time:446028ms step_avg:186.08ms
+step:2398/4150 train_time:446264ms step_avg:186.10ms
+step:2399/4150 train_time:446499ms step_avg:186.12ms
+step:2400/4150 train_time:446734ms step_avg:186.14ms
+step:2401/4150 train_time:446968ms step_avg:186.16ms
+step:2402/4150 train_time:447205ms step_avg:186.18ms
+step:2403/4150 train_time:447436ms step_avg:186.20ms
+step:2404/4150 train_time:447677ms step_avg:186.22ms
+step:2405/4150 train_time:447912ms step_avg:186.24ms
+step:2406/4150 train_time:448145ms step_avg:186.26ms
+step:2407/4150 train_time:448381ms step_avg:186.28ms
+step:2408/4150 train_time:448618ms step_avg:186.30ms
+step:2409/4150 train_time:448851ms step_avg:186.32ms
+step:2410/4150 train_time:449090ms step_avg:186.34ms
+step:2411/4150 train_time:449326ms step_avg:186.37ms
+step:2412/4150 train_time:449564ms step_avg:186.39ms
+step:2413/4150 train_time:449797ms step_avg:186.41ms
+step:2414/4150 train_time:450032ms step_avg:186.43ms
+step:2415/4150 train_time:450266ms step_avg:186.45ms
+step:2416/4150 train_time:450504ms step_avg:186.47ms
+step:2417/4150 train_time:450742ms step_avg:186.49ms
+step:2418/4150 train_time:450980ms step_avg:186.51ms
+step:2419/4150 train_time:451212ms step_avg:186.53ms
+step:2420/4150 train_time:451447ms step_avg:186.55ms
+step:2421/4150 train_time:451683ms step_avg:186.57ms
+step:2422/4150 train_time:451923ms step_avg:186.59ms
+step:2423/4150 train_time:452153ms step_avg:186.61ms
+step:2424/4150 train_time:452391ms step_avg:186.63ms
+step:2425/4150 train_time:452627ms step_avg:186.65ms
+step:2426/4150 train_time:452862ms step_avg:186.67ms
+step:2427/4150 train_time:453095ms step_avg:186.69ms
+step:2428/4150 train_time:453333ms step_avg:186.71ms
+step:2429/4150 train_time:453569ms step_avg:186.73ms
+step:2430/4150 train_time:453806ms step_avg:186.75ms
+step:2431/4150 train_time:454041ms step_avg:186.77ms
+step:2432/4150 train_time:454277ms step_avg:186.79ms
+step:2433/4150 train_time:454511ms step_avg:186.81ms
+step:2434/4150 train_time:454746ms step_avg:186.83ms
+step:2435/4150 train_time:454979ms step_avg:186.85ms
+step:2436/4150 train_time:455217ms step_avg:186.87ms
+step:2437/4150 train_time:455451ms step_avg:186.89ms
+step:2438/4150 train_time:455690ms step_avg:186.91ms
+step:2439/4150 train_time:455925ms step_avg:186.93ms
+step:2440/4150 train_time:456162ms step_avg:186.95ms
+step:2441/4150 train_time:456395ms step_avg:186.97ms
+step:2442/4150 train_time:456634ms step_avg:186.99ms
+step:2443/4150 train_time:456867ms step_avg:187.01ms
+step:2444/4150 train_time:457103ms step_avg:187.03ms
+step:2445/4150 train_time:457337ms step_avg:187.05ms
+step:2446/4150 train_time:457572ms step_avg:187.07ms
+step:2447/4150 train_time:457805ms step_avg:187.09ms
+step:2448/4150 train_time:458041ms step_avg:187.11ms
+step:2449/4150 train_time:458275ms step_avg:187.13ms
+step:2450/4150 train_time:458514ms step_avg:187.15ms
+step:2451/4150 train_time:458749ms step_avg:187.17ms
+step:2452/4150 train_time:458986ms step_avg:187.19ms
+step:2453/4150 train_time:459220ms step_avg:187.21ms
+step:2454/4150 train_time:459460ms step_avg:187.23ms
+step:2455/4150 train_time:459694ms step_avg:187.25ms
+step:2456/4150 train_time:459936ms step_avg:187.27ms
+step:2457/4150 train_time:460169ms step_avg:187.29ms
+step:2458/4150 train_time:460402ms step_avg:187.31ms
+step:2459/4150 train_time:460636ms step_avg:187.33ms
+step:2460/4150 train_time:460875ms step_avg:187.35ms
+step:2461/4150 train_time:461110ms step_avg:187.37ms
+step:2462/4150 train_time:461347ms step_avg:187.39ms
+step:2463/4150 train_time:461583ms step_avg:187.41ms
+step:2464/4150 train_time:461820ms step_avg:187.43ms
+step:2465/4150 train_time:462056ms step_avg:187.45ms
+step:2466/4150 train_time:462296ms step_avg:187.47ms
+step:2467/4150 train_time:462528ms step_avg:187.49ms
+step:2468/4150 train_time:462764ms step_avg:187.51ms
+step:2469/4150 train_time:462999ms step_avg:187.52ms
+step:2470/4150 train_time:463237ms step_avg:187.55ms
+step:2471/4150 train_time:463473ms step_avg:187.57ms
+step:2472/4150 train_time:463708ms step_avg:187.58ms
+step:2473/4150 train_time:463939ms step_avg:187.60ms
+step:2474/4150 train_time:464176ms step_avg:187.62ms
+step:2475/4150 train_time:464412ms step_avg:187.64ms
+step:2476/4150 train_time:464649ms step_avg:187.66ms
+step:2477/4150 train_time:464884ms step_avg:187.68ms
+step:2478/4150 train_time:465121ms step_avg:187.70ms
+step:2479/4150 train_time:465352ms step_avg:187.72ms
+step:2480/4150 train_time:465590ms step_avg:187.74ms
+step:2481/4150 train_time:465822ms step_avg:187.76ms
+step:2482/4150 train_time:466057ms step_avg:187.77ms
+step:2483/4150 train_time:466290ms step_avg:187.79ms
+step:2484/4150 train_time:466525ms step_avg:187.81ms
+step:2485/4150 train_time:466760ms step_avg:187.83ms
+step:2486/4150 train_time:466996ms step_avg:187.85ms
+step:2487/4150 train_time:467228ms step_avg:187.87ms
+step:2488/4150 train_time:467468ms step_avg:187.89ms
+step:2489/4150 train_time:467700ms step_avg:187.91ms
+step:2490/4150 train_time:467936ms step_avg:187.93ms
+step:2491/4150 train_time:468169ms step_avg:187.94ms
+step:2492/4150 train_time:468405ms step_avg:187.96ms
+step:2493/4150 train_time:468642ms step_avg:187.98ms
+step:2494/4150 train_time:468878ms step_avg:188.00ms
+step:2495/4150 train_time:469112ms step_avg:188.02ms
+step:2496/4150 train_time:469347ms step_avg:188.04ms
+step:2497/4150 train_time:469580ms step_avg:188.06ms
+step:2498/4150 train_time:469817ms step_avg:188.08ms
+step:2499/4150 train_time:470050ms step_avg:188.10ms
+step:2500/4150 train_time:470285ms step_avg:188.11ms
+step:2500/4150 val_loss:3.1074 train_time:470502ms step_avg:188.20ms
+step:2501/4150 train_time:470526ms step_avg:188.14ms
+step:2502/4150 train_time:470765ms step_avg:188.16ms
+step:2503/4150 train_time:471002ms step_avg:188.17ms
+step:2504/4150 train_time:471234ms step_avg:188.19ms
+step:2505/4150 train_time:471469ms step_avg:188.21ms
+step:2506/4150 train_time:471708ms step_avg:188.23ms
+step:2507/4150 train_time:471943ms step_avg:188.25ms
+step:2508/4150 train_time:472179ms step_avg:188.27ms
+step:2509/4150 train_time:472413ms step_avg:188.29ms
+step:2510/4150 train_time:472649ms step_avg:188.31ms
+step:2511/4150 train_time:472882ms step_avg:188.32ms
+step:2512/4150 train_time:473118ms step_avg:188.34ms
+step:2513/4150 train_time:473349ms step_avg:188.36ms
+step:2514/4150 train_time:473588ms step_avg:188.38ms
+step:2515/4150 train_time:473824ms step_avg:188.40ms
+step:2516/4150 train_time:474061ms step_avg:188.42ms
+step:2517/4150 train_time:474293ms step_avg:188.44ms
+step:2518/4150 train_time:474533ms step_avg:188.46ms
+step:2519/4150 train_time:474768ms step_avg:188.47ms
+step:2520/4150 train_time:475005ms step_avg:188.49ms
+step:2521/4150 train_time:475241ms step_avg:188.51ms
+step:2522/4150 train_time:475475ms step_avg:188.53ms
+step:2523/4150 train_time:475710ms step_avg:188.55ms
+step:2524/4150 train_time:475945ms step_avg:188.57ms
+step:2525/4150 train_time:476179ms step_avg:188.59ms
+step:2526/4150 train_time:476415ms step_avg:188.60ms
+step:2527/4150 train_time:476648ms step_avg:188.62ms
+step:2528/4150 train_time:476885ms step_avg:188.64ms
+step:2529/4150 train_time:477119ms step_avg:188.66ms
+step:2530/4150 train_time:477359ms step_avg:188.68ms
+step:2531/4150 train_time:477590ms step_avg:188.70ms
+step:2532/4150 train_time:477826ms step_avg:188.71ms
+step:2533/4150 train_time:478062ms step_avg:188.73ms
+step:2534/4150 train_time:478300ms step_avg:188.75ms
+step:2535/4150 train_time:478537ms step_avg:188.77ms
+step:2536/4150 train_time:478773ms step_avg:188.79ms
+step:2537/4150 train_time:479007ms step_avg:188.81ms
+step:2538/4150 train_time:479242ms step_avg:188.83ms
+step:2539/4150 train_time:479477ms step_avg:188.84ms
+step:2540/4150 train_time:479714ms step_avg:188.86ms
+step:2541/4150 train_time:479947ms step_avg:188.88ms
+step:2542/4150 train_time:480184ms step_avg:188.90ms
+step:2543/4150 train_time:480417ms step_avg:188.92ms
+step:2544/4150 train_time:480655ms step_avg:188.94ms
+step:2545/4150 train_time:480887ms step_avg:188.95ms
+step:2546/4150 train_time:481125ms step_avg:188.97ms
+step:2547/4150 train_time:481361ms step_avg:188.99ms
+step:2548/4150 train_time:481598ms step_avg:189.01ms
+step:2549/4150 train_time:481836ms step_avg:189.03ms
+step:2550/4150 train_time:482072ms step_avg:189.05ms
+step:2551/4150 train_time:482305ms step_avg:189.07ms
+step:2552/4150 train_time:482542ms step_avg:189.08ms
+step:2553/4150 train_time:482778ms step_avg:189.10ms
+step:2554/4150 train_time:483015ms step_avg:189.12ms
+step:2555/4150 train_time:483249ms step_avg:189.14ms
+step:2556/4150 train_time:483487ms step_avg:189.16ms
+step:2557/4150 train_time:483721ms step_avg:189.18ms
+step:2558/4150 train_time:483961ms step_avg:189.20ms
+step:2559/4150 train_time:484199ms step_avg:189.21ms
+step:2560/4150 train_time:484435ms step_avg:189.23ms
+step:2561/4150 train_time:484669ms step_avg:189.25ms
+step:2562/4150 train_time:484906ms step_avg:189.27ms
+step:2563/4150 train_time:485140ms step_avg:189.29ms
+step:2564/4150 train_time:485378ms step_avg:189.30ms
+step:2565/4150 train_time:485611ms step_avg:189.32ms
+step:2566/4150 train_time:485846ms step_avg:189.34ms
+step:2567/4150 train_time:486082ms step_avg:189.36ms
+step:2568/4150 train_time:486321ms step_avg:189.38ms
+step:2569/4150 train_time:486555ms step_avg:189.39ms
+step:2570/4150 train_time:486791ms step_avg:189.41ms
+step:2571/4150 train_time:487024ms step_avg:189.43ms
+step:2572/4150 train_time:487262ms step_avg:189.45ms
+step:2573/4150 train_time:487494ms step_avg:189.47ms
+step:2574/4150 train_time:487731ms step_avg:189.48ms
+step:2575/4150 train_time:487967ms step_avg:189.50ms
+step:2576/4150 train_time:488204ms step_avg:189.52ms
+step:2577/4150 train_time:488436ms step_avg:189.54ms
+step:2578/4150 train_time:488675ms step_avg:189.56ms
+step:2579/4150 train_time:488909ms step_avg:189.57ms
+step:2580/4150 train_time:489143ms step_avg:189.59ms
+step:2581/4150 train_time:489378ms step_avg:189.61ms
+step:2582/4150 train_time:489618ms step_avg:189.63ms
+step:2583/4150 train_time:489848ms step_avg:189.64ms
+step:2584/4150 train_time:490084ms step_avg:189.66ms
+step:2585/4150 train_time:490318ms step_avg:189.68ms
+step:2586/4150 train_time:490556ms step_avg:189.70ms
+step:2587/4150 train_time:490787ms step_avg:189.71ms
+step:2588/4150 train_time:491023ms step_avg:189.73ms
+step:2589/4150 train_time:491256ms step_avg:189.75ms
+step:2590/4150 train_time:491494ms step_avg:189.77ms
+step:2591/4150 train_time:491729ms step_avg:189.78ms
+step:2592/4150 train_time:491965ms step_avg:189.80ms
+step:2593/4150 train_time:492201ms step_avg:189.82ms
+step:2594/4150 train_time:492436ms step_avg:189.84ms
+step:2595/4150 train_time:492672ms step_avg:189.85ms
+step:2596/4150 train_time:492911ms step_avg:189.87ms
+step:2597/4150 train_time:493145ms step_avg:189.89ms
+step:2598/4150 train_time:493382ms step_avg:189.91ms
+step:2599/4150 train_time:493615ms step_avg:189.92ms
+step:2600/4150 train_time:493853ms step_avg:189.94ms
+step:2601/4150 train_time:494086ms step_avg:189.96ms
+step:2602/4150 train_time:494323ms step_avg:189.98ms
+step:2603/4150 train_time:494560ms step_avg:190.00ms
+step:2604/4150 train_time:494796ms step_avg:190.01ms
+step:2605/4150 train_time:495029ms step_avg:190.03ms
+step:2606/4150 train_time:495266ms step_avg:190.05ms
+step:2607/4150 train_time:495502ms step_avg:190.07ms
+step:2608/4150 train_time:495739ms step_avg:190.08ms
+step:2609/4150 train_time:495971ms step_avg:190.10ms
+step:2610/4150 train_time:496207ms step_avg:190.12ms
+step:2611/4150 train_time:496440ms step_avg:190.13ms
+step:2612/4150 train_time:496678ms step_avg:190.15ms
+step:2613/4150 train_time:496911ms step_avg:190.17ms
+step:2614/4150 train_time:497146ms step_avg:190.19ms
+step:2615/4150 train_time:497380ms step_avg:190.20ms
+step:2616/4150 train_time:497615ms step_avg:190.22ms
+step:2617/4150 train_time:497847ms step_avg:190.24ms
+step:2618/4150 train_time:498083ms step_avg:190.25ms
+step:2619/4150 train_time:498316ms step_avg:190.27ms
+step:2620/4150 train_time:498554ms step_avg:190.29ms
+step:2621/4150 train_time:498785ms step_avg:190.30ms
+step:2622/4150 train_time:499024ms step_avg:190.32ms
+step:2623/4150 train_time:499259ms step_avg:190.34ms
+step:2624/4150 train_time:499502ms step_avg:190.36ms
+step:2625/4150 train_time:499737ms step_avg:190.38ms
+step:2626/4150 train_time:499974ms step_avg:190.39ms
+step:2627/4150 train_time:500210ms step_avg:190.41ms
+step:2628/4150 train_time:500446ms step_avg:190.43ms
+step:2629/4150 train_time:500679ms step_avg:190.44ms
+step:2630/4150 train_time:500915ms step_avg:190.46ms
+step:2631/4150 train_time:501148ms step_avg:190.48ms
+step:2632/4150 train_time:501386ms step_avg:190.50ms
+step:2633/4150 train_time:501619ms step_avg:190.51ms
+step:2634/4150 train_time:501853ms step_avg:190.53ms
+step:2635/4150 train_time:502087ms step_avg:190.55ms
+step:2636/4150 train_time:502325ms step_avg:190.56ms
+step:2637/4150 train_time:502557ms step_avg:190.58ms
+step:2638/4150 train_time:502797ms step_avg:190.60ms
+step:2639/4150 train_time:503030ms step_avg:190.61ms
+step:2640/4150 train_time:503268ms step_avg:190.63ms
+step:2641/4150 train_time:503500ms step_avg:190.65ms
+step:2642/4150 train_time:503740ms step_avg:190.67ms
+step:2643/4150 train_time:503974ms step_avg:190.68ms
+step:2644/4150 train_time:504212ms step_avg:190.70ms
+step:2645/4150 train_time:504446ms step_avg:190.72ms
+step:2646/4150 train_time:504685ms step_avg:190.74ms
+step:2647/4150 train_time:504921ms step_avg:190.75ms
+step:2648/4150 train_time:505160ms step_avg:190.77ms
+step:2649/4150 train_time:505395ms step_avg:190.79ms
+step:2650/4150 train_time:505630ms step_avg:190.80ms
+step:2651/4150 train_time:505864ms step_avg:190.82ms
+step:2652/4150 train_time:506101ms step_avg:190.84ms
+step:2653/4150 train_time:506342ms step_avg:190.86ms
+step:2654/4150 train_time:506580ms step_avg:190.87ms
+step:2655/4150 train_time:506813ms step_avg:190.89ms
+step:2656/4150 train_time:507048ms step_avg:190.91ms
+step:2657/4150 train_time:507284ms step_avg:190.92ms
+step:2658/4150 train_time:507523ms step_avg:190.94ms
+step:2659/4150 train_time:507756ms step_avg:190.96ms
+step:2660/4150 train_time:507993ms step_avg:190.97ms
+step:2661/4150 train_time:508226ms step_avg:190.99ms
+step:2662/4150 train_time:508464ms step_avg:191.01ms
+step:2663/4150 train_time:508700ms step_avg:191.03ms
+step:2664/4150 train_time:508936ms step_avg:191.04ms
+step:2665/4150 train_time:509168ms step_avg:191.06ms
+step:2666/4150 train_time:509405ms step_avg:191.07ms
+step:2667/4150 train_time:509640ms step_avg:191.09ms
+step:2668/4150 train_time:509876ms step_avg:191.11ms
+step:2669/4150 train_time:510109ms step_avg:191.12ms
+step:2670/4150 train_time:510344ms step_avg:191.14ms
+step:2671/4150 train_time:510577ms step_avg:191.16ms
+step:2672/4150 train_time:510813ms step_avg:191.17ms
+step:2673/4150 train_time:511047ms step_avg:191.19ms
+step:2674/4150 train_time:511283ms step_avg:191.21ms
+step:2675/4150 train_time:511518ms step_avg:191.22ms
+step:2676/4150 train_time:511755ms step_avg:191.24ms
+step:2677/4150 train_time:511987ms step_avg:191.25ms
+step:2678/4150 train_time:512223ms step_avg:191.27ms
+step:2679/4150 train_time:512457ms step_avg:191.29ms
+step:2680/4150 train_time:512696ms step_avg:191.30ms
+step:2681/4150 train_time:512931ms step_avg:191.32ms
+step:2682/4150 train_time:513166ms step_avg:191.34ms
+step:2683/4150 train_time:513397ms step_avg:191.35ms
+step:2684/4150 train_time:513636ms step_avg:191.37ms
+step:2685/4150 train_time:513870ms step_avg:191.39ms
+step:2686/4150 train_time:514107ms step_avg:191.40ms
+step:2687/4150 train_time:514342ms step_avg:191.42ms
+step:2688/4150 train_time:514580ms step_avg:191.44ms
+step:2689/4150 train_time:514815ms step_avg:191.45ms
+step:2690/4150 train_time:515054ms step_avg:191.47ms
+step:2691/4150 train_time:515288ms step_avg:191.49ms
+step:2692/4150 train_time:515525ms step_avg:191.50ms
+step:2693/4150 train_time:515762ms step_avg:191.52ms
+step:2694/4150 train_time:516002ms step_avg:191.54ms
+step:2695/4150 train_time:516237ms step_avg:191.55ms
+step:2696/4150 train_time:516474ms step_avg:191.57ms
+step:2697/4150 train_time:516709ms step_avg:191.59ms
+step:2698/4150 train_time:516948ms step_avg:191.60ms
+step:2699/4150 train_time:517182ms step_avg:191.62ms
+step:2700/4150 train_time:517417ms step_avg:191.64ms
+step:2701/4150 train_time:517648ms step_avg:191.65ms
+step:2702/4150 train_time:517887ms step_avg:191.67ms
+step:2703/4150 train_time:518122ms step_avg:191.68ms
+step:2704/4150 train_time:518361ms step_avg:191.70ms
+step:2705/4150 train_time:518595ms step_avg:191.72ms
+step:2706/4150 train_time:518836ms step_avg:191.74ms
+step:2707/4150 train_time:519070ms step_avg:191.75ms
+step:2708/4150 train_time:519306ms step_avg:191.77ms
+step:2709/4150 train_time:519541ms step_avg:191.78ms
+step:2710/4150 train_time:519779ms step_avg:191.80ms
+step:2711/4150 train_time:520012ms step_avg:191.82ms
+step:2712/4150 train_time:520248ms step_avg:191.83ms
+step:2713/4150 train_time:520482ms step_avg:191.85ms
+step:2714/4150 train_time:520721ms step_avg:191.86ms
+step:2715/4150 train_time:520954ms step_avg:191.88ms
+step:2716/4150 train_time:521190ms step_avg:191.90ms
+step:2717/4150 train_time:521422ms step_avg:191.91ms
+step:2718/4150 train_time:521660ms step_avg:191.93ms
+step:2719/4150 train_time:521893ms step_avg:191.94ms
+step:2720/4150 train_time:522131ms step_avg:191.96ms
+step:2721/4150 train_time:522365ms step_avg:191.98ms
+step:2722/4150 train_time:522602ms step_avg:191.99ms
+step:2723/4150 train_time:522838ms step_avg:192.01ms
+step:2724/4150 train_time:523077ms step_avg:192.03ms
+step:2725/4150 train_time:523311ms step_avg:192.04ms
+step:2726/4150 train_time:523546ms step_avg:192.06ms
+step:2727/4150 train_time:523782ms step_avg:192.07ms
+step:2728/4150 train_time:524018ms step_avg:192.09ms
+step:2729/4150 train_time:524251ms step_avg:192.10ms
+step:2730/4150 train_time:524493ms step_avg:192.12ms
+step:2731/4150 train_time:524726ms step_avg:192.14ms
+step:2732/4150 train_time:524962ms step_avg:192.15ms
+step:2733/4150 train_time:525195ms step_avg:192.17ms
+step:2734/4150 train_time:525432ms step_avg:192.18ms
+step:2735/4150 train_time:525666ms step_avg:192.20ms
+step:2736/4150 train_time:525901ms step_avg:192.22ms
+step:2737/4150 train_time:526135ms step_avg:192.23ms
+step:2738/4150 train_time:526371ms step_avg:192.25ms
+step:2739/4150 train_time:526607ms step_avg:192.26ms
+step:2740/4150 train_time:526846ms step_avg:192.28ms
+step:2741/4150 train_time:527080ms step_avg:192.29ms
+step:2742/4150 train_time:527317ms step_avg:192.31ms
+step:2743/4150 train_time:527552ms step_avg:192.33ms
+step:2744/4150 train_time:527791ms step_avg:192.34ms
+step:2745/4150 train_time:528024ms step_avg:192.36ms
+step:2746/4150 train_time:528259ms step_avg:192.37ms
+step:2747/4150 train_time:528492ms step_avg:192.39ms
+step:2748/4150 train_time:528731ms step_avg:192.41ms
+step:2749/4150 train_time:528965ms step_avg:192.42ms
+step:2750/4150 train_time:529203ms step_avg:192.44ms
+step:2750/4150 val_loss:3.0742 train_time:529424ms step_avg:192.52ms
+step:2751/4150 train_time:529448ms step_avg:192.46ms
+step:2752/4150 train_time:529686ms step_avg:192.47ms
+step:2753/4150 train_time:529922ms step_avg:192.49ms
+step:2754/4150 train_time:530156ms step_avg:192.50ms
+step:2755/4150 train_time:530387ms step_avg:192.52ms
+step:2756/4150 train_time:530624ms step_avg:192.53ms
+step:2757/4150 train_time:530860ms step_avg:192.55ms
+step:2758/4150 train_time:531097ms step_avg:192.57ms
+step:2759/4150 train_time:531332ms step_avg:192.58ms
+step:2760/4150 train_time:531569ms step_avg:192.60ms
+step:2761/4150 train_time:531803ms step_avg:192.61ms
+step:2762/4150 train_time:532042ms step_avg:192.63ms
+step:2763/4150 train_time:532275ms step_avg:192.64ms
+step:2764/4150 train_time:532514ms step_avg:192.66ms
+step:2765/4150 train_time:532752ms step_avg:192.68ms
+step:2766/4150 train_time:532989ms step_avg:192.69ms
+step:2767/4150 train_time:533222ms step_avg:192.71ms
+step:2768/4150 train_time:533458ms step_avg:192.72ms
+step:2769/4150 train_time:533693ms step_avg:192.74ms
+step:2770/4150 train_time:533933ms step_avg:192.76ms
+step:2771/4150 train_time:534164ms step_avg:192.77ms
+step:2772/4150 train_time:534402ms step_avg:192.79ms
+step:2773/4150 train_time:534637ms step_avg:192.80ms
+step:2774/4150 train_time:534875ms step_avg:192.82ms
+step:2775/4150 train_time:535109ms step_avg:192.83ms
+step:2776/4150 train_time:535347ms step_avg:192.85ms
+step:2777/4150 train_time:535583ms step_avg:192.86ms
+step:2778/4150 train_time:535822ms step_avg:192.88ms
+step:2779/4150 train_time:536056ms step_avg:192.90ms
+step:2780/4150 train_time:536294ms step_avg:192.91ms
+step:2781/4150 train_time:536530ms step_avg:192.93ms
+step:2782/4150 train_time:536766ms step_avg:192.94ms
+step:2783/4150 train_time:537001ms step_avg:192.96ms
+step:2784/4150 train_time:537239ms step_avg:192.97ms
+step:2785/4150 train_time:537475ms step_avg:192.99ms
+step:2786/4150 train_time:537711ms step_avg:193.00ms
+step:2787/4150 train_time:537945ms step_avg:193.02ms
+step:2788/4150 train_time:538183ms step_avg:193.04ms
+step:2789/4150 train_time:538417ms step_avg:193.05ms
+step:2790/4150 train_time:538655ms step_avg:193.07ms
+step:2791/4150 train_time:538892ms step_avg:193.08ms
+step:2792/4150 train_time:539127ms step_avg:193.10ms
+step:2793/4150 train_time:539361ms step_avg:193.11ms
+step:2794/4150 train_time:539596ms step_avg:193.13ms
+step:2795/4150 train_time:539832ms step_avg:193.14ms
+step:2796/4150 train_time:540068ms step_avg:193.16ms
+step:2797/4150 train_time:540301ms step_avg:193.17ms
+step:2798/4150 train_time:540537ms step_avg:193.19ms
+step:2799/4150 train_time:540774ms step_avg:193.20ms
+step:2800/4150 train_time:541013ms step_avg:193.22ms
+step:2801/4150 train_time:541248ms step_avg:193.23ms
+step:2802/4150 train_time:541484ms step_avg:193.25ms
+step:2803/4150 train_time:541717ms step_avg:193.26ms
+step:2804/4150 train_time:541952ms step_avg:193.28ms
+step:2805/4150 train_time:542186ms step_avg:193.29ms
+step:2806/4150 train_time:542423ms step_avg:193.31ms
+step:2807/4150 train_time:542659ms step_avg:193.32ms
+step:2808/4150 train_time:542897ms step_avg:193.34ms
+step:2809/4150 train_time:543132ms step_avg:193.35ms
+step:2810/4150 train_time:543376ms step_avg:193.37ms
+step:2811/4150 train_time:543609ms step_avg:193.39ms
+step:2812/4150 train_time:543845ms step_avg:193.40ms
+step:2813/4150 train_time:544079ms step_avg:193.42ms
+step:2814/4150 train_time:544318ms step_avg:193.43ms
+step:2815/4150 train_time:544554ms step_avg:193.45ms
+step:2816/4150 train_time:544796ms step_avg:193.46ms
+step:2817/4150 train_time:545030ms step_avg:193.48ms
+step:2818/4150 train_time:545271ms step_avg:193.50ms
+step:2819/4150 train_time:545503ms step_avg:193.51ms
+step:2820/4150 train_time:545740ms step_avg:193.52ms
+step:2821/4150 train_time:545974ms step_avg:193.54ms
+step:2822/4150 train_time:546215ms step_avg:193.56ms
+step:2823/4150 train_time:546446ms step_avg:193.57ms
+step:2824/4150 train_time:546683ms step_avg:193.58ms
+step:2825/4150 train_time:546920ms step_avg:193.60ms
+step:2826/4150 train_time:547155ms step_avg:193.61ms
+step:2827/4150 train_time:547389ms step_avg:193.63ms
+step:2828/4150 train_time:547626ms step_avg:193.64ms
+step:2829/4150 train_time:547859ms step_avg:193.66ms
+step:2830/4150 train_time:548096ms step_avg:193.67ms
+step:2831/4150 train_time:548336ms step_avg:193.69ms
+step:2832/4150 train_time:548576ms step_avg:193.71ms
+step:2833/4150 train_time:548811ms step_avg:193.72ms
+step:2834/4150 train_time:549047ms step_avg:193.74ms
+step:2835/4150 train_time:549283ms step_avg:193.75ms
+step:2836/4150 train_time:549521ms step_avg:193.77ms
+step:2837/4150 train_time:549753ms step_avg:193.78ms
+step:2838/4150 train_time:549995ms step_avg:193.80ms
+step:2839/4150 train_time:550230ms step_avg:193.81ms
+step:2840/4150 train_time:550468ms step_avg:193.83ms
+step:2841/4150 train_time:550702ms step_avg:193.84ms
+step:2842/4150 train_time:550940ms step_avg:193.86ms
+step:2843/4150 train_time:551174ms step_avg:193.87ms
+step:2844/4150 train_time:551414ms step_avg:193.89ms
+step:2845/4150 train_time:551650ms step_avg:193.90ms
+step:2846/4150 train_time:551887ms step_avg:193.92ms
+step:2847/4150 train_time:552121ms step_avg:193.93ms
+step:2848/4150 train_time:552359ms step_avg:193.95ms
+step:2849/4150 train_time:552592ms step_avg:193.96ms
+step:2850/4150 train_time:552828ms step_avg:193.97ms
+step:2851/4150 train_time:553059ms step_avg:193.99ms
+step:2852/4150 train_time:553297ms step_avg:194.00ms
+step:2853/4150 train_time:553533ms step_avg:194.02ms
+step:2854/4150 train_time:553772ms step_avg:194.03ms
+step:2855/4150 train_time:554006ms step_avg:194.05ms
+step:2856/4150 train_time:554242ms step_avg:194.06ms
+step:2857/4150 train_time:554477ms step_avg:194.08ms
+step:2858/4150 train_time:554717ms step_avg:194.09ms
+step:2859/4150 train_time:554952ms step_avg:194.11ms
+step:2860/4150 train_time:555189ms step_avg:194.12ms
+step:2861/4150 train_time:555425ms step_avg:194.14ms
+step:2862/4150 train_time:555664ms step_avg:194.15ms
+step:2863/4150 train_time:555900ms step_avg:194.17ms
+step:2864/4150 train_time:556136ms step_avg:194.18ms
+step:2865/4150 train_time:556370ms step_avg:194.20ms
+step:2866/4150 train_time:556607ms step_avg:194.21ms
+step:2867/4150 train_time:556843ms step_avg:194.22ms
+step:2868/4150 train_time:557080ms step_avg:194.24ms
+step:2869/4150 train_time:557314ms step_avg:194.25ms
+step:2870/4150 train_time:557553ms step_avg:194.27ms
+step:2871/4150 train_time:557790ms step_avg:194.28ms
+step:2872/4150 train_time:558027ms step_avg:194.30ms
+step:2873/4150 train_time:558261ms step_avg:194.31ms
+step:2874/4150 train_time:558500ms step_avg:194.33ms
+step:2875/4150 train_time:558734ms step_avg:194.34ms
+step:2876/4150 train_time:558971ms step_avg:194.36ms
+step:2877/4150 train_time:559205ms step_avg:194.37ms
+step:2878/4150 train_time:559448ms step_avg:194.39ms
+step:2879/4150 train_time:559681ms step_avg:194.40ms
+step:2880/4150 train_time:559921ms step_avg:194.42ms
+step:2881/4150 train_time:560153ms step_avg:194.43ms
+step:2882/4150 train_time:560391ms step_avg:194.45ms
+step:2883/4150 train_time:560625ms step_avg:194.46ms
+step:2884/4150 train_time:560862ms step_avg:194.47ms
+step:2885/4150 train_time:561093ms step_avg:194.49ms
+step:2886/4150 train_time:561330ms step_avg:194.50ms
+step:2887/4150 train_time:561565ms step_avg:194.52ms
+step:2888/4150 train_time:561803ms step_avg:194.53ms
+step:2889/4150 train_time:562034ms step_avg:194.54ms
+step:2890/4150 train_time:562275ms step_avg:194.56ms
+step:2891/4150 train_time:562512ms step_avg:194.57ms
+step:2892/4150 train_time:562753ms step_avg:194.59ms
+step:2893/4150 train_time:562986ms step_avg:194.60ms
+step:2894/4150 train_time:563224ms step_avg:194.62ms
+step:2895/4150 train_time:563458ms step_avg:194.63ms
+step:2896/4150 train_time:563693ms step_avg:194.65ms
+step:2897/4150 train_time:563931ms step_avg:194.66ms
+step:2898/4150 train_time:564168ms step_avg:194.67ms
+step:2899/4150 train_time:564404ms step_avg:194.69ms
+step:2900/4150 train_time:564639ms step_avg:194.70ms
+step:2901/4150 train_time:564875ms step_avg:194.72ms
+step:2902/4150 train_time:565112ms step_avg:194.73ms
+step:2903/4150 train_time:565343ms step_avg:194.74ms
+step:2904/4150 train_time:565581ms step_avg:194.76ms
+step:2905/4150 train_time:565817ms step_avg:194.77ms
+step:2906/4150 train_time:566054ms step_avg:194.79ms
+step:2907/4150 train_time:566286ms step_avg:194.80ms
+step:2908/4150 train_time:566523ms step_avg:194.82ms
+step:2909/4150 train_time:566761ms step_avg:194.83ms
+step:2910/4150 train_time:567000ms step_avg:194.85ms
+step:2911/4150 train_time:567235ms step_avg:194.86ms
+step:2912/4150 train_time:567470ms step_avg:194.87ms
+step:2913/4150 train_time:567704ms step_avg:194.89ms
+step:2914/4150 train_time:567941ms step_avg:194.90ms
+step:2915/4150 train_time:568176ms step_avg:194.91ms
+step:2916/4150 train_time:568414ms step_avg:194.93ms
+step:2917/4150 train_time:568646ms step_avg:194.94ms
+step:2918/4150 train_time:568884ms step_avg:194.96ms
+step:2919/4150 train_time:569122ms step_avg:194.97ms
+step:2920/4150 train_time:569361ms step_avg:194.99ms
+step:2921/4150 train_time:569597ms step_avg:195.00ms
+step:2922/4150 train_time:569833ms step_avg:195.01ms
+step:2923/4150 train_time:570065ms step_avg:195.03ms
+step:2924/4150 train_time:570305ms step_avg:195.04ms
+step:2925/4150 train_time:570539ms step_avg:195.06ms
+step:2926/4150 train_time:570774ms step_avg:195.07ms
+step:2927/4150 train_time:571006ms step_avg:195.08ms
+step:2928/4150 train_time:571243ms step_avg:195.10ms
+step:2929/4150 train_time:571480ms step_avg:195.11ms
+step:2930/4150 train_time:571719ms step_avg:195.13ms
+step:2931/4150 train_time:571954ms step_avg:195.14ms
+step:2932/4150 train_time:572192ms step_avg:195.15ms
+step:2933/4150 train_time:572425ms step_avg:195.17ms
+step:2934/4150 train_time:572663ms step_avg:195.18ms
+step:2935/4150 train_time:572898ms step_avg:195.20ms
+step:2936/4150 train_time:573136ms step_avg:195.21ms
+step:2937/4150 train_time:573371ms step_avg:195.22ms
+step:2938/4150 train_time:573608ms step_avg:195.24ms
+step:2939/4150 train_time:573844ms step_avg:195.25ms
+step:2940/4150 train_time:574081ms step_avg:195.27ms
+step:2941/4150 train_time:574318ms step_avg:195.28ms
+step:2942/4150 train_time:574555ms step_avg:195.29ms
+step:2943/4150 train_time:574791ms step_avg:195.31ms
+step:2944/4150 train_time:575031ms step_avg:195.32ms
+step:2945/4150 train_time:575262ms step_avg:195.34ms
+step:2946/4150 train_time:575499ms step_avg:195.35ms
+step:2947/4150 train_time:575735ms step_avg:195.36ms
+step:2948/4150 train_time:575971ms step_avg:195.38ms
+step:2949/4150 train_time:576201ms step_avg:195.39ms
+step:2950/4150 train_time:576440ms step_avg:195.40ms
+step:2951/4150 train_time:576675ms step_avg:195.42ms
+step:2952/4150 train_time:576911ms step_avg:195.43ms
+step:2953/4150 train_time:577145ms step_avg:195.44ms
+step:2954/4150 train_time:577384ms step_avg:195.46ms
+step:2955/4150 train_time:577619ms step_avg:195.47ms
+step:2956/4150 train_time:577857ms step_avg:195.49ms
+step:2957/4150 train_time:578092ms step_avg:195.50ms
+step:2958/4150 train_time:578328ms step_avg:195.51ms
+step:2959/4150 train_time:578568ms step_avg:195.53ms
+step:2960/4150 train_time:578803ms step_avg:195.54ms
+step:2961/4150 train_time:579036ms step_avg:195.55ms
+step:2962/4150 train_time:579276ms step_avg:195.57ms
+step:2963/4150 train_time:579509ms step_avg:195.58ms
+step:2964/4150 train_time:579749ms step_avg:195.60ms
+step:2965/4150 train_time:579983ms step_avg:195.61ms
+step:2966/4150 train_time:580218ms step_avg:195.62ms
+step:2967/4150 train_time:580456ms step_avg:195.64ms
+step:2968/4150 train_time:580696ms step_avg:195.65ms
+step:2969/4150 train_time:580934ms step_avg:195.67ms
+step:2970/4150 train_time:581173ms step_avg:195.68ms
+step:2971/4150 train_time:581407ms step_avg:195.69ms
+step:2972/4150 train_time:581645ms step_avg:195.71ms
+step:2973/4150 train_time:581881ms step_avg:195.72ms
+step:2974/4150 train_time:582118ms step_avg:195.74ms
+step:2975/4150 train_time:582351ms step_avg:195.75ms
+step:2976/4150 train_time:582592ms step_avg:195.76ms
+step:2977/4150 train_time:582825ms step_avg:195.78ms
+step:2978/4150 train_time:583059ms step_avg:195.79ms
+step:2979/4150 train_time:583290ms step_avg:195.80ms
+step:2980/4150 train_time:583530ms step_avg:195.82ms
+step:2981/4150 train_time:583765ms step_avg:195.83ms
+step:2982/4150 train_time:584001ms step_avg:195.84ms
+step:2983/4150 train_time:584235ms step_avg:195.86ms
+step:2984/4150 train_time:584475ms step_avg:195.87ms
+step:2985/4150 train_time:584713ms step_avg:195.88ms
+step:2986/4150 train_time:584952ms step_avg:195.90ms
+step:2987/4150 train_time:585184ms step_avg:195.91ms
+step:2988/4150 train_time:585423ms step_avg:195.92ms
+step:2989/4150 train_time:585659ms step_avg:195.94ms
+step:2990/4150 train_time:585898ms step_avg:195.95ms
+step:2991/4150 train_time:586131ms step_avg:195.96ms
+step:2992/4150 train_time:586371ms step_avg:195.98ms
+step:2993/4150 train_time:586603ms step_avg:195.99ms
+step:2994/4150 train_time:586840ms step_avg:196.01ms
+step:2995/4150 train_time:587075ms step_avg:196.02ms
+step:2996/4150 train_time:587310ms step_avg:196.03ms
+step:2997/4150 train_time:587544ms step_avg:196.04ms
+step:2998/4150 train_time:587781ms step_avg:196.06ms
+step:2999/4150 train_time:588018ms step_avg:196.07ms
+step:3000/4150 train_time:588257ms step_avg:196.09ms
+step:3000/4150 val_loss:3.0427 train_time:588474ms step_avg:196.16ms
+step:3001/4150 train_time:588497ms step_avg:196.10ms
+step:3002/4150 train_time:588737ms step_avg:196.12ms
+step:3003/4150 train_time:588974ms step_avg:196.13ms
+step:3004/4150 train_time:589208ms step_avg:196.14ms
+step:3005/4150 train_time:589440ms step_avg:196.15ms
+step:3006/4150 train_time:589679ms step_avg:196.17ms
+step:3007/4150 train_time:589920ms step_avg:196.18ms
+step:3008/4150 train_time:590158ms step_avg:196.20ms
+step:3009/4150 train_time:590392ms step_avg:196.21ms
+step:3010/4150 train_time:590630ms step_avg:196.22ms
+step:3011/4150 train_time:590864ms step_avg:196.24ms
+step:3012/4150 train_time:591100ms step_avg:196.25ms
+step:3013/4150 train_time:591336ms step_avg:196.26ms
+step:3014/4150 train_time:591576ms step_avg:196.28ms
+step:3015/4150 train_time:591814ms step_avg:196.29ms
+step:3016/4150 train_time:592051ms step_avg:196.30ms
+step:3017/4150 train_time:592284ms step_avg:196.32ms
+step:3018/4150 train_time:592520ms step_avg:196.33ms
+step:3019/4150 train_time:592756ms step_avg:196.34ms
+step:3020/4150 train_time:592995ms step_avg:196.36ms
+step:3021/4150 train_time:593228ms step_avg:196.37ms
+step:3022/4150 train_time:593466ms step_avg:196.38ms
+step:3023/4150 train_time:593703ms step_avg:196.40ms
+step:3024/4150 train_time:593940ms step_avg:196.41ms
+step:3025/4150 train_time:594172ms step_avg:196.42ms
+step:3026/4150 train_time:594408ms step_avg:196.43ms
+step:3027/4150 train_time:594642ms step_avg:196.45ms
+step:3028/4150 train_time:594879ms step_avg:196.46ms
+step:3029/4150 train_time:595112ms step_avg:196.47ms
+step:3030/4150 train_time:595351ms step_avg:196.49ms
+step:3031/4150 train_time:595585ms step_avg:196.50ms
+step:3032/4150 train_time:595822ms step_avg:196.51ms
+step:3033/4150 train_time:596056ms step_avg:196.52ms
+step:3034/4150 train_time:596294ms step_avg:196.54ms
+step:3035/4150 train_time:596533ms step_avg:196.55ms
+step:3036/4150 train_time:596768ms step_avg:196.56ms
+step:3037/4150 train_time:597004ms step_avg:196.58ms
+step:3038/4150 train_time:597241ms step_avg:196.59ms
+step:3039/4150 train_time:597473ms step_avg:196.60ms
+step:3040/4150 train_time:597714ms step_avg:196.62ms
+step:3041/4150 train_time:597950ms step_avg:196.63ms
+step:3042/4150 train_time:598186ms step_avg:196.64ms
+step:3043/4150 train_time:598422ms step_avg:196.66ms
+step:3044/4150 train_time:598658ms step_avg:196.67ms
+step:3045/4150 train_time:598894ms step_avg:196.68ms
+step:3046/4150 train_time:599131ms step_avg:196.69ms
+step:3047/4150 train_time:599367ms step_avg:196.71ms
+step:3048/4150 train_time:599604ms step_avg:196.72ms
+step:3049/4150 train_time:599838ms step_avg:196.73ms
+step:3050/4150 train_time:600074ms step_avg:196.75ms
+step:3051/4150 train_time:600309ms step_avg:196.76ms
+step:3052/4150 train_time:600548ms step_avg:196.77ms
+step:3053/4150 train_time:600782ms step_avg:196.78ms
+step:3054/4150 train_time:601020ms step_avg:196.80ms
+step:3055/4150 train_time:601250ms step_avg:196.81ms
+step:3056/4150 train_time:601487ms step_avg:196.82ms
+step:3057/4150 train_time:601723ms step_avg:196.83ms
+step:3058/4150 train_time:601961ms step_avg:196.85ms
+step:3059/4150 train_time:602195ms step_avg:196.86ms
+step:3060/4150 train_time:602434ms step_avg:196.87ms
+step:3061/4150 train_time:602669ms step_avg:196.89ms
+step:3062/4150 train_time:602907ms step_avg:196.90ms
+step:3063/4150 train_time:603143ms step_avg:196.91ms
+step:3064/4150 train_time:603382ms step_avg:196.93ms
+step:3065/4150 train_time:603617ms step_avg:196.94ms
+step:3066/4150 train_time:603857ms step_avg:196.95ms
+step:3067/4150 train_time:604092ms step_avg:196.97ms
+step:3068/4150 train_time:604330ms step_avg:196.98ms
+step:3069/4150 train_time:604560ms step_avg:196.99ms
+step:3070/4150 train_time:604796ms step_avg:197.00ms
+step:3071/4150 train_time:605031ms step_avg:197.01ms
+step:3072/4150 train_time:605268ms step_avg:197.03ms
+step:3073/4150 train_time:605501ms step_avg:197.04ms
+step:3074/4150 train_time:605738ms step_avg:197.05ms
+step:3075/4150 train_time:605976ms step_avg:197.07ms
+step:3076/4150 train_time:606213ms step_avg:197.08ms
+step:3077/4150 train_time:606445ms step_avg:197.09ms
+step:3078/4150 train_time:606684ms step_avg:197.10ms
+step:3079/4150 train_time:606921ms step_avg:197.12ms
+step:3080/4150 train_time:607158ms step_avg:197.13ms
+step:3081/4150 train_time:607392ms step_avg:197.14ms
+step:3082/4150 train_time:607634ms step_avg:197.16ms
+step:3083/4150 train_time:607868ms step_avg:197.17ms
+step:3084/4150 train_time:608106ms step_avg:197.18ms
+step:3085/4150 train_time:608339ms step_avg:197.19ms
+step:3086/4150 train_time:608577ms step_avg:197.21ms
+step:3087/4150 train_time:608812ms step_avg:197.22ms
+step:3088/4150 train_time:609050ms step_avg:197.23ms
+step:3089/4150 train_time:609282ms step_avg:197.24ms
+step:3090/4150 train_time:609518ms step_avg:197.26ms
+step:3091/4150 train_time:609753ms step_avg:197.27ms
+step:3092/4150 train_time:609993ms step_avg:197.28ms
+step:3093/4150 train_time:610228ms step_avg:197.29ms
+step:3094/4150 train_time:610467ms step_avg:197.31ms
+step:3095/4150 train_time:610699ms step_avg:197.32ms
+step:3096/4150 train_time:610936ms step_avg:197.33ms
+step:3097/4150 train_time:611172ms step_avg:197.34ms
+step:3098/4150 train_time:611410ms step_avg:197.36ms
+step:3099/4150 train_time:611642ms step_avg:197.37ms
+step:3100/4150 train_time:611877ms step_avg:197.38ms
+step:3101/4150 train_time:612110ms step_avg:197.39ms
+step:3102/4150 train_time:612346ms step_avg:197.40ms
+step:3103/4150 train_time:612579ms step_avg:197.42ms
+step:3104/4150 train_time:612819ms step_avg:197.43ms
+step:3105/4150 train_time:613053ms step_avg:197.44ms
+step:3106/4150 train_time:613288ms step_avg:197.45ms
+step:3107/4150 train_time:613522ms step_avg:197.46ms
+step:3108/4150 train_time:613761ms step_avg:197.48ms
+step:3109/4150 train_time:613997ms step_avg:197.49ms
+step:3110/4150 train_time:614236ms step_avg:197.50ms
+step:3111/4150 train_time:614473ms step_avg:197.52ms
+step:3112/4150 train_time:614709ms step_avg:197.53ms
+step:3113/4150 train_time:614943ms step_avg:197.54ms
+step:3114/4150 train_time:615180ms step_avg:197.55ms
+step:3115/4150 train_time:615417ms step_avg:197.57ms
+step:3116/4150 train_time:615654ms step_avg:197.58ms
+step:3117/4150 train_time:615888ms step_avg:197.59ms
+step:3118/4150 train_time:616126ms step_avg:197.60ms
+step:3119/4150 train_time:616361ms step_avg:197.61ms
+step:3120/4150 train_time:616602ms step_avg:197.63ms
+step:3121/4150 train_time:616838ms step_avg:197.64ms
+step:3122/4150 train_time:617077ms step_avg:197.65ms
+step:3123/4150 train_time:617313ms step_avg:197.67ms
+step:3124/4150 train_time:617551ms step_avg:197.68ms
+step:3125/4150 train_time:617782ms step_avg:197.69ms
+step:3126/4150 train_time:618018ms step_avg:197.70ms
+step:3127/4150 train_time:618253ms step_avg:197.71ms
+step:3128/4150 train_time:618494ms step_avg:197.73ms
+step:3129/4150 train_time:618727ms step_avg:197.74ms
+step:3130/4150 train_time:618967ms step_avg:197.75ms
+step:3131/4150 train_time:619199ms step_avg:197.76ms
+step:3132/4150 train_time:619435ms step_avg:197.78ms
+step:3133/4150 train_time:619674ms step_avg:197.79ms
+step:3134/4150 train_time:619910ms step_avg:197.80ms
+step:3135/4150 train_time:620144ms step_avg:197.81ms
+step:3136/4150 train_time:620383ms step_avg:197.83ms
+step:3137/4150 train_time:620620ms step_avg:197.84ms
+step:3138/4150 train_time:620858ms step_avg:197.85ms
+step:3139/4150 train_time:621095ms step_avg:197.86ms
+step:3140/4150 train_time:621334ms step_avg:197.88ms
+step:3141/4150 train_time:621567ms step_avg:197.89ms
+step:3142/4150 train_time:621805ms step_avg:197.90ms
+step:3143/4150 train_time:622037ms step_avg:197.91ms
+step:3144/4150 train_time:622277ms step_avg:197.93ms
+step:3145/4150 train_time:622514ms step_avg:197.94ms
+step:3146/4150 train_time:622752ms step_avg:197.95ms
+step:3147/4150 train_time:622985ms step_avg:197.96ms
+step:3148/4150 train_time:623222ms step_avg:197.97ms
+step:3149/4150 train_time:623457ms step_avg:197.99ms
+step:3150/4150 train_time:623697ms step_avg:198.00ms
+step:3151/4150 train_time:623933ms step_avg:198.01ms
+step:3152/4150 train_time:624170ms step_avg:198.02ms
+step:3153/4150 train_time:624403ms step_avg:198.03ms
+step:3154/4150 train_time:624643ms step_avg:198.05ms
+step:3155/4150 train_time:624881ms step_avg:198.06ms
+step:3156/4150 train_time:625117ms step_avg:198.07ms
+step:3157/4150 train_time:625353ms step_avg:198.08ms
+step:3158/4150 train_time:625592ms step_avg:198.10ms
+step:3159/4150 train_time:625828ms step_avg:198.11ms
+step:3160/4150 train_time:626068ms step_avg:198.12ms
+step:3161/4150 train_time:626303ms step_avg:198.13ms
+step:3162/4150 train_time:626538ms step_avg:198.15ms
+step:3163/4150 train_time:626775ms step_avg:198.16ms
+step:3164/4150 train_time:627015ms step_avg:198.17ms
+step:3165/4150 train_time:627250ms step_avg:198.18ms
+step:3166/4150 train_time:627484ms step_avg:198.19ms
+step:3167/4150 train_time:627718ms step_avg:198.21ms
+step:3168/4150 train_time:627957ms step_avg:198.22ms
+step:3169/4150 train_time:628190ms step_avg:198.23ms
+step:3170/4150 train_time:628427ms step_avg:198.24ms
+step:3171/4150 train_time:628660ms step_avg:198.25ms
+step:3172/4150 train_time:628898ms step_avg:198.27ms
+step:3173/4150 train_time:629136ms step_avg:198.28ms
+step:3174/4150 train_time:629375ms step_avg:198.29ms
+step:3175/4150 train_time:629610ms step_avg:198.30ms
+step:3176/4150 train_time:629848ms step_avg:198.31ms
+step:3177/4150 train_time:630081ms step_avg:198.33ms
+step:3178/4150 train_time:630319ms step_avg:198.34ms
+step:3179/4150 train_time:630555ms step_avg:198.35ms
+step:3180/4150 train_time:630793ms step_avg:198.36ms
+step:3181/4150 train_time:631025ms step_avg:198.37ms
+step:3182/4150 train_time:631262ms step_avg:198.39ms
+step:3183/4150 train_time:631498ms step_avg:198.40ms
+step:3184/4150 train_time:631735ms step_avg:198.41ms
+step:3185/4150 train_time:631968ms step_avg:198.42ms
+step:3186/4150 train_time:632205ms step_avg:198.43ms
+step:3187/4150 train_time:632439ms step_avg:198.44ms
+step:3188/4150 train_time:632676ms step_avg:198.46ms
+step:3189/4150 train_time:632912ms step_avg:198.47ms
+step:3190/4150 train_time:633149ms step_avg:198.48ms
+step:3191/4150 train_time:633385ms step_avg:198.49ms
+step:3192/4150 train_time:633618ms step_avg:198.50ms
+step:3193/4150 train_time:633853ms step_avg:198.51ms
+step:3194/4150 train_time:634087ms step_avg:198.52ms
+step:3195/4150 train_time:634323ms step_avg:198.54ms
+step:3196/4150 train_time:634557ms step_avg:198.55ms
+step:3197/4150 train_time:634791ms step_avg:198.56ms
+step:3198/4150 train_time:635029ms step_avg:198.57ms
+step:3199/4150 train_time:635265ms step_avg:198.58ms
+step:3200/4150 train_time:635500ms step_avg:198.59ms
+step:3201/4150 train_time:635737ms step_avg:198.61ms
+step:3202/4150 train_time:635975ms step_avg:198.62ms
+step:3203/4150 train_time:636208ms step_avg:198.63ms
+step:3204/4150 train_time:636445ms step_avg:198.64ms
+step:3205/4150 train_time:636681ms step_avg:198.65ms
+step:3206/4150 train_time:636921ms step_avg:198.67ms
+step:3207/4150 train_time:637154ms step_avg:198.68ms
+step:3208/4150 train_time:637393ms step_avg:198.69ms
+step:3209/4150 train_time:637628ms step_avg:198.70ms
+step:3210/4150 train_time:637865ms step_avg:198.71ms
+step:3211/4150 train_time:638099ms step_avg:198.72ms
+step:3212/4150 train_time:638337ms step_avg:198.74ms
+step:3213/4150 train_time:638569ms step_avg:198.75ms
+step:3214/4150 train_time:638807ms step_avg:198.76ms
+step:3215/4150 train_time:639042ms step_avg:198.77ms
+step:3216/4150 train_time:639276ms step_avg:198.78ms
+step:3217/4150 train_time:639514ms step_avg:198.79ms
+step:3218/4150 train_time:639749ms step_avg:198.80ms
+step:3219/4150 train_time:639985ms step_avg:198.81ms
+step:3220/4150 train_time:640221ms step_avg:198.83ms
+step:3221/4150 train_time:640453ms step_avg:198.84ms
+step:3222/4150 train_time:640689ms step_avg:198.85ms
+step:3223/4150 train_time:640923ms step_avg:198.86ms
+step:3224/4150 train_time:641160ms step_avg:198.87ms
+step:3225/4150 train_time:641395ms step_avg:198.88ms
+step:3226/4150 train_time:641633ms step_avg:198.89ms
+step:3227/4150 train_time:641868ms step_avg:198.91ms
+step:3228/4150 train_time:642105ms step_avg:198.92ms
+step:3229/4150 train_time:642338ms step_avg:198.93ms
+step:3230/4150 train_time:642574ms step_avg:198.94ms
+step:3231/4150 train_time:642808ms step_avg:198.95ms
+step:3232/4150 train_time:643045ms step_avg:198.96ms
+step:3233/4150 train_time:643279ms step_avg:198.97ms
+step:3234/4150 train_time:643516ms step_avg:198.98ms
+step:3235/4150 train_time:643749ms step_avg:199.00ms
+step:3236/4150 train_time:643986ms step_avg:199.01ms
+step:3237/4150 train_time:644219ms step_avg:199.02ms
+step:3238/4150 train_time:644458ms step_avg:199.03ms
+step:3239/4150 train_time:644697ms step_avg:199.04ms
+step:3240/4150 train_time:644934ms step_avg:199.05ms
+step:3241/4150 train_time:645170ms step_avg:199.07ms
+step:3242/4150 train_time:645410ms step_avg:199.08ms
+step:3243/4150 train_time:645642ms step_avg:199.09ms
+step:3244/4150 train_time:645880ms step_avg:199.10ms
+step:3245/4150 train_time:646115ms step_avg:199.11ms
+step:3246/4150 train_time:646352ms step_avg:199.12ms
+step:3247/4150 train_time:646588ms step_avg:199.13ms
+step:3248/4150 train_time:646828ms step_avg:199.15ms
+step:3249/4150 train_time:647063ms step_avg:199.16ms
+step:3250/4150 train_time:647299ms step_avg:199.17ms
+step:3250/4150 val_loss:3.0102 train_time:647515ms step_avg:199.24ms
+step:3251/4150 train_time:647538ms step_avg:199.18ms
+step:3252/4150 train_time:647777ms step_avg:199.19ms
+step:3253/4150 train_time:648012ms step_avg:199.20ms
+step:3254/4150 train_time:648247ms step_avg:199.22ms
+step:3255/4150 train_time:648479ms step_avg:199.23ms
+step:3256/4150 train_time:648717ms step_avg:199.24ms
+step:3257/4150 train_time:648956ms step_avg:199.25ms
+step:3258/4150 train_time:649190ms step_avg:199.26ms
+step:3259/4150 train_time:649422ms step_avg:199.27ms
+step:3260/4150 train_time:649659ms step_avg:199.28ms
+step:3261/4150 train_time:649895ms step_avg:199.29ms
+step:3262/4150 train_time:650132ms step_avg:199.30ms
+step:3263/4150 train_time:650365ms step_avg:199.32ms
+step:3264/4150 train_time:650604ms step_avg:199.33ms
+step:3265/4150 train_time:650839ms step_avg:199.34ms
+step:3266/4150 train_time:651076ms step_avg:199.35ms
+step:3267/4150 train_time:651312ms step_avg:199.36ms
+step:3268/4150 train_time:651548ms step_avg:199.37ms
+step:3269/4150 train_time:651779ms step_avg:199.38ms
+step:3270/4150 train_time:652018ms step_avg:199.39ms
+step:3271/4150 train_time:652255ms step_avg:199.41ms
+step:3272/4150 train_time:652492ms step_avg:199.42ms
+step:3273/4150 train_time:652727ms step_avg:199.43ms
+step:3274/4150 train_time:652966ms step_avg:199.44ms
+step:3275/4150 train_time:653201ms step_avg:199.45ms
+step:3276/4150 train_time:653441ms step_avg:199.46ms
+step:3277/4150 train_time:653674ms step_avg:199.47ms
+step:3278/4150 train_time:653910ms step_avg:199.48ms
+step:3279/4150 train_time:654145ms step_avg:199.50ms
+step:3280/4150 train_time:654383ms step_avg:199.51ms
+step:3281/4150 train_time:654616ms step_avg:199.52ms
+step:3282/4150 train_time:654853ms step_avg:199.53ms
+step:3283/4150 train_time:655086ms step_avg:199.54ms
+step:3284/4150 train_time:655326ms step_avg:199.55ms
+step:3285/4150 train_time:655558ms step_avg:199.56ms
+step:3286/4150 train_time:655796ms step_avg:199.57ms
+step:3287/4150 train_time:656029ms step_avg:199.58ms
+step:3288/4150 train_time:656267ms step_avg:199.59ms
+step:3289/4150 train_time:656501ms step_avg:199.61ms
+step:3290/4150 train_time:656738ms step_avg:199.62ms
+step:3291/4150 train_time:656976ms step_avg:199.63ms
+step:3292/4150 train_time:657214ms step_avg:199.64ms
+step:3293/4150 train_time:657450ms step_avg:199.65ms
+step:3294/4150 train_time:657688ms step_avg:199.66ms
+step:3295/4150 train_time:657927ms step_avg:199.67ms
+step:3296/4150 train_time:658161ms step_avg:199.68ms
+step:3297/4150 train_time:658397ms step_avg:199.70ms
+step:3298/4150 train_time:658635ms step_avg:199.71ms
+step:3299/4150 train_time:658869ms step_avg:199.72ms
+step:3300/4150 train_time:659107ms step_avg:199.73ms
+step:3301/4150 train_time:659339ms step_avg:199.74ms
+step:3302/4150 train_time:659575ms step_avg:199.75ms
+step:3303/4150 train_time:659807ms step_avg:199.76ms
+step:3304/4150 train_time:660046ms step_avg:199.77ms
+step:3305/4150 train_time:660279ms step_avg:199.78ms
+step:3306/4150 train_time:660516ms step_avg:199.79ms
+step:3307/4150 train_time:660750ms step_avg:199.80ms
+step:3308/4150 train_time:660987ms step_avg:199.81ms
+step:3309/4150 train_time:661222ms step_avg:199.83ms
+step:3310/4150 train_time:661457ms step_avg:199.84ms
+step:3311/4150 train_time:661691ms step_avg:199.85ms
+step:3312/4150 train_time:661927ms step_avg:199.86ms
+step:3313/4150 train_time:662159ms step_avg:199.87ms
+step:3314/4150 train_time:662397ms step_avg:199.88ms
+step:3315/4150 train_time:662632ms step_avg:199.89ms
+step:3316/4150 train_time:662869ms step_avg:199.90ms
+step:3317/4150 train_time:663108ms step_avg:199.91ms
+step:3318/4150 train_time:663347ms step_avg:199.92ms
+step:3319/4150 train_time:663585ms step_avg:199.94ms
+step:3320/4150 train_time:663824ms step_avg:199.95ms
+step:3321/4150 train_time:664059ms step_avg:199.96ms
+step:3322/4150 train_time:664296ms step_avg:199.97ms
+step:3323/4150 train_time:664530ms step_avg:199.98ms
+step:3324/4150 train_time:664768ms step_avg:199.99ms
+step:3325/4150 train_time:665003ms step_avg:200.00ms
+step:3326/4150 train_time:665239ms step_avg:200.01ms
+step:3327/4150 train_time:665474ms step_avg:200.02ms
+step:3328/4150 train_time:665712ms step_avg:200.03ms
+step:3329/4150 train_time:665949ms step_avg:200.04ms
+step:3330/4150 train_time:666188ms step_avg:200.06ms
+step:3331/4150 train_time:666421ms step_avg:200.07ms
+step:3332/4150 train_time:666663ms step_avg:200.08ms
+step:3333/4150 train_time:666899ms step_avg:200.09ms
+step:3334/4150 train_time:667133ms step_avg:200.10ms
+step:3335/4150 train_time:667368ms step_avg:200.11ms
+step:3336/4150 train_time:667607ms step_avg:200.12ms
+step:3337/4150 train_time:667841ms step_avg:200.13ms
+step:3338/4150 train_time:668078ms step_avg:200.14ms
+step:3339/4150 train_time:668312ms step_avg:200.15ms
+step:3340/4150 train_time:668547ms step_avg:200.16ms
+step:3341/4150 train_time:668785ms step_avg:200.18ms
+step:3342/4150 train_time:669024ms step_avg:200.19ms
+step:3343/4150 train_time:669257ms step_avg:200.20ms
+step:3344/4150 train_time:669493ms step_avg:200.21ms
+step:3345/4150 train_time:669729ms step_avg:200.22ms
+step:3346/4150 train_time:669971ms step_avg:200.23ms
+step:3347/4150 train_time:670204ms step_avg:200.24ms
+step:3348/4150 train_time:670441ms step_avg:200.25ms
+step:3349/4150 train_time:670674ms step_avg:200.26ms
+step:3350/4150 train_time:670914ms step_avg:200.27ms
+step:3351/4150 train_time:671147ms step_avg:200.28ms
+step:3352/4150 train_time:671385ms step_avg:200.29ms
+step:3353/4150 train_time:671617ms step_avg:200.30ms
+step:3354/4150 train_time:671854ms step_avg:200.31ms
+step:3355/4150 train_time:672087ms step_avg:200.32ms
+step:3356/4150 train_time:672328ms step_avg:200.34ms
+step:3357/4150 train_time:672561ms step_avg:200.35ms
+step:3358/4150 train_time:672796ms step_avg:200.36ms
+step:3359/4150 train_time:673033ms step_avg:200.37ms
+step:3360/4150 train_time:673270ms step_avg:200.38ms
+step:3361/4150 train_time:673506ms step_avg:200.39ms
+step:3362/4150 train_time:673745ms step_avg:200.40ms
+step:3363/4150 train_time:673979ms step_avg:200.41ms
+step:3364/4150 train_time:674217ms step_avg:200.42ms
+step:3365/4150 train_time:674454ms step_avg:200.43ms
+step:3366/4150 train_time:674694ms step_avg:200.44ms
+step:3367/4150 train_time:674925ms step_avg:200.45ms
+step:3368/4150 train_time:675162ms step_avg:200.46ms
+step:3369/4150 train_time:675398ms step_avg:200.47ms
+step:3370/4150 train_time:675636ms step_avg:200.49ms
+step:3371/4150 train_time:675869ms step_avg:200.50ms
+step:3372/4150 train_time:676107ms step_avg:200.51ms
+step:3373/4150 train_time:676341ms step_avg:200.52ms
+step:3374/4150 train_time:676578ms step_avg:200.53ms
+step:3375/4150 train_time:676815ms step_avg:200.54ms
+step:3376/4150 train_time:677054ms step_avg:200.55ms
+step:3377/4150 train_time:677289ms step_avg:200.56ms
+step:3378/4150 train_time:677529ms step_avg:200.57ms
+step:3379/4150 train_time:677762ms step_avg:200.58ms
+step:3380/4150 train_time:677997ms step_avg:200.59ms
+step:3381/4150 train_time:678232ms step_avg:200.60ms
+step:3382/4150 train_time:678471ms step_avg:200.61ms
+step:3383/4150 train_time:678704ms step_avg:200.62ms
+step:3384/4150 train_time:678939ms step_avg:200.63ms
+step:3385/4150 train_time:679177ms step_avg:200.64ms
+step:3386/4150 train_time:679414ms step_avg:200.65ms
+step:3387/4150 train_time:679649ms step_avg:200.66ms
+step:3388/4150 train_time:679890ms step_avg:200.68ms
+step:3389/4150 train_time:680124ms step_avg:200.69ms
+step:3390/4150 train_time:680360ms step_avg:200.70ms
+step:3391/4150 train_time:680596ms step_avg:200.71ms
+step:3392/4150 train_time:680836ms step_avg:200.72ms
+step:3393/4150 train_time:681070ms step_avg:200.73ms
+step:3394/4150 train_time:681308ms step_avg:200.74ms
+step:3395/4150 train_time:681543ms step_avg:200.75ms
+step:3396/4150 train_time:681781ms step_avg:200.76ms
+step:3397/4150 train_time:682015ms step_avg:200.77ms
+step:3398/4150 train_time:682253ms step_avg:200.78ms
+step:3399/4150 train_time:682485ms step_avg:200.79ms
+step:3400/4150 train_time:682728ms step_avg:200.80ms
+step:3401/4150 train_time:682962ms step_avg:200.81ms
+step:3402/4150 train_time:683200ms step_avg:200.82ms
+step:3403/4150 train_time:683433ms step_avg:200.83ms
+step:3404/4150 train_time:683672ms step_avg:200.84ms
+step:3405/4150 train_time:683905ms step_avg:200.85ms
+step:3406/4150 train_time:684142ms step_avg:200.86ms
+step:3407/4150 train_time:684375ms step_avg:200.87ms
+step:3408/4150 train_time:684615ms step_avg:200.88ms
+step:3409/4150 train_time:684850ms step_avg:200.89ms
+step:3410/4150 train_time:685091ms step_avg:200.91ms
+step:3411/4150 train_time:685322ms step_avg:200.92ms
+step:3412/4150 train_time:685563ms step_avg:200.93ms
+step:3413/4150 train_time:685799ms step_avg:200.94ms
+step:3414/4150 train_time:686038ms step_avg:200.95ms
+step:3415/4150 train_time:686271ms step_avg:200.96ms
+step:3416/4150 train_time:686510ms step_avg:200.97ms
+step:3417/4150 train_time:686744ms step_avg:200.98ms
+step:3418/4150 train_time:686982ms step_avg:200.99ms
+step:3419/4150 train_time:687217ms step_avg:201.00ms
+step:3420/4150 train_time:687453ms step_avg:201.01ms
+step:3421/4150 train_time:687691ms step_avg:201.02ms
+step:3422/4150 train_time:687927ms step_avg:201.03ms
+step:3423/4150 train_time:688161ms step_avg:201.04ms
+step:3424/4150 train_time:688397ms step_avg:201.05ms
+step:3425/4150 train_time:688630ms step_avg:201.06ms
+step:3426/4150 train_time:688867ms step_avg:201.07ms
+step:3427/4150 train_time:689102ms step_avg:201.08ms
+step:3428/4150 train_time:689337ms step_avg:201.09ms
+step:3429/4150 train_time:689573ms step_avg:201.10ms
+step:3430/4150 train_time:689814ms step_avg:201.11ms
+step:3431/4150 train_time:690052ms step_avg:201.12ms
+step:3432/4150 train_time:690286ms step_avg:201.13ms
+step:3433/4150 train_time:690519ms step_avg:201.14ms
+step:3434/4150 train_time:690756ms step_avg:201.15ms
+step:3435/4150 train_time:690992ms step_avg:201.16ms
+step:3436/4150 train_time:691229ms step_avg:201.17ms
+step:3437/4150 train_time:691465ms step_avg:201.18ms
+step:3438/4150 train_time:691705ms step_avg:201.19ms
+step:3439/4150 train_time:691940ms step_avg:201.20ms
+step:3440/4150 train_time:692182ms step_avg:201.22ms
+step:3441/4150 train_time:692418ms step_avg:201.23ms
+step:3442/4150 train_time:692654ms step_avg:201.24ms
+step:3443/4150 train_time:692889ms step_avg:201.25ms
+step:3444/4150 train_time:693124ms step_avg:201.26ms
+step:3445/4150 train_time:693359ms step_avg:201.27ms
+step:3446/4150 train_time:693594ms step_avg:201.28ms
+step:3447/4150 train_time:693830ms step_avg:201.29ms
+step:3448/4150 train_time:694067ms step_avg:201.30ms
+step:3449/4150 train_time:694300ms step_avg:201.30ms
+step:3450/4150 train_time:694536ms step_avg:201.31ms
+step:3451/4150 train_time:694769ms step_avg:201.32ms
+step:3452/4150 train_time:695009ms step_avg:201.34ms
+step:3453/4150 train_time:695246ms step_avg:201.35ms
+step:3454/4150 train_time:695485ms step_avg:201.36ms
+step:3455/4150 train_time:695721ms step_avg:201.37ms
+step:3456/4150 train_time:695956ms step_avg:201.38ms
+step:3457/4150 train_time:696191ms step_avg:201.39ms
+step:3458/4150 train_time:696428ms step_avg:201.40ms
+step:3459/4150 train_time:696666ms step_avg:201.41ms
+step:3460/4150 train_time:696905ms step_avg:201.42ms
+step:3461/4150 train_time:697136ms step_avg:201.43ms
+step:3462/4150 train_time:697372ms step_avg:201.44ms
+step:3463/4150 train_time:697608ms step_avg:201.45ms
+step:3464/4150 train_time:697846ms step_avg:201.46ms
+step:3465/4150 train_time:698080ms step_avg:201.47ms
+step:3466/4150 train_time:698317ms step_avg:201.48ms
+step:3467/4150 train_time:698552ms step_avg:201.49ms
+step:3468/4150 train_time:698791ms step_avg:201.50ms
+step:3469/4150 train_time:699023ms step_avg:201.51ms
+step:3470/4150 train_time:699258ms step_avg:201.52ms
+step:3471/4150 train_time:699492ms step_avg:201.52ms
+step:3472/4150 train_time:699730ms step_avg:201.54ms
+step:3473/4150 train_time:699964ms step_avg:201.54ms
+step:3474/4150 train_time:700202ms step_avg:201.55ms
+step:3475/4150 train_time:700435ms step_avg:201.56ms
+step:3476/4150 train_time:700674ms step_avg:201.57ms
+step:3477/4150 train_time:700910ms step_avg:201.58ms
+step:3478/4150 train_time:701148ms step_avg:201.60ms
+step:3479/4150 train_time:701381ms step_avg:201.60ms
+step:3480/4150 train_time:701622ms step_avg:201.62ms
+step:3481/4150 train_time:701856ms step_avg:201.62ms
+step:3482/4150 train_time:702092ms step_avg:201.63ms
+step:3483/4150 train_time:702327ms step_avg:201.64ms
+step:3484/4150 train_time:702562ms step_avg:201.65ms
+step:3485/4150 train_time:702799ms step_avg:201.66ms
+step:3486/4150 train_time:703037ms step_avg:201.67ms
+step:3487/4150 train_time:703272ms step_avg:201.68ms
+step:3488/4150 train_time:703509ms step_avg:201.69ms
+step:3489/4150 train_time:703747ms step_avg:201.70ms
+step:3490/4150 train_time:703984ms step_avg:201.71ms
+step:3491/4150 train_time:704220ms step_avg:201.72ms
+step:3492/4150 train_time:704455ms step_avg:201.73ms
+step:3493/4150 train_time:704690ms step_avg:201.74ms
+step:3494/4150 train_time:704927ms step_avg:201.75ms
+step:3495/4150 train_time:705163ms step_avg:201.76ms
+step:3496/4150 train_time:705401ms step_avg:201.77ms
+step:3497/4150 train_time:705634ms step_avg:201.78ms
+step:3498/4150 train_time:705872ms step_avg:201.79ms
+step:3499/4150 train_time:706106ms step_avg:201.80ms
+step:3500/4150 train_time:706344ms step_avg:201.81ms
+step:3500/4150 val_loss:2.9790 train_time:706559ms step_avg:201.87ms
+step:3501/4150 train_time:706585ms step_avg:201.82ms
+step:3502/4150 train_time:706823ms step_avg:201.83ms
+step:3503/4150 train_time:707061ms step_avg:201.84ms
+step:3504/4150 train_time:707294ms step_avg:201.85ms
+step:3505/4150 train_time:707522ms step_avg:201.86ms
+step:3506/4150 train_time:707764ms step_avg:201.87ms
+step:3507/4150 train_time:708002ms step_avg:201.88ms
+step:3508/4150 train_time:708240ms step_avg:201.89ms
+step:3509/4150 train_time:708471ms step_avg:201.90ms
+step:3510/4150 train_time:708710ms step_avg:201.91ms
+step:3511/4150 train_time:708948ms step_avg:201.92ms
+step:3512/4150 train_time:709185ms step_avg:201.93ms
+step:3513/4150 train_time:709420ms step_avg:201.94ms
+step:3514/4150 train_time:709655ms step_avg:201.95ms
+step:3515/4150 train_time:709891ms step_avg:201.96ms
+step:3516/4150 train_time:710128ms step_avg:201.97ms
+step:3517/4150 train_time:710363ms step_avg:201.98ms
+step:3518/4150 train_time:710600ms step_avg:201.99ms
+step:3519/4150 train_time:710835ms step_avg:202.00ms
+step:3520/4150 train_time:711073ms step_avg:202.01ms
+step:3521/4150 train_time:711306ms step_avg:202.02ms
+step:3522/4150 train_time:711543ms step_avg:202.03ms
+step:3523/4150 train_time:711784ms step_avg:202.04ms
+step:3524/4150 train_time:712021ms step_avg:202.05ms
+step:3525/4150 train_time:712252ms step_avg:202.06ms
+step:3526/4150 train_time:712487ms step_avg:202.07ms
+step:3527/4150 train_time:712722ms step_avg:202.08ms
+step:3528/4150 train_time:712960ms step_avg:202.09ms
+step:3529/4150 train_time:713195ms step_avg:202.10ms
+step:3530/4150 train_time:713430ms step_avg:202.10ms
+step:3531/4150 train_time:713663ms step_avg:202.11ms
+step:3532/4150 train_time:713903ms step_avg:202.12ms
+step:3533/4150 train_time:714140ms step_avg:202.13ms
+step:3534/4150 train_time:714381ms step_avg:202.15ms
+step:3535/4150 train_time:714614ms step_avg:202.15ms
+step:3536/4150 train_time:714853ms step_avg:202.16ms
+step:3537/4150 train_time:715089ms step_avg:202.17ms
+step:3538/4150 train_time:715326ms step_avg:202.18ms
+step:3539/4150 train_time:715560ms step_avg:202.19ms
+step:3540/4150 train_time:715800ms step_avg:202.20ms
+step:3541/4150 train_time:716034ms step_avg:202.21ms
+step:3542/4150 train_time:716270ms step_avg:202.22ms
+step:3543/4150 train_time:716507ms step_avg:202.23ms
+step:3544/4150 train_time:716744ms step_avg:202.24ms
+step:3545/4150 train_time:716977ms step_avg:202.25ms
+step:3546/4150 train_time:717216ms step_avg:202.26ms
+step:3547/4150 train_time:717449ms step_avg:202.27ms
+step:3548/4150 train_time:717689ms step_avg:202.28ms
+step:3549/4150 train_time:717924ms step_avg:202.29ms
+step:3550/4150 train_time:718159ms step_avg:202.30ms
+step:3551/4150 train_time:718394ms step_avg:202.31ms
+step:3552/4150 train_time:718630ms step_avg:202.32ms
+step:3553/4150 train_time:718866ms step_avg:202.33ms
+step:3554/4150 train_time:719104ms step_avg:202.34ms
+step:3555/4150 train_time:719342ms step_avg:202.35ms
+step:3556/4150 train_time:719578ms step_avg:202.36ms
+step:3557/4150 train_time:719811ms step_avg:202.36ms
+step:3558/4150 train_time:720049ms step_avg:202.37ms
+step:3559/4150 train_time:720286ms step_avg:202.38ms
+step:3560/4150 train_time:720522ms step_avg:202.39ms
+step:3561/4150 train_time:720754ms step_avg:202.40ms
+step:3562/4150 train_time:720993ms step_avg:202.41ms
+step:3563/4150 train_time:721229ms step_avg:202.42ms
+step:3564/4150 train_time:721464ms step_avg:202.43ms
+step:3565/4150 train_time:721699ms step_avg:202.44ms
+step:3566/4150 train_time:721937ms step_avg:202.45ms
+step:3567/4150 train_time:722174ms step_avg:202.46ms
+step:3568/4150 train_time:722410ms step_avg:202.47ms
+step:3569/4150 train_time:722645ms step_avg:202.48ms
+step:3570/4150 train_time:722882ms step_avg:202.49ms
+step:3571/4150 train_time:723120ms step_avg:202.50ms
+step:3572/4150 train_time:723355ms step_avg:202.51ms
+step:3573/4150 train_time:723591ms step_avg:202.52ms
+step:3574/4150 train_time:723827ms step_avg:202.53ms
+step:3575/4150 train_time:724062ms step_avg:202.53ms
+step:3576/4150 train_time:724298ms step_avg:202.54ms
+step:3577/4150 train_time:724532ms step_avg:202.55ms
+step:3578/4150 train_time:724767ms step_avg:202.56ms
+step:3579/4150 train_time:725001ms step_avg:202.57ms
+step:3580/4150 train_time:725242ms step_avg:202.58ms
+step:3581/4150 train_time:725482ms step_avg:202.59ms
+step:3582/4150 train_time:725718ms step_avg:202.60ms
+step:3583/4150 train_time:725952ms step_avg:202.61ms
+step:3584/4150 train_time:726190ms step_avg:202.62ms
+step:3585/4150 train_time:726426ms step_avg:202.63ms
+step:3586/4150 train_time:726662ms step_avg:202.64ms
+step:3587/4150 train_time:726894ms step_avg:202.65ms
+step:3588/4150 train_time:727132ms step_avg:202.66ms
+step:3589/4150 train_time:727370ms step_avg:202.67ms
+step:3590/4150 train_time:727607ms step_avg:202.68ms
+step:3591/4150 train_time:727842ms step_avg:202.69ms
+step:3592/4150 train_time:728083ms step_avg:202.70ms
+step:3593/4150 train_time:728318ms step_avg:202.70ms
+step:3594/4150 train_time:728556ms step_avg:202.71ms
+step:3595/4150 train_time:728791ms step_avg:202.72ms
+step:3596/4150 train_time:729027ms step_avg:202.73ms
+step:3597/4150 train_time:729262ms step_avg:202.74ms
+step:3598/4150 train_time:729502ms step_avg:202.75ms
+step:3599/4150 train_time:729733ms step_avg:202.76ms
+step:3600/4150 train_time:729968ms step_avg:202.77ms
+step:3601/4150 train_time:730202ms step_avg:202.78ms
+step:3602/4150 train_time:730443ms step_avg:202.79ms
+step:3603/4150 train_time:730679ms step_avg:202.80ms
+step:3604/4150 train_time:730915ms step_avg:202.81ms
+step:3605/4150 train_time:731147ms step_avg:202.81ms
+step:3606/4150 train_time:731388ms step_avg:202.83ms
+step:3607/4150 train_time:731623ms step_avg:202.83ms
+step:3608/4150 train_time:731863ms step_avg:202.84ms
+step:3609/4150 train_time:732095ms step_avg:202.85ms
+step:3610/4150 train_time:732335ms step_avg:202.86ms
+step:3611/4150 train_time:732569ms step_avg:202.87ms
+step:3612/4150 train_time:732807ms step_avg:202.88ms
+step:3613/4150 train_time:733041ms step_avg:202.89ms
+step:3614/4150 train_time:733279ms step_avg:202.90ms
+step:3615/4150 train_time:733510ms step_avg:202.91ms
+step:3616/4150 train_time:733749ms step_avg:202.92ms
+step:3617/4150 train_time:733985ms step_avg:202.93ms
+step:3618/4150 train_time:734221ms step_avg:202.94ms
+step:3619/4150 train_time:734458ms step_avg:202.95ms
+step:3620/4150 train_time:734695ms step_avg:202.95ms
+step:3621/4150 train_time:734932ms step_avg:202.96ms
+step:3622/4150 train_time:735169ms step_avg:202.97ms
+step:3623/4150 train_time:735403ms step_avg:202.98ms
+step:3624/4150 train_time:735640ms step_avg:202.99ms
+step:3625/4150 train_time:735871ms step_avg:203.00ms
+step:3626/4150 train_time:736108ms step_avg:203.01ms
+step:3627/4150 train_time:736342ms step_avg:203.02ms
+step:3628/4150 train_time:736578ms step_avg:203.03ms
+step:3629/4150 train_time:736811ms step_avg:203.03ms
+step:3630/4150 train_time:737049ms step_avg:203.04ms
+step:3631/4150 train_time:737283ms step_avg:203.05ms
+step:3632/4150 train_time:737521ms step_avg:203.06ms
+step:3633/4150 train_time:737752ms step_avg:203.07ms
+step:3634/4150 train_time:737991ms step_avg:203.08ms
+step:3635/4150 train_time:738222ms step_avg:203.09ms
+step:3636/4150 train_time:738459ms step_avg:203.10ms
+step:3637/4150 train_time:738694ms step_avg:203.11ms
+step:3638/4150 train_time:738930ms step_avg:203.11ms
+step:3639/4150 train_time:739162ms step_avg:203.12ms
+step:3640/4150 train_time:739400ms step_avg:203.13ms
+step:3641/4150 train_time:739635ms step_avg:203.14ms
+step:3642/4150 train_time:739876ms step_avg:203.15ms
+step:3643/4150 train_time:740107ms step_avg:203.16ms
+step:3644/4150 train_time:740345ms step_avg:203.17ms
+step:3645/4150 train_time:740580ms step_avg:203.18ms
+step:3646/4150 train_time:740820ms step_avg:203.19ms
+step:3647/4150 train_time:741054ms step_avg:203.20ms
+step:3648/4150 train_time:741289ms step_avg:203.20ms
+step:3649/4150 train_time:741525ms step_avg:203.21ms
+step:3650/4150 train_time:741762ms step_avg:203.22ms
+step:3651/4150 train_time:741998ms step_avg:203.23ms
+step:3652/4150 train_time:742235ms step_avg:203.24ms
+step:3653/4150 train_time:742469ms step_avg:203.25ms
+step:3654/4150 train_time:742707ms step_avg:203.26ms
+step:3655/4150 train_time:742942ms step_avg:203.27ms
+step:3656/4150 train_time:743180ms step_avg:203.28ms
+step:3657/4150 train_time:743417ms step_avg:203.29ms
+step:3658/4150 train_time:743655ms step_avg:203.30ms
+step:3659/4150 train_time:743887ms step_avg:203.30ms
+step:3660/4150 train_time:744127ms step_avg:203.31ms
+step:3661/4150 train_time:744359ms step_avg:203.32ms
+step:3662/4150 train_time:744598ms step_avg:203.33ms
+step:3663/4150 train_time:744834ms step_avg:203.34ms
+step:3664/4150 train_time:745072ms step_avg:203.35ms
+step:3665/4150 train_time:745305ms step_avg:203.36ms
+step:3666/4150 train_time:745543ms step_avg:203.37ms
+step:3667/4150 train_time:745777ms step_avg:203.38ms
+step:3668/4150 train_time:746017ms step_avg:203.39ms
+step:3669/4150 train_time:746252ms step_avg:203.39ms
+step:3670/4150 train_time:746490ms step_avg:203.40ms
+step:3671/4150 train_time:746724ms step_avg:203.41ms
+step:3672/4150 train_time:746962ms step_avg:203.42ms
+step:3673/4150 train_time:747195ms step_avg:203.43ms
+step:3674/4150 train_time:747434ms step_avg:203.44ms
+step:3675/4150 train_time:747670ms step_avg:203.45ms
+step:3676/4150 train_time:747909ms step_avg:203.46ms
+step:3677/4150 train_time:748146ms step_avg:203.47ms
+step:3678/4150 train_time:748385ms step_avg:203.48ms
+step:3679/4150 train_time:748622ms step_avg:203.49ms
+step:3680/4150 train_time:748857ms step_avg:203.49ms
+step:3681/4150 train_time:749091ms step_avg:203.50ms
+step:3682/4150 train_time:749329ms step_avg:203.51ms
+step:3683/4150 train_time:749564ms step_avg:203.52ms
+step:3684/4150 train_time:749803ms step_avg:203.53ms
+step:3685/4150 train_time:750037ms step_avg:203.54ms
+step:3686/4150 train_time:750274ms step_avg:203.55ms
+step:3687/4150 train_time:750506ms step_avg:203.55ms
+step:3688/4150 train_time:750744ms step_avg:203.56ms
+step:3689/4150 train_time:750976ms step_avg:203.57ms
+step:3690/4150 train_time:751214ms step_avg:203.58ms
+step:3691/4150 train_time:751448ms step_avg:203.59ms
+step:3692/4150 train_time:751684ms step_avg:203.60ms
+step:3693/4150 train_time:751919ms step_avg:203.61ms
+step:3694/4150 train_time:752156ms step_avg:203.62ms
+step:3695/4150 train_time:752390ms step_avg:203.62ms
+step:3696/4150 train_time:752626ms step_avg:203.63ms
+step:3697/4150 train_time:752860ms step_avg:203.64ms
+step:3698/4150 train_time:753101ms step_avg:203.65ms
+step:3699/4150 train_time:753334ms step_avg:203.66ms
+step:3700/4150 train_time:753571ms step_avg:203.67ms
+step:3701/4150 train_time:753808ms step_avg:203.68ms
+step:3702/4150 train_time:754045ms step_avg:203.69ms
+step:3703/4150 train_time:754280ms step_avg:203.69ms
+step:3704/4150 train_time:754519ms step_avg:203.70ms
+step:3705/4150 train_time:754753ms step_avg:203.71ms
+step:3706/4150 train_time:754990ms step_avg:203.72ms
+step:3707/4150 train_time:755222ms step_avg:203.73ms
+step:3708/4150 train_time:755460ms step_avg:203.74ms
+step:3709/4150 train_time:755694ms step_avg:203.75ms
+step:3710/4150 train_time:755931ms step_avg:203.75ms
+step:3711/4150 train_time:756165ms step_avg:203.76ms
+step:3712/4150 train_time:756407ms step_avg:203.77ms
+step:3713/4150 train_time:756639ms step_avg:203.78ms
+step:3714/4150 train_time:756875ms step_avg:203.79ms
+step:3715/4150 train_time:757112ms step_avg:203.80ms
+step:3716/4150 train_time:757350ms step_avg:203.81ms
+step:3717/4150 train_time:757586ms step_avg:203.82ms
+step:3718/4150 train_time:757823ms step_avg:203.83ms
+step:3719/4150 train_time:758058ms step_avg:203.83ms
+step:3720/4150 train_time:758298ms step_avg:203.84ms
+step:3721/4150 train_time:758531ms step_avg:203.85ms
+step:3722/4150 train_time:758767ms step_avg:203.86ms
+step:3723/4150 train_time:759003ms step_avg:203.87ms
+step:3724/4150 train_time:759241ms step_avg:203.88ms
+step:3725/4150 train_time:759479ms step_avg:203.89ms
+step:3726/4150 train_time:759713ms step_avg:203.90ms
+step:3727/4150 train_time:759949ms step_avg:203.90ms
+step:3728/4150 train_time:760187ms step_avg:203.91ms
+step:3729/4150 train_time:760426ms step_avg:203.92ms
+step:3730/4150 train_time:760661ms step_avg:203.93ms
+step:3731/4150 train_time:760898ms step_avg:203.94ms
+step:3732/4150 train_time:761137ms step_avg:203.95ms
+step:3733/4150 train_time:761371ms step_avg:203.96ms
+step:3734/4150 train_time:761610ms step_avg:203.97ms
+step:3735/4150 train_time:761845ms step_avg:203.97ms
+step:3736/4150 train_time:762081ms step_avg:203.98ms
+step:3737/4150 train_time:762313ms step_avg:203.99ms
+step:3738/4150 train_time:762556ms step_avg:204.00ms
+step:3739/4150 train_time:762791ms step_avg:204.01ms
+step:3740/4150 train_time:763029ms step_avg:204.02ms
+step:3741/4150 train_time:763264ms step_avg:204.03ms
+step:3742/4150 train_time:763501ms step_avg:204.04ms
+step:3743/4150 train_time:763734ms step_avg:204.04ms
+step:3744/4150 train_time:763974ms step_avg:204.05ms
+step:3745/4150 train_time:764209ms step_avg:204.06ms
+step:3746/4150 train_time:764447ms step_avg:204.07ms
+step:3747/4150 train_time:764682ms step_avg:204.08ms
+step:3748/4150 train_time:764919ms step_avg:204.09ms
+step:3749/4150 train_time:765156ms step_avg:204.10ms
+step:3750/4150 train_time:765395ms step_avg:204.11ms
+step:3750/4150 val_loss:2.9516 train_time:765607ms step_avg:204.16ms
+step:3751/4150 train_time:765631ms step_avg:204.11ms
+step:3752/4150 train_time:765870ms step_avg:204.12ms
+step:3753/4150 train_time:766105ms step_avg:204.13ms
+step:3754/4150 train_time:766339ms step_avg:204.14ms
+step:3755/4150 train_time:766574ms step_avg:204.15ms
+step:3756/4150 train_time:766816ms step_avg:204.16ms
+step:3757/4150 train_time:767055ms step_avg:204.17ms
+step:3758/4150 train_time:767292ms step_avg:204.18ms
+step:3759/4150 train_time:767524ms step_avg:204.18ms
+step:3760/4150 train_time:767763ms step_avg:204.19ms
+step:3761/4150 train_time:768001ms step_avg:204.20ms
+step:3762/4150 train_time:768238ms step_avg:204.21ms
+step:3763/4150 train_time:768468ms step_avg:204.22ms
+step:3764/4150 train_time:768702ms step_avg:204.22ms
+step:3765/4150 train_time:768938ms step_avg:204.23ms
+step:3766/4150 train_time:769175ms step_avg:204.24ms
+step:3767/4150 train_time:769410ms step_avg:204.25ms
+step:3768/4150 train_time:769646ms step_avg:204.26ms
+step:3769/4150 train_time:769881ms step_avg:204.27ms
+step:3770/4150 train_time:770118ms step_avg:204.28ms
+step:3771/4150 train_time:770351ms step_avg:204.28ms
+step:3772/4150 train_time:770591ms step_avg:204.29ms
+step:3773/4150 train_time:770823ms step_avg:204.30ms
+step:3774/4150 train_time:771060ms step_avg:204.31ms
+step:3775/4150 train_time:771299ms step_avg:204.32ms
+step:3776/4150 train_time:771540ms step_avg:204.33ms
+step:3777/4150 train_time:771776ms step_avg:204.34ms
+step:3778/4150 train_time:772015ms step_avg:204.34ms
+step:3779/4150 train_time:772251ms step_avg:204.35ms
+step:3780/4150 train_time:772488ms step_avg:204.36ms
+step:3781/4150 train_time:772721ms step_avg:204.37ms
+step:3782/4150 train_time:772959ms step_avg:204.38ms
+step:3783/4150 train_time:773193ms step_avg:204.39ms
+step:3784/4150 train_time:773429ms step_avg:204.39ms
+step:3785/4150 train_time:773662ms step_avg:204.40ms
+step:3786/4150 train_time:773902ms step_avg:204.41ms
+step:3787/4150 train_time:774139ms step_avg:204.42ms
+step:3788/4150 train_time:774376ms step_avg:204.43ms
+step:3789/4150 train_time:774611ms step_avg:204.44ms
+step:3790/4150 train_time:774852ms step_avg:204.45ms
+step:3791/4150 train_time:775087ms step_avg:204.45ms
+step:3792/4150 train_time:775323ms step_avg:204.46ms
+step:3793/4150 train_time:775556ms step_avg:204.47ms
+step:3794/4150 train_time:775794ms step_avg:204.48ms
+step:3795/4150 train_time:776029ms step_avg:204.49ms
+step:3796/4150 train_time:776267ms step_avg:204.50ms
+step:3797/4150 train_time:776501ms step_avg:204.50ms
+step:3798/4150 train_time:776739ms step_avg:204.51ms
+step:3799/4150 train_time:776973ms step_avg:204.52ms
+step:3800/4150 train_time:777210ms step_avg:204.53ms
+step:3801/4150 train_time:777444ms step_avg:204.54ms
+step:3802/4150 train_time:777682ms step_avg:204.55ms
+step:3803/4150 train_time:777917ms step_avg:204.55ms
+step:3804/4150 train_time:778156ms step_avg:204.56ms
+step:3805/4150 train_time:778393ms step_avg:204.57ms
+step:3806/4150 train_time:778629ms step_avg:204.58ms
+step:3807/4150 train_time:778862ms step_avg:204.59ms
+step:3808/4150 train_time:779101ms step_avg:204.60ms
+step:3809/4150 train_time:779334ms step_avg:204.60ms
+step:3810/4150 train_time:779573ms step_avg:204.61ms
+step:3811/4150 train_time:779805ms step_avg:204.62ms
+step:3812/4150 train_time:780043ms step_avg:204.63ms
+step:3813/4150 train_time:780279ms step_avg:204.64ms
+step:3814/4150 train_time:780515ms step_avg:204.64ms
+step:3815/4150 train_time:780747ms step_avg:204.65ms
+step:3816/4150 train_time:780983ms step_avg:204.66ms
+step:3817/4150 train_time:781217ms step_avg:204.67ms
+step:3818/4150 train_time:781455ms step_avg:204.68ms
+step:3819/4150 train_time:781687ms step_avg:204.68ms
+step:3820/4150 train_time:781921ms step_avg:204.69ms
+step:3821/4150 train_time:782156ms step_avg:204.70ms
+step:3822/4150 train_time:782393ms step_avg:204.71ms
+step:3823/4150 train_time:782626ms step_avg:204.72ms
+step:3824/4150 train_time:782863ms step_avg:204.72ms
+step:3825/4150 train_time:783099ms step_avg:204.73ms
+step:3826/4150 train_time:783339ms step_avg:204.74ms
+step:3827/4150 train_time:783575ms step_avg:204.75ms
+step:3828/4150 train_time:783812ms step_avg:204.76ms
+step:3829/4150 train_time:784048ms step_avg:204.77ms
+step:3830/4150 train_time:784285ms step_avg:204.77ms
+step:3831/4150 train_time:784521ms step_avg:204.78ms
+step:3832/4150 train_time:784759ms step_avg:204.79ms
+step:3833/4150 train_time:784994ms step_avg:204.80ms
+step:3834/4150 train_time:785232ms step_avg:204.81ms
+step:3835/4150 train_time:785465ms step_avg:204.81ms
+step:3836/4150 train_time:785704ms step_avg:204.82ms
+step:3837/4150 train_time:785938ms step_avg:204.83ms
+step:3838/4150 train_time:786177ms step_avg:204.84ms
+step:3839/4150 train_time:786415ms step_avg:204.85ms
+step:3840/4150 train_time:786653ms step_avg:204.86ms
+step:3841/4150 train_time:786886ms step_avg:204.86ms
+step:3842/4150 train_time:787122ms step_avg:204.87ms
+step:3843/4150 train_time:787357ms step_avg:204.88ms
+step:3844/4150 train_time:787593ms step_avg:204.89ms
+step:3845/4150 train_time:787828ms step_avg:204.90ms
+step:3846/4150 train_time:788066ms step_avg:204.91ms
+step:3847/4150 train_time:788299ms step_avg:204.91ms
+step:3848/4150 train_time:788537ms step_avg:204.92ms
+step:3849/4150 train_time:788773ms step_avg:204.93ms
+step:3850/4150 train_time:789008ms step_avg:204.94ms
+step:3851/4150 train_time:789241ms step_avg:204.94ms
+step:3852/4150 train_time:789480ms step_avg:204.95ms
+step:3853/4150 train_time:789716ms step_avg:204.96ms
+step:3854/4150 train_time:789957ms step_avg:204.97ms
+step:3855/4150 train_time:790190ms step_avg:204.98ms
+step:3856/4150 train_time:790427ms step_avg:204.99ms
+step:3857/4150 train_time:790661ms step_avg:204.99ms
+step:3858/4150 train_time:790900ms step_avg:205.00ms
+step:3859/4150 train_time:791133ms step_avg:205.01ms
+step:3860/4150 train_time:791371ms step_avg:205.02ms
+step:3861/4150 train_time:791605ms step_avg:205.03ms
+step:3862/4150 train_time:791840ms step_avg:205.03ms
+step:3863/4150 train_time:792076ms step_avg:205.04ms
+step:3864/4150 train_time:792315ms step_avg:205.05ms
+step:3865/4150 train_time:792555ms step_avg:205.06ms
+step:3866/4150 train_time:792795ms step_avg:205.07ms
+step:3867/4150 train_time:793029ms step_avg:205.08ms
+step:3868/4150 train_time:793273ms step_avg:205.09ms
+step:3869/4150 train_time:793507ms step_avg:205.09ms
+step:3870/4150 train_time:793742ms step_avg:205.10ms
+step:3871/4150 train_time:793979ms step_avg:205.11ms
+step:3872/4150 train_time:794215ms step_avg:205.12ms
+step:3873/4150 train_time:794452ms step_avg:205.13ms
+step:3874/4150 train_time:794687ms step_avg:205.13ms
+step:3875/4150 train_time:794921ms step_avg:205.14ms
+step:3876/4150 train_time:795159ms step_avg:205.15ms
+step:3877/4150 train_time:795396ms step_avg:205.16ms
+step:3878/4150 train_time:795633ms step_avg:205.17ms
+step:3879/4150 train_time:795870ms step_avg:205.17ms
+step:3880/4150 train_time:796109ms step_avg:205.18ms
+step:3881/4150 train_time:796344ms step_avg:205.19ms
+step:3882/4150 train_time:796580ms step_avg:205.20ms
+step:3883/4150 train_time:796814ms step_avg:205.21ms
+step:3884/4150 train_time:797052ms step_avg:205.21ms
+step:3885/4150 train_time:797287ms step_avg:205.22ms
+step:3886/4150 train_time:797524ms step_avg:205.23ms
+step:3887/4150 train_time:797757ms step_avg:205.24ms
+step:3888/4150 train_time:797996ms step_avg:205.25ms
+step:3889/4150 train_time:798229ms step_avg:205.25ms
+step:3890/4150 train_time:798467ms step_avg:205.26ms
+step:3891/4150 train_time:798702ms step_avg:205.27ms
+step:3892/4150 train_time:798939ms step_avg:205.28ms
+step:3893/4150 train_time:799179ms step_avg:205.29ms
+step:3894/4150 train_time:799415ms step_avg:205.29ms
+step:3895/4150 train_time:799651ms step_avg:205.30ms
+step:3896/4150 train_time:799890ms step_avg:205.31ms
+step:3897/4150 train_time:800124ms step_avg:205.32ms
+step:3898/4150 train_time:800361ms step_avg:205.33ms
+step:3899/4150 train_time:800600ms step_avg:205.33ms
+step:3900/4150 train_time:800837ms step_avg:205.34ms
+step:3901/4150 train_time:801071ms step_avg:205.35ms
+step:3902/4150 train_time:801311ms step_avg:205.36ms
+step:3903/4150 train_time:801544ms step_avg:205.37ms
+step:3904/4150 train_time:801782ms step_avg:205.37ms
+step:3905/4150 train_time:802015ms step_avg:205.38ms
+step:3906/4150 train_time:802253ms step_avg:205.39ms
+step:3907/4150 train_time:802486ms step_avg:205.40ms
+step:3908/4150 train_time:802723ms step_avg:205.41ms
+step:3909/4150 train_time:802959ms step_avg:205.41ms
+step:3910/4150 train_time:803196ms step_avg:205.42ms
+step:3911/4150 train_time:803432ms step_avg:205.43ms
+step:3912/4150 train_time:803668ms step_avg:205.44ms
+step:3913/4150 train_time:803903ms step_avg:205.44ms
+step:3914/4150 train_time:804141ms step_avg:205.45ms
+step:3915/4150 train_time:804378ms step_avg:205.46ms
+step:3916/4150 train_time:804614ms step_avg:205.47ms
+step:3917/4150 train_time:804851ms step_avg:205.48ms
+step:3918/4150 train_time:805086ms step_avg:205.48ms
+step:3919/4150 train_time:805319ms step_avg:205.49ms
+step:3920/4150 train_time:805557ms step_avg:205.50ms
+step:3921/4150 train_time:805791ms step_avg:205.51ms
+step:3922/4150 train_time:806030ms step_avg:205.52ms
+step:3923/4150 train_time:806261ms step_avg:205.52ms
+step:3924/4150 train_time:806500ms step_avg:205.53ms
+step:3925/4150 train_time:806737ms step_avg:205.54ms
+step:3926/4150 train_time:806975ms step_avg:205.55ms
+step:3927/4150 train_time:807209ms step_avg:205.55ms
+step:3928/4150 train_time:807445ms step_avg:205.56ms
+step:3929/4150 train_time:807681ms step_avg:205.57ms
+step:3930/4150 train_time:807918ms step_avg:205.58ms
+step:3931/4150 train_time:808152ms step_avg:205.58ms
+step:3932/4150 train_time:808388ms step_avg:205.59ms
+step:3933/4150 train_time:808620ms step_avg:205.60ms
+step:3934/4150 train_time:808857ms step_avg:205.61ms
+step:3935/4150 train_time:809091ms step_avg:205.61ms
+step:3936/4150 train_time:809333ms step_avg:205.62ms
+step:3937/4150 train_time:809569ms step_avg:205.63ms
+step:3938/4150 train_time:809806ms step_avg:205.64ms
+step:3939/4150 train_time:810041ms step_avg:205.65ms
+step:3940/4150 train_time:810280ms step_avg:205.65ms
+step:3941/4150 train_time:810518ms step_avg:205.66ms
+step:3942/4150 train_time:810752ms step_avg:205.67ms
+step:3943/4150 train_time:810987ms step_avg:205.68ms
+step:3944/4150 train_time:811223ms step_avg:205.69ms
+step:3945/4150 train_time:811460ms step_avg:205.69ms
+step:3946/4150 train_time:811697ms step_avg:205.70ms
+step:3947/4150 train_time:811934ms step_avg:205.71ms
+step:3948/4150 train_time:812177ms step_avg:205.72ms
+step:3949/4150 train_time:812412ms step_avg:205.73ms
+step:3950/4150 train_time:812655ms step_avg:205.74ms
+step:3951/4150 train_time:812892ms step_avg:205.74ms
+step:3952/4150 train_time:813128ms step_avg:205.75ms
+step:3953/4150 train_time:813362ms step_avg:205.76ms
+step:3954/4150 train_time:813600ms step_avg:205.77ms
+step:3955/4150 train_time:813837ms step_avg:205.77ms
+step:3956/4150 train_time:814072ms step_avg:205.78ms
+step:3957/4150 train_time:814305ms step_avg:205.79ms
+step:3958/4150 train_time:814542ms step_avg:205.80ms
+step:3959/4150 train_time:814776ms step_avg:205.80ms
+step:3960/4150 train_time:815012ms step_avg:205.81ms
+step:3961/4150 train_time:815247ms step_avg:205.82ms
+step:3962/4150 train_time:815484ms step_avg:205.83ms
+step:3963/4150 train_time:815717ms step_avg:205.83ms
+step:3964/4150 train_time:815955ms step_avg:205.84ms
+step:3965/4150 train_time:816189ms step_avg:205.85ms
+step:3966/4150 train_time:816423ms step_avg:205.86ms
+step:3967/4150 train_time:816658ms step_avg:205.86ms
+step:3968/4150 train_time:816895ms step_avg:205.87ms
+step:3969/4150 train_time:817128ms step_avg:205.88ms
+step:3970/4150 train_time:817368ms step_avg:205.89ms
+step:3971/4150 train_time:817603ms step_avg:205.89ms
+step:3972/4150 train_time:817840ms step_avg:205.90ms
+step:3973/4150 train_time:818074ms step_avg:205.91ms
+step:3974/4150 train_time:818313ms step_avg:205.92ms
+step:3975/4150 train_time:818546ms step_avg:205.92ms
+step:3976/4150 train_time:818783ms step_avg:205.93ms
+step:3977/4150 train_time:819018ms step_avg:205.94ms
+step:3978/4150 train_time:819255ms step_avg:205.95ms
+step:3979/4150 train_time:819490ms step_avg:205.95ms
+step:3980/4150 train_time:819727ms step_avg:205.96ms
+step:3981/4150 train_time:819960ms step_avg:205.97ms
+step:3982/4150 train_time:820198ms step_avg:205.98ms
+step:3983/4150 train_time:820437ms step_avg:205.98ms
+step:3984/4150 train_time:820670ms step_avg:205.99ms
+step:3985/4150 train_time:820902ms step_avg:206.00ms
+step:3986/4150 train_time:821140ms step_avg:206.01ms
+step:3987/4150 train_time:821376ms step_avg:206.01ms
+step:3988/4150 train_time:821616ms step_avg:206.02ms
+step:3989/4150 train_time:821848ms step_avg:206.03ms
+step:3990/4150 train_time:822087ms step_avg:206.04ms
+step:3991/4150 train_time:822321ms step_avg:206.04ms
+step:3992/4150 train_time:822559ms step_avg:206.05ms
+step:3993/4150 train_time:822794ms step_avg:206.06ms
+step:3994/4150 train_time:823037ms step_avg:206.07ms
+step:3995/4150 train_time:823271ms step_avg:206.08ms
+step:3996/4150 train_time:823513ms step_avg:206.08ms
+step:3997/4150 train_time:823748ms step_avg:206.09ms
+step:3998/4150 train_time:823985ms step_avg:206.10ms
+step:3999/4150 train_time:824218ms step_avg:206.11ms
+step:4000/4150 train_time:824460ms step_avg:206.11ms
+step:4000/4150 val_loss:2.9287 train_time:824674ms step_avg:206.17ms
+step:4001/4150 train_time:824698ms step_avg:206.12ms
+step:4002/4150 train_time:824940ms step_avg:206.13ms
+step:4003/4150 train_time:825176ms step_avg:206.14ms
+step:4004/4150 train_time:825408ms step_avg:206.15ms
+step:4005/4150 train_time:825642ms step_avg:206.15ms
+step:4006/4150 train_time:825884ms step_avg:206.16ms
+step:4007/4150 train_time:826120ms step_avg:206.17ms
+step:4008/4150 train_time:826356ms step_avg:206.18ms
+step:4009/4150 train_time:826587ms step_avg:206.18ms
+step:4010/4150 train_time:826825ms step_avg:206.19ms
+step:4011/4150 train_time:827063ms step_avg:206.20ms
+step:4012/4150 train_time:827297ms step_avg:206.21ms
+step:4013/4150 train_time:827531ms step_avg:206.21ms
+step:4014/4150 train_time:827767ms step_avg:206.22ms
+step:4015/4150 train_time:828002ms step_avg:206.23ms
+step:4016/4150 train_time:828242ms step_avg:206.24ms
+step:4017/4150 train_time:828474ms step_avg:206.24ms
+step:4018/4150 train_time:828710ms step_avg:206.25ms
+step:4019/4150 train_time:828951ms step_avg:206.26ms
+step:4020/4150 train_time:829188ms step_avg:206.27ms
+step:4021/4150 train_time:829421ms step_avg:206.27ms
+step:4022/4150 train_time:829656ms step_avg:206.28ms
+step:4023/4150 train_time:829891ms step_avg:206.29ms
+step:4024/4150 train_time:830133ms step_avg:206.30ms
+step:4025/4150 train_time:830368ms step_avg:206.30ms
+step:4026/4150 train_time:830604ms step_avg:206.31ms
+step:4027/4150 train_time:830836ms step_avg:206.32ms
+step:4028/4150 train_time:831073ms step_avg:206.32ms
+step:4029/4150 train_time:831307ms step_avg:206.33ms
+step:4030/4150 train_time:831545ms step_avg:206.34ms
+step:4031/4150 train_time:831780ms step_avg:206.35ms
+step:4032/4150 train_time:832018ms step_avg:206.35ms
+step:4033/4150 train_time:832254ms step_avg:206.36ms
+step:4034/4150 train_time:832491ms step_avg:206.37ms
+step:4035/4150 train_time:832724ms step_avg:206.38ms
+step:4036/4150 train_time:832957ms step_avg:206.38ms
+step:4037/4150 train_time:833194ms step_avg:206.39ms
+step:4038/4150 train_time:833435ms step_avg:206.40ms
+step:4039/4150 train_time:833668ms step_avg:206.40ms
+step:4040/4150 train_time:833909ms step_avg:206.41ms
+step:4041/4150 train_time:834142ms step_avg:206.42ms
+step:4042/4150 train_time:834379ms step_avg:206.43ms
+step:4043/4150 train_time:834610ms step_avg:206.43ms
+step:4044/4150 train_time:834849ms step_avg:206.44ms
+step:4045/4150 train_time:835081ms step_avg:206.45ms
+step:4046/4150 train_time:835315ms step_avg:206.45ms
+step:4047/4150 train_time:835549ms step_avg:206.46ms
+step:4048/4150 train_time:835784ms step_avg:206.47ms
+step:4049/4150 train_time:836018ms step_avg:206.48ms
+step:4050/4150 train_time:836255ms step_avg:206.48ms
+step:4051/4150 train_time:836492ms step_avg:206.49ms
+step:4052/4150 train_time:836727ms step_avg:206.50ms
+step:4053/4150 train_time:836963ms step_avg:206.50ms
+step:4054/4150 train_time:837200ms step_avg:206.51ms
+step:4055/4150 train_time:837434ms step_avg:206.52ms
+step:4056/4150 train_time:837671ms step_avg:206.53ms
+step:4057/4150 train_time:837907ms step_avg:206.53ms
+step:4058/4150 train_time:838144ms step_avg:206.54ms
+step:4059/4150 train_time:838378ms step_avg:206.55ms
+step:4060/4150 train_time:838616ms step_avg:206.56ms
+step:4061/4150 train_time:838853ms step_avg:206.56ms
+step:4062/4150 train_time:839090ms step_avg:206.57ms
+step:4063/4150 train_time:839324ms step_avg:206.58ms
+step:4064/4150 train_time:839562ms step_avg:206.59ms
+step:4065/4150 train_time:839797ms step_avg:206.59ms
+step:4066/4150 train_time:840033ms step_avg:206.60ms
+step:4067/4150 train_time:840272ms step_avg:206.61ms
+step:4068/4150 train_time:840512ms step_avg:206.62ms
+step:4069/4150 train_time:840748ms step_avg:206.62ms
+step:4070/4150 train_time:840990ms step_avg:206.63ms
+step:4071/4150 train_time:841223ms step_avg:206.64ms
+step:4072/4150 train_time:841460ms step_avg:206.65ms
+step:4073/4150 train_time:841696ms step_avg:206.65ms
+step:4074/4150 train_time:841932ms step_avg:206.66ms
+step:4075/4150 train_time:842169ms step_avg:206.67ms
+step:4076/4150 train_time:842406ms step_avg:206.67ms
+step:4077/4150 train_time:842640ms step_avg:206.68ms
+step:4078/4150 train_time:842875ms step_avg:206.69ms
+step:4079/4150 train_time:843110ms step_avg:206.70ms
+step:4080/4150 train_time:843347ms step_avg:206.70ms
+step:4081/4150 train_time:843582ms step_avg:206.71ms
+step:4082/4150 train_time:843818ms step_avg:206.72ms
+step:4083/4150 train_time:844054ms step_avg:206.72ms
+step:4084/4150 train_time:844295ms step_avg:206.73ms
+step:4085/4150 train_time:844530ms step_avg:206.74ms
+step:4086/4150 train_time:844767ms step_avg:206.75ms
+step:4087/4150 train_time:845000ms step_avg:206.75ms
+step:4088/4150 train_time:845237ms step_avg:206.76ms
+step:4089/4150 train_time:845473ms step_avg:206.77ms
+step:4090/4150 train_time:845715ms step_avg:206.78ms
+step:4091/4150 train_time:845950ms step_avg:206.78ms
+step:4092/4150 train_time:846190ms step_avg:206.79ms
+step:4093/4150 train_time:846422ms step_avg:206.80ms
+step:4094/4150 train_time:846660ms step_avg:206.81ms
+step:4095/4150 train_time:846896ms step_avg:206.81ms
+step:4096/4150 train_time:847133ms step_avg:206.82ms
+step:4097/4150 train_time:847368ms step_avg:206.83ms
+step:4098/4150 train_time:847604ms step_avg:206.83ms
+step:4099/4150 train_time:847837ms step_avg:206.84ms
+step:4100/4150 train_time:848074ms step_avg:206.85ms
+step:4101/4150 train_time:848314ms step_avg:206.86ms
+step:4102/4150 train_time:848551ms step_avg:206.86ms
+step:4103/4150 train_time:848786ms step_avg:206.87ms
+step:4104/4150 train_time:849023ms step_avg:206.88ms
+step:4105/4150 train_time:849257ms step_avg:206.88ms
+step:4106/4150 train_time:849495ms step_avg:206.89ms
+step:4107/4150 train_time:849729ms step_avg:206.90ms
+step:4108/4150 train_time:849968ms step_avg:206.91ms
+step:4109/4150 train_time:850203ms step_avg:206.91ms
+step:4110/4150 train_time:850438ms step_avg:206.92ms
+step:4111/4150 train_time:850673ms step_avg:206.93ms
+step:4112/4150 train_time:850910ms step_avg:206.93ms
+step:4113/4150 train_time:851143ms step_avg:206.94ms
+step:4114/4150 train_time:851382ms step_avg:206.95ms
+step:4115/4150 train_time:851617ms step_avg:206.95ms
+step:4116/4150 train_time:851855ms step_avg:206.96ms
+step:4117/4150 train_time:852090ms step_avg:206.97ms
+step:4118/4150 train_time:852326ms step_avg:206.98ms
+step:4119/4150 train_time:852562ms step_avg:206.98ms
+step:4120/4150 train_time:852798ms step_avg:206.99ms
+step:4121/4150 train_time:853032ms step_avg:207.00ms
+step:4122/4150 train_time:853270ms step_avg:207.00ms
+step:4123/4150 train_time:853505ms step_avg:207.01ms
+step:4124/4150 train_time:853740ms step_avg:207.02ms
+step:4125/4150 train_time:853978ms step_avg:207.02ms
+step:4126/4150 train_time:854217ms step_avg:207.03ms
+step:4127/4150 train_time:854450ms step_avg:207.04ms
+step:4128/4150 train_time:854691ms step_avg:207.05ms
+step:4129/4150 train_time:854927ms step_avg:207.05ms
+step:4130/4150 train_time:855164ms step_avg:207.06ms
+step:4131/4150 train_time:855398ms step_avg:207.07ms
+step:4132/4150 train_time:855636ms step_avg:207.08ms
+step:4133/4150 train_time:855873ms step_avg:207.08ms
+step:4134/4150 train_time:856112ms step_avg:207.09ms
+step:4135/4150 train_time:856346ms step_avg:207.10ms
+step:4136/4150 train_time:856581ms step_avg:207.10ms
+step:4137/4150 train_time:856817ms step_avg:207.11ms
+step:4138/4150 train_time:857054ms step_avg:207.12ms
+step:4139/4150 train_time:857292ms step_avg:207.13ms
+step:4140/4150 train_time:857532ms step_avg:207.13ms
+step:4141/4150 train_time:857766ms step_avg:207.14ms
+step:4142/4150 train_time:858005ms step_avg:207.15ms
+step:4143/4150 train_time:858239ms step_avg:207.15ms
+step:4144/4150 train_time:858478ms step_avg:207.16ms
+step:4145/4150 train_time:858711ms step_avg:207.17ms
+step:4146/4150 train_time:858949ms step_avg:207.18ms
+step:4147/4150 train_time:859185ms step_avg:207.18ms
+step:4148/4150 train_time:859422ms step_avg:207.19ms
+step:4149/4150 train_time:859656ms step_avg:207.20ms
+step:4150/4150 train_time:859895ms step_avg:207.20ms
+step:4150/4150 val_loss:2.9176 train_time:860109ms step_avg:207.26ms
+peak memory allocated: 59977 MiB reserved: 60604 MiB

--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/c6556b77-eec6-4b35-ab51-7da4a00f4219.txt
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/c6556b77-eec6-4b35-ab51-7da4a00f4219.txt
@@ -1,0 +1,6376 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+import numpy as np
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
+
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = False # turn off fp8 for now -> requires tuning of scales which hasnt been done on medium track
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(16, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
+
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
+        self.yarn = Yarn(head_dim, max_seq_len)
+
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+        self.embed.weight.label = 'embed'
+
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
+        self.embed2.weight.label = 'embed2'
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [2, 4, 6]
+        skip_out = [9, 10, 11]
+        backout_layer = 11
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
+            short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
+
+        skip_idx = 0
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve_list[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
+            )
+            next_ve_gate = None
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
+                skip_idx += 1
+                x = x + skip_gate_out * skip_connections.pop()
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
+            else:
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                h_backout_snap = x
+
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
+        x = norm(x)
+
+        if not self.training:
+            loss = 0
+            for i in range(4):
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
+                logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+                loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
+            return loss
+
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return min(11,args.ws_schedule[ws_idx] // 2), args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/12:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/12:
+        lr_max = 1.73  # (24/8)**0.5
+    if x > 3/12:
+        lr_max = 2.0
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
+
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / (args.num_scheduled_iterations/4)
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        # only apply yarn for first few
+        if new_ws_long != self.ws_long and new_ws_long<=13:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
+                                524288, 524288, 524288, 524288,
+                                524288, 524288, 524288, 524288
+                               )
+    train_bs_extension: int = 32 * 2048 * 8
+    train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3/4
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11, 13,
+                          15, 17, 19, 21,
+                          23, 23, 23, 23)
+    ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
+    ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=16,
+    num_heads=8,
+    head_dim=128,
+    model_dim=1024,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Mon Apr 27 07:43:58 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   42C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   36C    P0            117W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   41C    P0            116W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   37C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          274232      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    1   N/A  N/A          274233      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    2   N/A  N/A          274234      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    3   N/A  N/A          274235      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    4   N/A  N/A          274236      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    5   N/A  N/A          274237      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    6   N/A  N/A          274238      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    7   N/A  N/A          274239      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 343, 344, 345, 687, 688, 689, 1031, 1032, 1033, 1374, 1375, 1376, 1718, 1719, 1720, 2062, 2063, 2064, 2406, 2407, 2408, 2749, 2750, 2751] for warmup
+Resetting Model
+step:0/4150 val_loss:10.8320 train_time:0ms step_avg:0.03ms
+step:1/4150 train_time:68ms step_avg:68.21ms
+step:2/4150 train_time:117ms step_avg:58.45ms
+step:3/4150 train_time:185ms step_avg:61.57ms
+step:4/4150 train_time:251ms step_avg:62.72ms
+step:5/4150 train_time:320ms step_avg:63.96ms
+step:6/4150 train_time:385ms step_avg:64.19ms
+step:7/4150 train_time:454ms step_avg:64.85ms
+step:8/4150 train_time:519ms step_avg:64.93ms
+step:9/4150 train_time:589ms step_avg:65.43ms
+step:10/4150 train_time:655ms step_avg:65.47ms
+step:11/4150 train_time:723ms step_avg:65.77ms
+step:12/4150 train_time:789ms step_avg:65.73ms
+step:13/4150 train_time:858ms step_avg:66.04ms
+step:14/4150 train_time:924ms step_avg:65.98ms
+step:15/4150 train_time:995ms step_avg:66.31ms
+step:16/4150 train_time:1061ms step_avg:66.33ms
+step:17/4150 train_time:1132ms step_avg:66.61ms
+step:18/4150 train_time:1198ms step_avg:66.56ms
+step:19/4150 train_time:1268ms step_avg:66.75ms
+step:20/4150 train_time:1334ms step_avg:66.72ms
+step:21/4150 train_time:1404ms step_avg:66.88ms
+step:22/4150 train_time:1470ms step_avg:66.82ms
+step:23/4150 train_time:1540ms step_avg:66.98ms
+step:24/4150 train_time:1606ms step_avg:66.93ms
+step:25/4150 train_time:1676ms step_avg:67.03ms
+step:26/4150 train_time:1741ms step_avg:66.97ms
+step:27/4150 train_time:1811ms step_avg:67.07ms
+step:28/4150 train_time:1878ms step_avg:67.05ms
+step:29/4150 train_time:1947ms step_avg:67.14ms
+step:30/4150 train_time:2013ms step_avg:67.09ms
+step:31/4150 train_time:2084ms step_avg:67.24ms
+step:32/4150 train_time:2150ms step_avg:67.19ms
+step:33/4150 train_time:2221ms step_avg:67.29ms
+step:34/4150 train_time:2286ms step_avg:67.24ms
+step:35/4150 train_time:2357ms step_avg:67.33ms
+step:36/4150 train_time:2423ms step_avg:67.29ms
+step:37/4150 train_time:2493ms step_avg:67.38ms
+step:38/4150 train_time:2559ms step_avg:67.33ms
+step:39/4150 train_time:2628ms step_avg:67.39ms
+step:40/4150 train_time:2694ms step_avg:67.35ms
+step:41/4150 train_time:2763ms step_avg:67.39ms
+step:42/4150 train_time:2829ms step_avg:67.35ms
+step:43/4150 train_time:2899ms step_avg:67.41ms
+step:44/4150 train_time:2964ms step_avg:67.37ms
+step:45/4150 train_time:3034ms step_avg:67.43ms
+step:46/4150 train_time:3100ms step_avg:67.39ms
+step:47/4150 train_time:3170ms step_avg:67.44ms
+step:48/4150 train_time:3236ms step_avg:67.42ms
+step:49/4150 train_time:3306ms step_avg:67.48ms
+step:50/4150 train_time:3372ms step_avg:67.44ms
+step:51/4150 train_time:3444ms step_avg:67.52ms
+step:52/4150 train_time:3509ms step_avg:67.49ms
+step:53/4150 train_time:3579ms step_avg:67.53ms
+step:54/4150 train_time:3645ms step_avg:67.50ms
+step:55/4150 train_time:3715ms step_avg:67.54ms
+step:56/4150 train_time:3781ms step_avg:67.51ms
+step:57/4150 train_time:3852ms step_avg:67.57ms
+step:58/4150 train_time:3917ms step_avg:67.54ms
+step:59/4150 train_time:3987ms step_avg:67.58ms
+step:60/4150 train_time:4053ms step_avg:67.55ms
+step:61/4150 train_time:4124ms step_avg:67.60ms
+step:62/4150 train_time:4190ms step_avg:67.58ms
+step:63/4150 train_time:4260ms step_avg:67.61ms
+step:64/4150 train_time:4325ms step_avg:67.58ms
+step:65/4150 train_time:4395ms step_avg:67.62ms
+step:66/4150 train_time:4461ms step_avg:67.58ms
+step:67/4150 train_time:4530ms step_avg:67.62ms
+step:68/4150 train_time:4596ms step_avg:67.59ms
+step:69/4150 train_time:4666ms step_avg:67.62ms
+step:70/4150 train_time:4731ms step_avg:67.58ms
+step:71/4150 train_time:4800ms step_avg:67.61ms
+step:72/4150 train_time:4866ms step_avg:67.58ms
+step:73/4150 train_time:4935ms step_avg:67.61ms
+step:74/4150 train_time:5000ms step_avg:67.57ms
+step:75/4150 train_time:5070ms step_avg:67.60ms
+step:76/4150 train_time:5136ms step_avg:67.58ms
+step:77/4150 train_time:5206ms step_avg:67.61ms
+step:78/4150 train_time:5272ms step_avg:67.59ms
+step:79/4150 train_time:5341ms step_avg:67.61ms
+step:80/4150 train_time:5406ms step_avg:67.58ms
+step:81/4150 train_time:5476ms step_avg:67.61ms
+step:82/4150 train_time:5541ms step_avg:67.58ms
+step:83/4150 train_time:5612ms step_avg:67.62ms
+step:84/4150 train_time:5678ms step_avg:67.60ms
+step:85/4150 train_time:5748ms step_avg:67.62ms
+step:86/4150 train_time:5814ms step_avg:67.60ms
+step:87/4150 train_time:5883ms step_avg:67.62ms
+step:88/4150 train_time:5949ms step_avg:67.60ms
+step:89/4150 train_time:6018ms step_avg:67.62ms
+step:90/4150 train_time:6084ms step_avg:67.60ms
+step:91/4150 train_time:6153ms step_avg:67.61ms
+step:92/4150 train_time:6218ms step_avg:67.59ms
+step:93/4150 train_time:6288ms step_avg:67.62ms
+step:94/4150 train_time:6354ms step_avg:67.60ms
+step:95/4150 train_time:6424ms step_avg:67.62ms
+step:96/4150 train_time:6490ms step_avg:67.60ms
+step:97/4150 train_time:6559ms step_avg:67.62ms
+step:98/4150 train_time:6625ms step_avg:67.60ms
+step:99/4150 train_time:6695ms step_avg:67.62ms
+step:100/4150 train_time:6761ms step_avg:67.61ms
+step:101/4150 train_time:6830ms step_avg:67.62ms
+step:102/4150 train_time:6895ms step_avg:67.60ms
+step:103/4150 train_time:6964ms step_avg:67.61ms
+step:104/4150 train_time:7030ms step_avg:67.59ms
+step:105/4150 train_time:7099ms step_avg:67.61ms
+step:106/4150 train_time:7165ms step_avg:67.60ms
+step:107/4150 train_time:7235ms step_avg:67.62ms
+step:108/4150 train_time:7300ms step_avg:67.59ms
+step:109/4150 train_time:7370ms step_avg:67.61ms
+step:110/4150 train_time:7435ms step_avg:67.59ms
+step:111/4150 train_time:7505ms step_avg:67.61ms
+step:112/4150 train_time:7570ms step_avg:67.59ms
+step:113/4150 train_time:7641ms step_avg:67.62ms
+step:114/4150 train_time:7706ms step_avg:67.60ms
+step:115/4150 train_time:7776ms step_avg:67.62ms
+step:116/4150 train_time:7842ms step_avg:67.60ms
+step:117/4150 train_time:7911ms step_avg:67.62ms
+step:118/4150 train_time:7977ms step_avg:67.60ms
+step:119/4150 train_time:8046ms step_avg:67.62ms
+step:120/4150 train_time:8112ms step_avg:67.60ms
+step:121/4150 train_time:8183ms step_avg:67.62ms
+step:122/4150 train_time:8248ms step_avg:67.61ms
+step:123/4150 train_time:8318ms step_avg:67.63ms
+step:124/4150 train_time:8383ms step_avg:67.61ms
+step:125/4150 train_time:8453ms step_avg:67.62ms
+step:126/4150 train_time:8518ms step_avg:67.61ms
+step:127/4150 train_time:8588ms step_avg:67.62ms
+step:128/4150 train_time:8654ms step_avg:67.61ms
+step:129/4150 train_time:8724ms step_avg:67.63ms
+step:130/4150 train_time:8789ms step_avg:67.61ms
+step:131/4150 train_time:8860ms step_avg:67.63ms
+step:132/4150 train_time:8925ms step_avg:67.62ms
+step:133/4150 train_time:8995ms step_avg:67.64ms
+step:134/4150 train_time:9061ms step_avg:67.62ms
+step:135/4150 train_time:9131ms step_avg:67.64ms
+step:136/4150 train_time:9197ms step_avg:67.62ms
+step:137/4150 train_time:9266ms step_avg:67.64ms
+step:138/4150 train_time:9332ms step_avg:67.63ms
+step:139/4150 train_time:9402ms step_avg:67.64ms
+step:140/4150 train_time:9468ms step_avg:67.63ms
+step:141/4150 train_time:9537ms step_avg:67.64ms
+step:142/4150 train_time:9602ms step_avg:67.62ms
+step:143/4150 train_time:9672ms step_avg:67.63ms
+step:144/4150 train_time:9737ms step_avg:67.62ms
+step:145/4150 train_time:9807ms step_avg:67.63ms
+step:146/4150 train_time:9872ms step_avg:67.62ms
+step:147/4150 train_time:9943ms step_avg:67.64ms
+step:148/4150 train_time:10009ms step_avg:67.63ms
+step:149/4150 train_time:10078ms step_avg:67.64ms
+step:150/4150 train_time:10145ms step_avg:67.63ms
+step:151/4150 train_time:10214ms step_avg:67.65ms
+step:152/4150 train_time:10280ms step_avg:67.63ms
+step:153/4150 train_time:10351ms step_avg:67.65ms
+step:154/4150 train_time:10417ms step_avg:67.64ms
+step:155/4150 train_time:10487ms step_avg:67.66ms
+step:156/4150 train_time:10551ms step_avg:67.64ms
+step:157/4150 train_time:10621ms step_avg:67.65ms
+step:158/4150 train_time:10687ms step_avg:67.64ms
+step:159/4150 train_time:10756ms step_avg:67.65ms
+step:160/4150 train_time:10821ms step_avg:67.63ms
+step:161/4150 train_time:10891ms step_avg:67.64ms
+step:162/4150 train_time:10956ms step_avg:67.63ms
+step:163/4150 train_time:11026ms step_avg:67.64ms
+step:164/4150 train_time:11091ms step_avg:67.63ms
+step:165/4150 train_time:11160ms step_avg:67.64ms
+step:166/4150 train_time:11225ms step_avg:67.62ms
+step:167/4150 train_time:11295ms step_avg:67.63ms
+step:168/4150 train_time:11360ms step_avg:67.62ms
+step:169/4150 train_time:11430ms step_avg:67.63ms
+step:170/4150 train_time:11495ms step_avg:67.62ms
+step:171/4150 train_time:11565ms step_avg:67.63ms
+step:172/4150 train_time:11630ms step_avg:67.62ms
+step:173/4150 train_time:11700ms step_avg:67.63ms
+step:174/4150 train_time:11766ms step_avg:67.62ms
+step:175/4150 train_time:11835ms step_avg:67.63ms
+step:176/4150 train_time:11900ms step_avg:67.62ms
+step:177/4150 train_time:11970ms step_avg:67.62ms
+step:178/4150 train_time:12035ms step_avg:67.61ms
+step:179/4150 train_time:12105ms step_avg:67.63ms
+step:180/4150 train_time:12171ms step_avg:67.61ms
+step:181/4150 train_time:12241ms step_avg:67.63ms
+step:182/4150 train_time:12306ms step_avg:67.61ms
+step:183/4150 train_time:12375ms step_avg:67.62ms
+step:184/4150 train_time:12440ms step_avg:67.61ms
+step:185/4150 train_time:12510ms step_avg:67.62ms
+step:186/4150 train_time:12576ms step_avg:67.61ms
+step:187/4150 train_time:12646ms step_avg:67.62ms
+step:188/4150 train_time:12711ms step_avg:67.61ms
+step:189/4150 train_time:12780ms step_avg:67.62ms
+step:190/4150 train_time:12846ms step_avg:67.61ms
+step:191/4150 train_time:12915ms step_avg:67.62ms
+step:192/4150 train_time:12980ms step_avg:67.60ms
+step:193/4150 train_time:13050ms step_avg:67.62ms
+step:194/4150 train_time:13115ms step_avg:67.60ms
+step:195/4150 train_time:13185ms step_avg:67.62ms
+step:196/4150 train_time:13250ms step_avg:67.60ms
+step:197/4150 train_time:13320ms step_avg:67.61ms
+step:198/4150 train_time:13385ms step_avg:67.60ms
+step:199/4150 train_time:13454ms step_avg:67.61ms
+step:200/4150 train_time:13520ms step_avg:67.60ms
+step:201/4150 train_time:13589ms step_avg:67.61ms
+step:202/4150 train_time:13654ms step_avg:67.60ms
+step:203/4150 train_time:13724ms step_avg:67.60ms
+step:204/4150 train_time:13789ms step_avg:67.59ms
+step:205/4150 train_time:13858ms step_avg:67.60ms
+step:206/4150 train_time:13923ms step_avg:67.59ms
+step:207/4150 train_time:13993ms step_avg:67.60ms
+step:208/4150 train_time:14058ms step_avg:67.59ms
+step:209/4150 train_time:14128ms step_avg:67.60ms
+step:210/4150 train_time:14193ms step_avg:67.58ms
+step:211/4150 train_time:14262ms step_avg:67.59ms
+step:212/4150 train_time:14328ms step_avg:67.59ms
+step:213/4150 train_time:14398ms step_avg:67.59ms
+step:214/4150 train_time:14463ms step_avg:67.58ms
+step:215/4150 train_time:14533ms step_avg:67.60ms
+step:216/4150 train_time:14598ms step_avg:67.58ms
+step:217/4150 train_time:14667ms step_avg:67.59ms
+step:218/4150 train_time:14733ms step_avg:67.58ms
+step:219/4150 train_time:14802ms step_avg:67.59ms
+step:220/4150 train_time:14868ms step_avg:67.58ms
+step:221/4150 train_time:14937ms step_avg:67.59ms
+step:222/4150 train_time:15002ms step_avg:67.57ms
+step:223/4150 train_time:15071ms step_avg:67.59ms
+step:224/4150 train_time:15137ms step_avg:67.58ms
+step:225/4150 train_time:15207ms step_avg:67.59ms
+step:226/4150 train_time:15273ms step_avg:67.58ms
+step:227/4150 train_time:15342ms step_avg:67.59ms
+step:228/4150 train_time:15408ms step_avg:67.58ms
+step:229/4150 train_time:15477ms step_avg:67.58ms
+step:230/4150 train_time:15542ms step_avg:67.57ms
+step:231/4150 train_time:15612ms step_avg:67.58ms
+step:232/4150 train_time:15677ms step_avg:67.57ms
+step:233/4150 train_time:15746ms step_avg:67.58ms
+step:234/4150 train_time:15812ms step_avg:67.57ms
+step:235/4150 train_time:15882ms step_avg:67.58ms
+step:236/4150 train_time:15947ms step_avg:67.57ms
+step:237/4150 train_time:16016ms step_avg:67.58ms
+step:238/4150 train_time:16081ms step_avg:67.57ms
+step:239/4150 train_time:16150ms step_avg:67.57ms
+step:240/4150 train_time:16215ms step_avg:67.56ms
+step:241/4150 train_time:16285ms step_avg:67.57ms
+step:242/4150 train_time:16350ms step_avg:67.56ms
+step:243/4150 train_time:16419ms step_avg:67.57ms
+step:244/4150 train_time:16485ms step_avg:67.56ms
+step:245/4150 train_time:16555ms step_avg:67.57ms
+step:246/4150 train_time:16620ms step_avg:67.56ms
+step:247/4150 train_time:16690ms step_avg:67.57ms
+step:248/4150 train_time:16755ms step_avg:67.56ms
+step:249/4150 train_time:16825ms step_avg:67.57ms
+step:250/4150 train_time:16890ms step_avg:67.56ms
+step:250/4150 val_loss:4.4823 train_time:16955ms step_avg:67.82ms
+step:251/4150 train_time:16976ms step_avg:67.63ms
+step:252/4150 train_time:17028ms step_avg:67.57ms
+step:253/4150 train_time:17097ms step_avg:67.58ms
+step:254/4150 train_time:17163ms step_avg:67.57ms
+step:255/4150 train_time:17234ms step_avg:67.58ms
+step:256/4150 train_time:17302ms step_avg:67.59ms
+step:257/4150 train_time:17373ms step_avg:67.60ms
+step:258/4150 train_time:17439ms step_avg:67.59ms
+step:259/4150 train_time:17508ms step_avg:67.60ms
+step:260/4150 train_time:17573ms step_avg:67.59ms
+step:261/4150 train_time:17642ms step_avg:67.59ms
+step:262/4150 train_time:17707ms step_avg:67.58ms
+step:263/4150 train_time:17776ms step_avg:67.59ms
+step:264/4150 train_time:17841ms step_avg:67.58ms
+step:265/4150 train_time:17911ms step_avg:67.59ms
+step:266/4150 train_time:17976ms step_avg:67.58ms
+step:267/4150 train_time:18045ms step_avg:67.58ms
+step:268/4150 train_time:18110ms step_avg:67.57ms
+step:269/4150 train_time:18180ms step_avg:67.58ms
+step:270/4150 train_time:18245ms step_avg:67.57ms
+step:271/4150 train_time:18315ms step_avg:67.58ms
+step:272/4150 train_time:18381ms step_avg:67.58ms
+step:273/4150 train_time:18450ms step_avg:67.58ms
+step:274/4150 train_time:18516ms step_avg:67.58ms
+step:275/4150 train_time:18585ms step_avg:67.58ms
+step:276/4150 train_time:18650ms step_avg:67.57ms
+step:277/4150 train_time:18719ms step_avg:67.58ms
+step:278/4150 train_time:18784ms step_avg:67.57ms
+step:279/4150 train_time:18852ms step_avg:67.57ms
+step:280/4150 train_time:18918ms step_avg:67.56ms
+step:281/4150 train_time:18987ms step_avg:67.57ms
+step:282/4150 train_time:19052ms step_avg:67.56ms
+step:283/4150 train_time:19123ms step_avg:67.57ms
+step:284/4150 train_time:19187ms step_avg:67.56ms
+step:285/4150 train_time:19257ms step_avg:67.57ms
+step:286/4150 train_time:19322ms step_avg:67.56ms
+step:287/4150 train_time:19391ms step_avg:67.57ms
+step:288/4150 train_time:19458ms step_avg:67.56ms
+step:289/4150 train_time:19527ms step_avg:67.57ms
+step:290/4150 train_time:19592ms step_avg:67.56ms
+step:291/4150 train_time:19662ms step_avg:67.57ms
+step:292/4150 train_time:19727ms step_avg:67.56ms
+step:293/4150 train_time:19796ms step_avg:67.56ms
+step:294/4150 train_time:19861ms step_avg:67.56ms
+step:295/4150 train_time:19930ms step_avg:67.56ms
+step:296/4150 train_time:19995ms step_avg:67.55ms
+step:297/4150 train_time:20065ms step_avg:67.56ms
+step:298/4150 train_time:20130ms step_avg:67.55ms
+step:299/4150 train_time:20201ms step_avg:67.56ms
+step:300/4150 train_time:20265ms step_avg:67.55ms
+step:301/4150 train_time:20334ms step_avg:67.56ms
+step:302/4150 train_time:20399ms step_avg:67.55ms
+step:303/4150 train_time:20468ms step_avg:67.55ms
+step:304/4150 train_time:20534ms step_avg:67.55ms
+step:305/4150 train_time:20603ms step_avg:67.55ms
+step:306/4150 train_time:20668ms step_avg:67.54ms
+step:307/4150 train_time:20737ms step_avg:67.55ms
+step:308/4150 train_time:20802ms step_avg:67.54ms
+step:309/4150 train_time:20871ms step_avg:67.54ms
+step:310/4150 train_time:20936ms step_avg:67.54ms
+step:311/4150 train_time:21005ms step_avg:67.54ms
+step:312/4150 train_time:21070ms step_avg:67.53ms
+step:313/4150 train_time:21139ms step_avg:67.54ms
+step:314/4150 train_time:21205ms step_avg:67.53ms
+step:315/4150 train_time:21274ms step_avg:67.54ms
+step:316/4150 train_time:21340ms step_avg:67.53ms
+step:317/4150 train_time:21410ms step_avg:67.54ms
+step:318/4150 train_time:21476ms step_avg:67.53ms
+step:319/4150 train_time:21545ms step_avg:67.54ms
+step:320/4150 train_time:21610ms step_avg:67.53ms
+step:321/4150 train_time:21679ms step_avg:67.54ms
+step:322/4150 train_time:21744ms step_avg:67.53ms
+step:323/4150 train_time:21813ms step_avg:67.53ms
+step:324/4150 train_time:21878ms step_avg:67.53ms
+step:325/4150 train_time:21947ms step_avg:67.53ms
+step:326/4150 train_time:22011ms step_avg:67.52ms
+step:327/4150 train_time:22081ms step_avg:67.53ms
+step:328/4150 train_time:22146ms step_avg:67.52ms
+step:329/4150 train_time:22215ms step_avg:67.52ms
+step:330/4150 train_time:22280ms step_avg:67.52ms
+step:331/4150 train_time:22350ms step_avg:67.52ms
+step:332/4150 train_time:22415ms step_avg:67.51ms
+step:333/4150 train_time:22485ms step_avg:67.52ms
+step:334/4150 train_time:22550ms step_avg:67.51ms
+step:335/4150 train_time:22619ms step_avg:67.52ms
+step:336/4150 train_time:22685ms step_avg:67.51ms
+step:337/4150 train_time:22754ms step_avg:67.52ms
+step:338/4150 train_time:22819ms step_avg:67.51ms
+step:339/4150 train_time:22888ms step_avg:67.52ms
+step:340/4150 train_time:22953ms step_avg:67.51ms
+step:341/4150 train_time:23023ms step_avg:67.51ms
+step:342/4150 train_time:23088ms step_avg:67.51ms
+step:343/4150 train_time:23157ms step_avg:67.51ms
+step:344/4150 train_time:23222ms step_avg:67.51ms
+step:345/4150 train_time:23295ms step_avg:67.52ms
+step:346/4150 train_time:23416ms step_avg:67.68ms
+step:347/4150 train_time:23538ms step_avg:67.83ms
+step:348/4150 train_time:23660ms step_avg:67.99ms
+step:349/4150 train_time:23782ms step_avg:68.14ms
+step:350/4150 train_time:23902ms step_avg:68.29ms
+step:351/4150 train_time:24025ms step_avg:68.45ms
+step:352/4150 train_time:24147ms step_avg:68.60ms
+step:353/4150 train_time:24269ms step_avg:68.75ms
+step:354/4150 train_time:24389ms step_avg:68.90ms
+step:355/4150 train_time:24512ms step_avg:69.05ms
+step:356/4150 train_time:24633ms step_avg:69.19ms
+step:357/4150 train_time:24757ms step_avg:69.35ms
+step:358/4150 train_time:24877ms step_avg:69.49ms
+step:359/4150 train_time:24999ms step_avg:69.64ms
+step:360/4150 train_time:25123ms step_avg:69.79ms
+step:361/4150 train_time:25245ms step_avg:69.93ms
+step:362/4150 train_time:25366ms step_avg:70.07ms
+step:363/4150 train_time:25489ms step_avg:70.22ms
+step:364/4150 train_time:25609ms step_avg:70.35ms
+step:365/4150 train_time:25731ms step_avg:70.50ms
+step:366/4150 train_time:25852ms step_avg:70.63ms
+step:367/4150 train_time:25975ms step_avg:70.78ms
+step:368/4150 train_time:26098ms step_avg:70.92ms
+step:369/4150 train_time:26221ms step_avg:71.06ms
+step:370/4150 train_time:26341ms step_avg:71.19ms
+step:371/4150 train_time:26464ms step_avg:71.33ms
+step:372/4150 train_time:26584ms step_avg:71.46ms
+step:373/4150 train_time:26709ms step_avg:71.60ms
+step:374/4150 train_time:26829ms step_avg:71.73ms
+step:375/4150 train_time:26950ms step_avg:71.87ms
+step:376/4150 train_time:27070ms step_avg:71.99ms
+step:377/4150 train_time:27193ms step_avg:72.13ms
+step:378/4150 train_time:27314ms step_avg:72.26ms
+step:379/4150 train_time:27440ms step_avg:72.40ms
+step:380/4150 train_time:27561ms step_avg:72.53ms
+step:381/4150 train_time:27682ms step_avg:72.66ms
+step:382/4150 train_time:27802ms step_avg:72.78ms
+step:383/4150 train_time:27924ms step_avg:72.91ms
+step:384/4150 train_time:28045ms step_avg:73.03ms
+step:385/4150 train_time:28168ms step_avg:73.16ms
+step:386/4150 train_time:28288ms step_avg:73.29ms
+step:387/4150 train_time:28412ms step_avg:73.42ms
+step:388/4150 train_time:28534ms step_avg:73.54ms
+step:389/4150 train_time:28658ms step_avg:73.67ms
+step:390/4150 train_time:28778ms step_avg:73.79ms
+step:391/4150 train_time:28900ms step_avg:73.91ms
+step:392/4150 train_time:29019ms step_avg:74.03ms
+step:393/4150 train_time:29144ms step_avg:74.16ms
+step:394/4150 train_time:29264ms step_avg:74.27ms
+step:395/4150 train_time:29387ms step_avg:74.40ms
+step:396/4150 train_time:29508ms step_avg:74.51ms
+step:397/4150 train_time:29631ms step_avg:74.64ms
+step:398/4150 train_time:29750ms step_avg:74.75ms
+step:399/4150 train_time:29874ms step_avg:74.87ms
+step:400/4150 train_time:29995ms step_avg:74.99ms
+step:401/4150 train_time:30117ms step_avg:75.11ms
+step:402/4150 train_time:30238ms step_avg:75.22ms
+step:403/4150 train_time:30361ms step_avg:75.34ms
+step:404/4150 train_time:30481ms step_avg:75.45ms
+step:405/4150 train_time:30604ms step_avg:75.57ms
+step:406/4150 train_time:30725ms step_avg:75.68ms
+step:407/4150 train_time:30847ms step_avg:75.79ms
+step:408/4150 train_time:30966ms step_avg:75.90ms
+step:409/4150 train_time:31088ms step_avg:76.01ms
+step:410/4150 train_time:31210ms step_avg:76.12ms
+step:411/4150 train_time:31333ms step_avg:76.24ms
+step:412/4150 train_time:31453ms step_avg:76.34ms
+step:413/4150 train_time:31576ms step_avg:76.45ms
+step:414/4150 train_time:31697ms step_avg:76.56ms
+step:415/4150 train_time:31820ms step_avg:76.67ms
+step:416/4150 train_time:31939ms step_avg:76.78ms
+step:417/4150 train_time:32062ms step_avg:76.89ms
+step:418/4150 train_time:32181ms step_avg:76.99ms
+step:419/4150 train_time:32304ms step_avg:77.10ms
+step:420/4150 train_time:32425ms step_avg:77.20ms
+step:421/4150 train_time:32547ms step_avg:77.31ms
+step:422/4150 train_time:32668ms step_avg:77.41ms
+step:423/4150 train_time:32790ms step_avg:77.52ms
+step:424/4150 train_time:32912ms step_avg:77.62ms
+step:425/4150 train_time:33036ms step_avg:77.73ms
+step:426/4150 train_time:33158ms step_avg:77.84ms
+step:427/4150 train_time:33281ms step_avg:77.94ms
+step:428/4150 train_time:33401ms step_avg:78.04ms
+step:429/4150 train_time:33523ms step_avg:78.14ms
+step:430/4150 train_time:33644ms step_avg:78.24ms
+step:431/4150 train_time:33766ms step_avg:78.34ms
+step:432/4150 train_time:33886ms step_avg:78.44ms
+step:433/4150 train_time:34008ms step_avg:78.54ms
+step:434/4150 train_time:34128ms step_avg:78.64ms
+step:435/4150 train_time:34250ms step_avg:78.74ms
+step:436/4150 train_time:34371ms step_avg:78.83ms
+step:437/4150 train_time:34494ms step_avg:78.93ms
+step:438/4150 train_time:34615ms step_avg:79.03ms
+step:439/4150 train_time:34738ms step_avg:79.13ms
+step:440/4150 train_time:34859ms step_avg:79.22ms
+step:441/4150 train_time:34980ms step_avg:79.32ms
+step:442/4150 train_time:35100ms step_avg:79.41ms
+step:443/4150 train_time:35221ms step_avg:79.51ms
+step:444/4150 train_time:35341ms step_avg:79.60ms
+step:445/4150 train_time:35464ms step_avg:79.69ms
+step:446/4150 train_time:35584ms step_avg:79.78ms
+step:447/4150 train_time:35706ms step_avg:79.88ms
+step:448/4150 train_time:35827ms step_avg:79.97ms
+step:449/4150 train_time:35949ms step_avg:80.06ms
+step:450/4150 train_time:36069ms step_avg:80.15ms
+step:451/4150 train_time:36191ms step_avg:80.25ms
+step:452/4150 train_time:36311ms step_avg:80.33ms
+step:453/4150 train_time:36433ms step_avg:80.43ms
+step:454/4150 train_time:36555ms step_avg:80.52ms
+step:455/4150 train_time:36678ms step_avg:80.61ms
+step:456/4150 train_time:36799ms step_avg:80.70ms
+step:457/4150 train_time:36922ms step_avg:80.79ms
+step:458/4150 train_time:37042ms step_avg:80.88ms
+step:459/4150 train_time:37163ms step_avg:80.97ms
+step:460/4150 train_time:37283ms step_avg:81.05ms
+step:461/4150 train_time:37406ms step_avg:81.14ms
+step:462/4150 train_time:37527ms step_avg:81.23ms
+step:463/4150 train_time:37650ms step_avg:81.32ms
+step:464/4150 train_time:37770ms step_avg:81.40ms
+step:465/4150 train_time:37892ms step_avg:81.49ms
+step:466/4150 train_time:38013ms step_avg:81.57ms
+step:467/4150 train_time:38134ms step_avg:81.66ms
+step:468/4150 train_time:38255ms step_avg:81.74ms
+step:469/4150 train_time:38379ms step_avg:81.83ms
+step:470/4150 train_time:38500ms step_avg:81.91ms
+step:471/4150 train_time:38622ms step_avg:82.00ms
+step:472/4150 train_time:38742ms step_avg:82.08ms
+step:473/4150 train_time:38863ms step_avg:82.16ms
+step:474/4150 train_time:38985ms step_avg:82.25ms
+step:475/4150 train_time:39107ms step_avg:82.33ms
+step:476/4150 train_time:39227ms step_avg:82.41ms
+step:477/4150 train_time:39350ms step_avg:82.49ms
+step:478/4150 train_time:39469ms step_avg:82.57ms
+step:479/4150 train_time:39591ms step_avg:82.65ms
+step:480/4150 train_time:39712ms step_avg:82.73ms
+step:481/4150 train_time:39834ms step_avg:82.82ms
+step:482/4150 train_time:39955ms step_avg:82.89ms
+step:483/4150 train_time:40077ms step_avg:82.98ms
+step:484/4150 train_time:40197ms step_avg:83.05ms
+step:485/4150 train_time:40319ms step_avg:83.13ms
+step:486/4150 train_time:40440ms step_avg:83.21ms
+step:487/4150 train_time:40562ms step_avg:83.29ms
+step:488/4150 train_time:40682ms step_avg:83.36ms
+step:489/4150 train_time:40805ms step_avg:83.44ms
+step:490/4150 train_time:40924ms step_avg:83.52ms
+step:491/4150 train_time:41046ms step_avg:83.60ms
+step:492/4150 train_time:41166ms step_avg:83.67ms
+step:493/4150 train_time:41286ms step_avg:83.74ms
+step:494/4150 train_time:41406ms step_avg:83.82ms
+step:495/4150 train_time:41528ms step_avg:83.90ms
+step:496/4150 train_time:41648ms step_avg:83.97ms
+step:497/4150 train_time:41769ms step_avg:84.04ms
+step:498/4150 train_time:41890ms step_avg:84.12ms
+step:499/4150 train_time:42012ms step_avg:84.19ms
+step:500/4150 train_time:42132ms step_avg:84.26ms
+step:500/4150 val_loss:3.9106 train_time:42244ms step_avg:84.49ms
+step:501/4150 train_time:42265ms step_avg:84.36ms
+step:502/4150 train_time:42376ms step_avg:84.41ms
+step:503/4150 train_time:42501ms step_avg:84.49ms
+step:504/4150 train_time:42625ms step_avg:84.57ms
+step:505/4150 train_time:42747ms step_avg:84.65ms
+step:506/4150 train_time:42866ms step_avg:84.72ms
+step:507/4150 train_time:42986ms step_avg:84.78ms
+step:508/4150 train_time:43105ms step_avg:84.85ms
+step:509/4150 train_time:43228ms step_avg:84.93ms
+step:510/4150 train_time:43350ms step_avg:85.00ms
+step:511/4150 train_time:43474ms step_avg:85.08ms
+step:512/4150 train_time:43597ms step_avg:85.15ms
+step:513/4150 train_time:43719ms step_avg:85.22ms
+step:514/4150 train_time:43839ms step_avg:85.29ms
+step:515/4150 train_time:43959ms step_avg:85.36ms
+step:516/4150 train_time:44079ms step_avg:85.42ms
+step:517/4150 train_time:44201ms step_avg:85.50ms
+step:518/4150 train_time:44321ms step_avg:85.56ms
+step:519/4150 train_time:44444ms step_avg:85.63ms
+step:520/4150 train_time:44564ms step_avg:85.70ms
+step:521/4150 train_time:44686ms step_avg:85.77ms
+step:522/4150 train_time:44807ms step_avg:85.84ms
+step:523/4150 train_time:44928ms step_avg:85.90ms
+step:524/4150 train_time:45049ms step_avg:85.97ms
+step:525/4150 train_time:45173ms step_avg:86.04ms
+step:526/4150 train_time:45294ms step_avg:86.11ms
+step:527/4150 train_time:45416ms step_avg:86.18ms
+step:528/4150 train_time:45537ms step_avg:86.24ms
+step:529/4150 train_time:45659ms step_avg:86.31ms
+step:530/4150 train_time:45780ms step_avg:86.38ms
+step:531/4150 train_time:45902ms step_avg:86.44ms
+step:532/4150 train_time:46022ms step_avg:86.51ms
+step:533/4150 train_time:46144ms step_avg:86.57ms
+step:534/4150 train_time:46264ms step_avg:86.64ms
+step:535/4150 train_time:46387ms step_avg:86.70ms
+step:536/4150 train_time:46508ms step_avg:86.77ms
+step:537/4150 train_time:46632ms step_avg:86.84ms
+step:538/4150 train_time:46753ms step_avg:86.90ms
+step:539/4150 train_time:46875ms step_avg:86.97ms
+step:540/4150 train_time:46996ms step_avg:87.03ms
+step:541/4150 train_time:47118ms step_avg:87.09ms
+step:542/4150 train_time:47238ms step_avg:87.15ms
+step:543/4150 train_time:47360ms step_avg:87.22ms
+step:544/4150 train_time:47480ms step_avg:87.28ms
+step:545/4150 train_time:47602ms step_avg:87.34ms
+step:546/4150 train_time:47722ms step_avg:87.40ms
+step:547/4150 train_time:47845ms step_avg:87.47ms
+step:548/4150 train_time:47964ms step_avg:87.53ms
+step:549/4150 train_time:48085ms step_avg:87.59ms
+step:550/4150 train_time:48207ms step_avg:87.65ms
+step:551/4150 train_time:48329ms step_avg:87.71ms
+step:552/4150 train_time:48449ms step_avg:87.77ms
+step:553/4150 train_time:48572ms step_avg:87.83ms
+step:554/4150 train_time:48694ms step_avg:87.90ms
+step:555/4150 train_time:48815ms step_avg:87.96ms
+step:556/4150 train_time:48936ms step_avg:88.01ms
+step:557/4150 train_time:49058ms step_avg:88.07ms
+step:558/4150 train_time:49177ms step_avg:88.13ms
+step:559/4150 train_time:49299ms step_avg:88.19ms
+step:560/4150 train_time:49419ms step_avg:88.25ms
+step:561/4150 train_time:49542ms step_avg:88.31ms
+step:562/4150 train_time:49663ms step_avg:88.37ms
+step:563/4150 train_time:49785ms step_avg:88.43ms
+step:564/4150 train_time:49905ms step_avg:88.48ms
+step:565/4150 train_time:50027ms step_avg:88.54ms
+step:566/4150 train_time:50148ms step_avg:88.60ms
+step:567/4150 train_time:50270ms step_avg:88.66ms
+step:568/4150 train_time:50391ms step_avg:88.72ms
+step:569/4150 train_time:50513ms step_avg:88.77ms
+step:570/4150 train_time:50634ms step_avg:88.83ms
+step:571/4150 train_time:50758ms step_avg:88.89ms
+step:572/4150 train_time:50877ms step_avg:88.95ms
+step:573/4150 train_time:50999ms step_avg:89.00ms
+step:574/4150 train_time:51119ms step_avg:89.06ms
+step:575/4150 train_time:51241ms step_avg:89.11ms
+step:576/4150 train_time:51363ms step_avg:89.17ms
+step:577/4150 train_time:51485ms step_avg:89.23ms
+step:578/4150 train_time:51605ms step_avg:89.28ms
+step:579/4150 train_time:51728ms step_avg:89.34ms
+step:580/4150 train_time:51848ms step_avg:89.39ms
+step:581/4150 train_time:51971ms step_avg:89.45ms
+step:582/4150 train_time:52091ms step_avg:89.50ms
+step:583/4150 train_time:52214ms step_avg:89.56ms
+step:584/4150 train_time:52336ms step_avg:89.62ms
+step:585/4150 train_time:52459ms step_avg:89.67ms
+step:586/4150 train_time:52578ms step_avg:89.72ms
+step:587/4150 train_time:52699ms step_avg:89.78ms
+step:588/4150 train_time:52819ms step_avg:89.83ms
+step:589/4150 train_time:52942ms step_avg:89.89ms
+step:590/4150 train_time:53063ms step_avg:89.94ms
+step:591/4150 train_time:53186ms step_avg:89.99ms
+step:592/4150 train_time:53306ms step_avg:90.04ms
+step:593/4150 train_time:53429ms step_avg:90.10ms
+step:594/4150 train_time:53549ms step_avg:90.15ms
+step:595/4150 train_time:53671ms step_avg:90.20ms
+step:596/4150 train_time:53791ms step_avg:90.25ms
+step:597/4150 train_time:53913ms step_avg:90.31ms
+step:598/4150 train_time:54032ms step_avg:90.36ms
+step:599/4150 train_time:54155ms step_avg:90.41ms
+step:600/4150 train_time:54275ms step_avg:90.46ms
+step:601/4150 train_time:54396ms step_avg:90.51ms
+step:602/4150 train_time:54518ms step_avg:90.56ms
+step:603/4150 train_time:54640ms step_avg:90.61ms
+step:604/4150 train_time:54761ms step_avg:90.66ms
+step:605/4150 train_time:54881ms step_avg:90.71ms
+step:606/4150 train_time:55001ms step_avg:90.76ms
+step:607/4150 train_time:55123ms step_avg:90.81ms
+step:608/4150 train_time:55243ms step_avg:90.86ms
+step:609/4150 train_time:55364ms step_avg:90.91ms
+step:610/4150 train_time:55484ms step_avg:90.96ms
+step:611/4150 train_time:55605ms step_avg:91.01ms
+step:612/4150 train_time:55726ms step_avg:91.06ms
+step:613/4150 train_time:55849ms step_avg:91.11ms
+step:614/4150 train_time:55970ms step_avg:91.16ms
+step:615/4150 train_time:56094ms step_avg:91.21ms
+step:616/4150 train_time:56214ms step_avg:91.26ms
+step:617/4150 train_time:56336ms step_avg:91.31ms
+step:618/4150 train_time:56456ms step_avg:91.35ms
+step:619/4150 train_time:56577ms step_avg:91.40ms
+step:620/4150 train_time:56696ms step_avg:91.45ms
+step:621/4150 train_time:56818ms step_avg:91.50ms
+step:622/4150 train_time:56940ms step_avg:91.54ms
+step:623/4150 train_time:57062ms step_avg:91.59ms
+step:624/4150 train_time:57181ms step_avg:91.64ms
+step:625/4150 train_time:57303ms step_avg:91.68ms
+step:626/4150 train_time:57423ms step_avg:91.73ms
+step:627/4150 train_time:57544ms step_avg:91.78ms
+step:628/4150 train_time:57663ms step_avg:91.82ms
+step:629/4150 train_time:57786ms step_avg:91.87ms
+step:630/4150 train_time:57906ms step_avg:91.91ms
+step:631/4150 train_time:58030ms step_avg:91.96ms
+step:632/4150 train_time:58150ms step_avg:92.01ms
+step:633/4150 train_time:58272ms step_avg:92.06ms
+step:634/4150 train_time:58393ms step_avg:92.10ms
+step:635/4150 train_time:58515ms step_avg:92.15ms
+step:636/4150 train_time:58636ms step_avg:92.19ms
+step:637/4150 train_time:58758ms step_avg:92.24ms
+step:638/4150 train_time:58879ms step_avg:92.29ms
+step:639/4150 train_time:59002ms step_avg:92.33ms
+step:640/4150 train_time:59121ms step_avg:92.38ms
+step:641/4150 train_time:59243ms step_avg:92.42ms
+step:642/4150 train_time:59363ms step_avg:92.47ms
+step:643/4150 train_time:59484ms step_avg:92.51ms
+step:644/4150 train_time:59604ms step_avg:92.55ms
+step:645/4150 train_time:59726ms step_avg:92.60ms
+step:646/4150 train_time:59847ms step_avg:92.64ms
+step:647/4150 train_time:59969ms step_avg:92.69ms
+step:648/4150 train_time:60090ms step_avg:92.73ms
+step:649/4150 train_time:60212ms step_avg:92.78ms
+step:650/4150 train_time:60333ms step_avg:92.82ms
+step:651/4150 train_time:60455ms step_avg:92.86ms
+step:652/4150 train_time:60575ms step_avg:92.91ms
+step:653/4150 train_time:60698ms step_avg:92.95ms
+step:654/4150 train_time:60818ms step_avg:92.99ms
+step:655/4150 train_time:60941ms step_avg:93.04ms
+step:656/4150 train_time:61061ms step_avg:93.08ms
+step:657/4150 train_time:61182ms step_avg:93.12ms
+step:658/4150 train_time:61303ms step_avg:93.17ms
+step:659/4150 train_time:61425ms step_avg:93.21ms
+step:660/4150 train_time:61544ms step_avg:93.25ms
+step:661/4150 train_time:61665ms step_avg:93.29ms
+step:662/4150 train_time:61786ms step_avg:93.33ms
+step:663/4150 train_time:61908ms step_avg:93.38ms
+step:664/4150 train_time:62030ms step_avg:93.42ms
+step:665/4150 train_time:62151ms step_avg:93.46ms
+step:666/4150 train_time:62272ms step_avg:93.50ms
+step:667/4150 train_time:62395ms step_avg:93.55ms
+step:668/4150 train_time:62516ms step_avg:93.59ms
+step:669/4150 train_time:62639ms step_avg:93.63ms
+step:670/4150 train_time:62759ms step_avg:93.67ms
+step:671/4150 train_time:62880ms step_avg:93.71ms
+step:672/4150 train_time:63001ms step_avg:93.75ms
+step:673/4150 train_time:63122ms step_avg:93.79ms
+step:674/4150 train_time:63243ms step_avg:93.83ms
+step:675/4150 train_time:63368ms step_avg:93.88ms
+step:676/4150 train_time:63487ms step_avg:93.92ms
+step:677/4150 train_time:63609ms step_avg:93.96ms
+step:678/4150 train_time:63730ms step_avg:94.00ms
+step:679/4150 train_time:63855ms step_avg:94.04ms
+step:680/4150 train_time:63974ms step_avg:94.08ms
+step:681/4150 train_time:64095ms step_avg:94.12ms
+step:682/4150 train_time:64215ms step_avg:94.16ms
+step:683/4150 train_time:64337ms step_avg:94.20ms
+step:684/4150 train_time:64457ms step_avg:94.24ms
+step:685/4150 train_time:64578ms step_avg:94.28ms
+step:686/4150 train_time:64698ms step_avg:94.31ms
+step:687/4150 train_time:64820ms step_avg:94.35ms
+step:688/4150 train_time:64942ms step_avg:94.39ms
+step:689/4150 train_time:65067ms step_avg:94.44ms
+step:690/4150 train_time:65247ms step_avg:94.56ms
+step:691/4150 train_time:65424ms step_avg:94.68ms
+step:692/4150 train_time:65604ms step_avg:94.80ms
+step:693/4150 train_time:65782ms step_avg:94.92ms
+step:694/4150 train_time:65962ms step_avg:95.05ms
+step:695/4150 train_time:66141ms step_avg:95.17ms
+step:696/4150 train_time:66323ms step_avg:95.29ms
+step:697/4150 train_time:66501ms step_avg:95.41ms
+step:698/4150 train_time:66680ms step_avg:95.53ms
+step:699/4150 train_time:66860ms step_avg:95.65ms
+step:700/4150 train_time:67040ms step_avg:95.77ms
+step:701/4150 train_time:67220ms step_avg:95.89ms
+step:702/4150 train_time:67398ms step_avg:96.01ms
+step:703/4150 train_time:67576ms step_avg:96.13ms
+step:704/4150 train_time:67756ms step_avg:96.24ms
+step:705/4150 train_time:67934ms step_avg:96.36ms
+step:706/4150 train_time:68116ms step_avg:96.48ms
+step:707/4150 train_time:68296ms step_avg:96.60ms
+step:708/4150 train_time:68477ms step_avg:96.72ms
+step:709/4150 train_time:68655ms step_avg:96.83ms
+step:710/4150 train_time:68837ms step_avg:96.95ms
+step:711/4150 train_time:69016ms step_avg:97.07ms
+step:712/4150 train_time:69197ms step_avg:97.19ms
+step:713/4150 train_time:69375ms step_avg:97.30ms
+step:714/4150 train_time:69553ms step_avg:97.41ms
+step:715/4150 train_time:69732ms step_avg:97.53ms
+step:716/4150 train_time:69913ms step_avg:97.64ms
+step:717/4150 train_time:70093ms step_avg:97.76ms
+step:718/4150 train_time:70273ms step_avg:97.87ms
+step:719/4150 train_time:70452ms step_avg:97.99ms
+step:720/4150 train_time:70632ms step_avg:98.10ms
+step:721/4150 train_time:70812ms step_avg:98.21ms
+step:722/4150 train_time:70990ms step_avg:98.32ms
+step:723/4150 train_time:71169ms step_avg:98.44ms
+step:724/4150 train_time:71350ms step_avg:98.55ms
+step:725/4150 train_time:71527ms step_avg:98.66ms
+step:726/4150 train_time:71706ms step_avg:98.77ms
+step:727/4150 train_time:71884ms step_avg:98.88ms
+step:728/4150 train_time:72063ms step_avg:98.99ms
+step:729/4150 train_time:72242ms step_avg:99.10ms
+step:730/4150 train_time:72422ms step_avg:99.21ms
+step:731/4150 train_time:72599ms step_avg:99.32ms
+step:732/4150 train_time:72779ms step_avg:99.42ms
+step:733/4150 train_time:72956ms step_avg:99.53ms
+step:734/4150 train_time:73136ms step_avg:99.64ms
+step:735/4150 train_time:73316ms step_avg:99.75ms
+step:736/4150 train_time:73498ms step_avg:99.86ms
+step:737/4150 train_time:73678ms step_avg:99.97ms
+step:738/4150 train_time:73859ms step_avg:100.08ms
+step:739/4150 train_time:74039ms step_avg:100.19ms
+step:740/4150 train_time:74219ms step_avg:100.30ms
+step:741/4150 train_time:74399ms step_avg:100.40ms
+step:742/4150 train_time:74578ms step_avg:100.51ms
+step:743/4150 train_time:74756ms step_avg:100.61ms
+step:744/4150 train_time:74938ms step_avg:100.72ms
+step:745/4150 train_time:75119ms step_avg:100.83ms
+step:746/4150 train_time:75298ms step_avg:100.94ms
+step:747/4150 train_time:75476ms step_avg:101.04ms
+step:748/4150 train_time:75656ms step_avg:101.14ms
+step:749/4150 train_time:75835ms step_avg:101.25ms
+step:750/4150 train_time:76018ms step_avg:101.36ms
+step:750/4150 val_loss:3.5764 train_time:76182ms step_avg:101.58ms
+step:751/4150 train_time:76204ms step_avg:101.47ms
+step:752/4150 train_time:76379ms step_avg:101.57ms
+step:753/4150 train_time:76563ms step_avg:101.68ms
+step:754/4150 train_time:76743ms step_avg:101.78ms
+step:755/4150 train_time:76920ms step_avg:101.88ms
+step:756/4150 train_time:77097ms step_avg:101.98ms
+step:757/4150 train_time:77275ms step_avg:102.08ms
+step:758/4150 train_time:77461ms step_avg:102.19ms
+step:759/4150 train_time:77641ms step_avg:102.29ms
+step:760/4150 train_time:77821ms step_avg:102.40ms
+step:761/4150 train_time:77998ms step_avg:102.49ms
+step:762/4150 train_time:78177ms step_avg:102.59ms
+step:763/4150 train_time:78355ms step_avg:102.69ms
+step:764/4150 train_time:78539ms step_avg:102.80ms
+step:765/4150 train_time:78719ms step_avg:102.90ms
+step:766/4150 train_time:78898ms step_avg:103.00ms
+step:767/4150 train_time:79077ms step_avg:103.10ms
+step:768/4150 train_time:79254ms step_avg:103.20ms
+step:769/4150 train_time:79434ms step_avg:103.30ms
+step:770/4150 train_time:79616ms step_avg:103.40ms
+step:771/4150 train_time:79795ms step_avg:103.49ms
+step:772/4150 train_time:79972ms step_avg:103.59ms
+step:773/4150 train_time:80151ms step_avg:103.69ms
+step:774/4150 train_time:80331ms step_avg:103.79ms
+step:775/4150 train_time:80510ms step_avg:103.88ms
+step:776/4150 train_time:80694ms step_avg:103.99ms
+step:777/4150 train_time:80873ms step_avg:104.08ms
+step:778/4150 train_time:81054ms step_avg:104.18ms
+step:779/4150 train_time:81232ms step_avg:104.28ms
+step:780/4150 train_time:81413ms step_avg:104.38ms
+step:781/4150 train_time:81593ms step_avg:104.47ms
+step:782/4150 train_time:81775ms step_avg:104.57ms
+step:783/4150 train_time:81955ms step_avg:104.67ms
+step:784/4150 train_time:82135ms step_avg:104.76ms
+step:785/4150 train_time:82314ms step_avg:104.86ms
+step:786/4150 train_time:82492ms step_avg:104.95ms
+step:787/4150 train_time:82671ms step_avg:105.05ms
+step:788/4150 train_time:82853ms step_avg:105.14ms
+step:789/4150 train_time:83031ms step_avg:105.24ms
+step:790/4150 train_time:83211ms step_avg:105.33ms
+step:791/4150 train_time:83392ms step_avg:105.43ms
+step:792/4150 train_time:83573ms step_avg:105.52ms
+step:793/4150 train_time:83752ms step_avg:105.61ms
+step:794/4150 train_time:83933ms step_avg:105.71ms
+step:795/4150 train_time:84111ms step_avg:105.80ms
+step:796/4150 train_time:84289ms step_avg:105.89ms
+step:797/4150 train_time:84468ms step_avg:105.98ms
+step:798/4150 train_time:84648ms step_avg:106.08ms
+step:799/4150 train_time:84826ms step_avg:106.17ms
+step:800/4150 train_time:85005ms step_avg:106.26ms
+step:801/4150 train_time:85183ms step_avg:106.35ms
+step:802/4150 train_time:85363ms step_avg:106.44ms
+step:803/4150 train_time:85542ms step_avg:106.53ms
+step:804/4150 train_time:85721ms step_avg:106.62ms
+step:805/4150 train_time:85901ms step_avg:106.71ms
+step:806/4150 train_time:86080ms step_avg:106.80ms
+step:807/4150 train_time:86260ms step_avg:106.89ms
+step:808/4150 train_time:86441ms step_avg:106.98ms
+step:809/4150 train_time:86619ms step_avg:107.07ms
+step:810/4150 train_time:86799ms step_avg:107.16ms
+step:811/4150 train_time:86978ms step_avg:107.25ms
+step:812/4150 train_time:87159ms step_avg:107.34ms
+step:813/4150 train_time:87337ms step_avg:107.43ms
+step:814/4150 train_time:87517ms step_avg:107.52ms
+step:815/4150 train_time:87696ms step_avg:107.60ms
+step:816/4150 train_time:87875ms step_avg:107.69ms
+step:817/4150 train_time:88055ms step_avg:107.78ms
+step:818/4150 train_time:88235ms step_avg:107.87ms
+step:819/4150 train_time:88414ms step_avg:107.95ms
+step:820/4150 train_time:88593ms step_avg:108.04ms
+step:821/4150 train_time:88771ms step_avg:108.13ms
+step:822/4150 train_time:88952ms step_avg:108.21ms
+step:823/4150 train_time:89133ms step_avg:108.30ms
+step:824/4150 train_time:89313ms step_avg:108.39ms
+step:825/4150 train_time:89492ms step_avg:108.47ms
+step:826/4150 train_time:89672ms step_avg:108.56ms
+step:827/4150 train_time:89850ms step_avg:108.65ms
+step:828/4150 train_time:90031ms step_avg:108.73ms
+step:829/4150 train_time:90211ms step_avg:108.82ms
+step:830/4150 train_time:90393ms step_avg:108.91ms
+step:831/4150 train_time:90571ms step_avg:108.99ms
+step:832/4150 train_time:90752ms step_avg:109.08ms
+step:833/4150 train_time:90930ms step_avg:109.16ms
+step:834/4150 train_time:91109ms step_avg:109.24ms
+step:835/4150 train_time:91288ms step_avg:109.33ms
+step:836/4150 train_time:91467ms step_avg:109.41ms
+step:837/4150 train_time:91645ms step_avg:109.49ms
+step:838/4150 train_time:91825ms step_avg:109.58ms
+step:839/4150 train_time:92004ms step_avg:109.66ms
+step:840/4150 train_time:92183ms step_avg:109.74ms
+step:841/4150 train_time:92361ms step_avg:109.82ms
+step:842/4150 train_time:92541ms step_avg:109.91ms
+step:843/4150 train_time:92718ms step_avg:109.99ms
+step:844/4150 train_time:92899ms step_avg:110.07ms
+step:845/4150 train_time:93076ms step_avg:110.15ms
+step:846/4150 train_time:93257ms step_avg:110.23ms
+step:847/4150 train_time:93436ms step_avg:110.31ms
+step:848/4150 train_time:93617ms step_avg:110.40ms
+step:849/4150 train_time:93795ms step_avg:110.48ms
+step:850/4150 train_time:93976ms step_avg:110.56ms
+step:851/4150 train_time:94155ms step_avg:110.64ms
+step:852/4150 train_time:94337ms step_avg:110.72ms
+step:853/4150 train_time:94514ms step_avg:110.80ms
+step:854/4150 train_time:94693ms step_avg:110.88ms
+step:855/4150 train_time:94871ms step_avg:110.96ms
+step:856/4150 train_time:95053ms step_avg:111.04ms
+step:857/4150 train_time:95232ms step_avg:111.12ms
+step:858/4150 train_time:95412ms step_avg:111.20ms
+step:859/4150 train_time:95590ms step_avg:111.28ms
+step:860/4150 train_time:95769ms step_avg:111.36ms
+step:861/4150 train_time:95947ms step_avg:111.44ms
+step:862/4150 train_time:96129ms step_avg:111.52ms
+step:863/4150 train_time:96306ms step_avg:111.59ms
+step:864/4150 train_time:96486ms step_avg:111.67ms
+step:865/4150 train_time:96664ms step_avg:111.75ms
+step:866/4150 train_time:96843ms step_avg:111.83ms
+step:867/4150 train_time:97021ms step_avg:111.90ms
+step:868/4150 train_time:97201ms step_avg:111.98ms
+step:869/4150 train_time:97380ms step_avg:112.06ms
+step:870/4150 train_time:97560ms step_avg:112.14ms
+step:871/4150 train_time:97740ms step_avg:112.22ms
+step:872/4150 train_time:97918ms step_avg:112.29ms
+step:873/4150 train_time:98098ms step_avg:112.37ms
+step:874/4150 train_time:98279ms step_avg:112.45ms
+step:875/4150 train_time:98459ms step_avg:112.52ms
+step:876/4150 train_time:98638ms step_avg:112.60ms
+step:877/4150 train_time:98817ms step_avg:112.68ms
+step:878/4150 train_time:98995ms step_avg:112.75ms
+step:879/4150 train_time:99173ms step_avg:112.82ms
+step:880/4150 train_time:99354ms step_avg:112.90ms
+step:881/4150 train_time:99534ms step_avg:112.98ms
+step:882/4150 train_time:99713ms step_avg:113.05ms
+step:883/4150 train_time:99892ms step_avg:113.13ms
+step:884/4150 train_time:100072ms step_avg:113.20ms
+step:885/4150 train_time:100250ms step_avg:113.28ms
+step:886/4150 train_time:100432ms step_avg:113.35ms
+step:887/4150 train_time:100611ms step_avg:113.43ms
+step:888/4150 train_time:100792ms step_avg:113.50ms
+step:889/4150 train_time:100970ms step_avg:113.58ms
+step:890/4150 train_time:101150ms step_avg:113.65ms
+step:891/4150 train_time:101328ms step_avg:113.72ms
+step:892/4150 train_time:101509ms step_avg:113.80ms
+step:893/4150 train_time:101688ms step_avg:113.87ms
+step:894/4150 train_time:101869ms step_avg:113.95ms
+step:895/4150 train_time:102046ms step_avg:114.02ms
+step:896/4150 train_time:102226ms step_avg:114.09ms
+step:897/4150 train_time:102404ms step_avg:114.16ms
+step:898/4150 train_time:102587ms step_avg:114.24ms
+step:899/4150 train_time:102764ms step_avg:114.31ms
+step:900/4150 train_time:102945ms step_avg:114.38ms
+step:901/4150 train_time:103122ms step_avg:114.45ms
+step:902/4150 train_time:103301ms step_avg:114.52ms
+step:903/4150 train_time:103480ms step_avg:114.60ms
+step:904/4150 train_time:103659ms step_avg:114.67ms
+step:905/4150 train_time:103841ms step_avg:114.74ms
+step:906/4150 train_time:104023ms step_avg:114.82ms
+step:907/4150 train_time:104201ms step_avg:114.89ms
+step:908/4150 train_time:104379ms step_avg:114.95ms
+step:909/4150 train_time:104557ms step_avg:115.02ms
+step:910/4150 train_time:104738ms step_avg:115.10ms
+step:911/4150 train_time:104918ms step_avg:115.17ms
+step:912/4150 train_time:105097ms step_avg:115.24ms
+step:913/4150 train_time:105277ms step_avg:115.31ms
+step:914/4150 train_time:105457ms step_avg:115.38ms
+step:915/4150 train_time:105635ms step_avg:115.45ms
+step:916/4150 train_time:105816ms step_avg:115.52ms
+step:917/4150 train_time:105993ms step_avg:115.59ms
+step:918/4150 train_time:106174ms step_avg:115.66ms
+step:919/4150 train_time:106353ms step_avg:115.73ms
+step:920/4150 train_time:106533ms step_avg:115.80ms
+step:921/4150 train_time:106714ms step_avg:115.87ms
+step:922/4150 train_time:106896ms step_avg:115.94ms
+step:923/4150 train_time:107074ms step_avg:116.01ms
+step:924/4150 train_time:107253ms step_avg:116.08ms
+step:925/4150 train_time:107431ms step_avg:116.14ms
+step:926/4150 train_time:107613ms step_avg:116.21ms
+step:927/4150 train_time:107793ms step_avg:116.28ms
+step:928/4150 train_time:107974ms step_avg:116.35ms
+step:929/4150 train_time:108154ms step_avg:116.42ms
+step:930/4150 train_time:108334ms step_avg:116.49ms
+step:931/4150 train_time:108512ms step_avg:116.55ms
+step:932/4150 train_time:108691ms step_avg:116.62ms
+step:933/4150 train_time:108871ms step_avg:116.69ms
+step:934/4150 train_time:109053ms step_avg:116.76ms
+step:935/4150 train_time:109230ms step_avg:116.82ms
+step:936/4150 train_time:109409ms step_avg:116.89ms
+step:937/4150 train_time:109590ms step_avg:116.96ms
+step:938/4150 train_time:109768ms step_avg:117.02ms
+step:939/4150 train_time:109948ms step_avg:117.09ms
+step:940/4150 train_time:110131ms step_avg:117.16ms
+step:941/4150 train_time:110309ms step_avg:117.22ms
+step:942/4150 train_time:110487ms step_avg:117.29ms
+step:943/4150 train_time:110664ms step_avg:117.35ms
+step:944/4150 train_time:110844ms step_avg:117.42ms
+step:945/4150 train_time:111022ms step_avg:117.48ms
+step:946/4150 train_time:111203ms step_avg:117.55ms
+step:947/4150 train_time:111380ms step_avg:117.61ms
+step:948/4150 train_time:111559ms step_avg:117.68ms
+step:949/4150 train_time:111739ms step_avg:117.74ms
+step:950/4150 train_time:111917ms step_avg:117.81ms
+step:951/4150 train_time:112096ms step_avg:117.87ms
+step:952/4150 train_time:112278ms step_avg:117.94ms
+step:953/4150 train_time:112455ms step_avg:118.00ms
+step:954/4150 train_time:112636ms step_avg:118.07ms
+step:955/4150 train_time:112813ms step_avg:118.13ms
+step:956/4150 train_time:112995ms step_avg:118.20ms
+step:957/4150 train_time:113173ms step_avg:118.26ms
+step:958/4150 train_time:113354ms step_avg:118.32ms
+step:959/4150 train_time:113532ms step_avg:118.39ms
+step:960/4150 train_time:113710ms step_avg:118.45ms
+step:961/4150 train_time:113888ms step_avg:118.51ms
+step:962/4150 train_time:114070ms step_avg:118.58ms
+step:963/4150 train_time:114249ms step_avg:118.64ms
+step:964/4150 train_time:114429ms step_avg:118.70ms
+step:965/4150 train_time:114608ms step_avg:118.76ms
+step:966/4150 train_time:114787ms step_avg:118.83ms
+step:967/4150 train_time:114966ms step_avg:118.89ms
+step:968/4150 train_time:115145ms step_avg:118.95ms
+step:969/4150 train_time:115324ms step_avg:119.01ms
+step:970/4150 train_time:115503ms step_avg:119.07ms
+step:971/4150 train_time:115682ms step_avg:119.14ms
+step:972/4150 train_time:115862ms step_avg:119.20ms
+step:973/4150 train_time:116041ms step_avg:119.26ms
+step:974/4150 train_time:116221ms step_avg:119.32ms
+step:975/4150 train_time:116400ms step_avg:119.38ms
+step:976/4150 train_time:116579ms step_avg:119.45ms
+step:977/4150 train_time:116758ms step_avg:119.51ms
+step:978/4150 train_time:116940ms step_avg:119.57ms
+step:979/4150 train_time:117121ms step_avg:119.63ms
+step:980/4150 train_time:117302ms step_avg:119.70ms
+step:981/4150 train_time:117479ms step_avg:119.75ms
+step:982/4150 train_time:117659ms step_avg:119.82ms
+step:983/4150 train_time:117837ms step_avg:119.87ms
+step:984/4150 train_time:118019ms step_avg:119.94ms
+step:985/4150 train_time:118198ms step_avg:120.00ms
+step:986/4150 train_time:118376ms step_avg:120.06ms
+step:987/4150 train_time:118554ms step_avg:120.12ms
+step:988/4150 train_time:118732ms step_avg:120.17ms
+step:989/4150 train_time:118911ms step_avg:120.23ms
+step:990/4150 train_time:119092ms step_avg:120.30ms
+step:991/4150 train_time:119273ms step_avg:120.36ms
+step:992/4150 train_time:119456ms step_avg:120.42ms
+step:993/4150 train_time:119635ms step_avg:120.48ms
+step:994/4150 train_time:119814ms step_avg:120.54ms
+step:995/4150 train_time:119992ms step_avg:120.59ms
+step:996/4150 train_time:120172ms step_avg:120.65ms
+step:997/4150 train_time:120352ms step_avg:120.71ms
+step:998/4150 train_time:120533ms step_avg:120.77ms
+step:999/4150 train_time:120711ms step_avg:120.83ms
+step:1000/4150 train_time:120890ms step_avg:120.89ms
+step:1000/4150 val_loss:3.4422 train_time:121054ms step_avg:121.05ms
+step:1001/4150 train_time:121076ms step_avg:120.95ms
+step:1002/4150 train_time:121250ms step_avg:121.01ms
+step:1003/4150 train_time:121432ms step_avg:121.07ms
+step:1004/4150 train_time:121612ms step_avg:121.13ms
+step:1005/4150 train_time:121790ms step_avg:121.18ms
+step:1006/4150 train_time:121967ms step_avg:121.24ms
+step:1007/4150 train_time:122146ms step_avg:121.30ms
+step:1008/4150 train_time:122327ms step_avg:121.36ms
+step:1009/4150 train_time:122508ms step_avg:121.41ms
+step:1010/4150 train_time:122686ms step_avg:121.47ms
+step:1011/4150 train_time:122865ms step_avg:121.53ms
+step:1012/4150 train_time:123045ms step_avg:121.59ms
+step:1013/4150 train_time:123223ms step_avg:121.64ms
+step:1014/4150 train_time:123406ms step_avg:121.70ms
+step:1015/4150 train_time:123585ms step_avg:121.76ms
+step:1016/4150 train_time:123766ms step_avg:121.82ms
+step:1017/4150 train_time:123945ms step_avg:121.87ms
+step:1018/4150 train_time:124124ms step_avg:121.93ms
+step:1019/4150 train_time:124303ms step_avg:121.99ms
+step:1020/4150 train_time:124484ms step_avg:122.04ms
+step:1021/4150 train_time:124661ms step_avg:122.10ms
+step:1022/4150 train_time:124840ms step_avg:122.15ms
+step:1023/4150 train_time:125019ms step_avg:122.21ms
+step:1024/4150 train_time:125200ms step_avg:122.27ms
+step:1025/4150 train_time:125379ms step_avg:122.32ms
+step:1026/4150 train_time:125559ms step_avg:122.38ms
+step:1027/4150 train_time:125738ms step_avg:122.43ms
+step:1028/4150 train_time:125916ms step_avg:122.49ms
+step:1029/4150 train_time:126095ms step_avg:122.54ms
+step:1030/4150 train_time:126274ms step_avg:122.60ms
+step:1031/4150 train_time:126454ms step_avg:122.65ms
+step:1032/4150 train_time:126635ms step_avg:122.71ms
+step:1033/4150 train_time:126818ms step_avg:122.77ms
+step:1034/4150 train_time:127052ms step_avg:122.87ms
+step:1035/4150 train_time:127283ms step_avg:122.98ms
+step:1036/4150 train_time:127519ms step_avg:123.09ms
+step:1037/4150 train_time:127754ms step_avg:123.20ms
+step:1038/4150 train_time:127988ms step_avg:123.30ms
+step:1039/4150 train_time:128219ms step_avg:123.41ms
+step:1040/4150 train_time:128454ms step_avg:123.51ms
+step:1041/4150 train_time:128685ms step_avg:123.62ms
+step:1042/4150 train_time:128919ms step_avg:123.72ms
+step:1043/4150 train_time:129150ms step_avg:123.83ms
+step:1044/4150 train_time:129387ms step_avg:123.93ms
+step:1045/4150 train_time:129618ms step_avg:124.04ms
+step:1046/4150 train_time:129852ms step_avg:124.14ms
+step:1047/4150 train_time:130083ms step_avg:124.24ms
+step:1048/4150 train_time:130318ms step_avg:124.35ms
+step:1049/4150 train_time:130553ms step_avg:124.45ms
+step:1050/4150 train_time:130791ms step_avg:124.56ms
+step:1051/4150 train_time:131024ms step_avg:124.67ms
+step:1052/4150 train_time:131258ms step_avg:124.77ms
+step:1053/4150 train_time:131489ms step_avg:124.87ms
+step:1054/4150 train_time:131723ms step_avg:124.97ms
+step:1055/4150 train_time:131957ms step_avg:125.08ms
+step:1056/4150 train_time:132194ms step_avg:125.18ms
+step:1057/4150 train_time:132423ms step_avg:125.28ms
+step:1058/4150 train_time:132658ms step_avg:125.39ms
+step:1059/4150 train_time:132890ms step_avg:125.49ms
+step:1060/4150 train_time:133125ms step_avg:125.59ms
+step:1061/4150 train_time:133356ms step_avg:125.69ms
+step:1062/4150 train_time:133593ms step_avg:125.79ms
+step:1063/4150 train_time:133823ms step_avg:125.89ms
+step:1064/4150 train_time:134058ms step_avg:125.99ms
+step:1065/4150 train_time:134292ms step_avg:126.10ms
+step:1066/4150 train_time:134524ms step_avg:126.20ms
+step:1067/4150 train_time:134757ms step_avg:126.30ms
+step:1068/4150 train_time:134994ms step_avg:126.40ms
+step:1069/4150 train_time:135226ms step_avg:126.50ms
+step:1070/4150 train_time:135461ms step_avg:126.60ms
+step:1071/4150 train_time:135693ms step_avg:126.70ms
+step:1072/4150 train_time:135930ms step_avg:126.80ms
+step:1073/4150 train_time:136162ms step_avg:126.90ms
+step:1074/4150 train_time:136398ms step_avg:127.00ms
+step:1075/4150 train_time:136632ms step_avg:127.10ms
+step:1076/4150 train_time:136867ms step_avg:127.20ms
+step:1077/4150 train_time:137098ms step_avg:127.30ms
+step:1078/4150 train_time:137332ms step_avg:127.40ms
+step:1079/4150 train_time:137565ms step_avg:127.49ms
+step:1080/4150 train_time:137799ms step_avg:127.59ms
+step:1081/4150 train_time:138030ms step_avg:127.69ms
+step:1082/4150 train_time:138264ms step_avg:127.79ms
+step:1083/4150 train_time:138497ms step_avg:127.88ms
+step:1084/4150 train_time:138731ms step_avg:127.98ms
+step:1085/4150 train_time:138962ms step_avg:128.08ms
+step:1086/4150 train_time:139196ms step_avg:128.17ms
+step:1087/4150 train_time:139428ms step_avg:128.27ms
+step:1088/4150 train_time:139662ms step_avg:128.37ms
+step:1089/4150 train_time:139894ms step_avg:128.46ms
+step:1090/4150 train_time:140129ms step_avg:128.56ms
+step:1091/4150 train_time:140360ms step_avg:128.65ms
+step:1092/4150 train_time:140596ms step_avg:128.75ms
+step:1093/4150 train_time:140827ms step_avg:128.84ms
+step:1094/4150 train_time:141060ms step_avg:128.94ms
+step:1095/4150 train_time:141292ms step_avg:129.03ms
+step:1096/4150 train_time:141525ms step_avg:129.13ms
+step:1097/4150 train_time:141758ms step_avg:129.22ms
+step:1098/4150 train_time:141992ms step_avg:129.32ms
+step:1099/4150 train_time:142223ms step_avg:129.41ms
+step:1100/4150 train_time:142457ms step_avg:129.51ms
+step:1101/4150 train_time:142688ms step_avg:129.60ms
+step:1102/4150 train_time:142920ms step_avg:129.69ms
+step:1103/4150 train_time:143151ms step_avg:129.78ms
+step:1104/4150 train_time:143388ms step_avg:129.88ms
+step:1105/4150 train_time:143620ms step_avg:129.97ms
+step:1106/4150 train_time:143854ms step_avg:130.07ms
+step:1107/4150 train_time:144085ms step_avg:130.16ms
+step:1108/4150 train_time:144320ms step_avg:130.25ms
+step:1109/4150 train_time:144554ms step_avg:130.35ms
+step:1110/4150 train_time:144789ms step_avg:130.44ms
+step:1111/4150 train_time:145022ms step_avg:130.53ms
+step:1112/4150 train_time:145255ms step_avg:130.63ms
+step:1113/4150 train_time:145486ms step_avg:130.71ms
+step:1114/4150 train_time:145720ms step_avg:130.81ms
+step:1115/4150 train_time:145953ms step_avg:130.90ms
+step:1116/4150 train_time:146188ms step_avg:130.99ms
+step:1117/4150 train_time:146419ms step_avg:131.08ms
+step:1118/4150 train_time:146655ms step_avg:131.18ms
+step:1119/4150 train_time:146887ms step_avg:131.27ms
+step:1120/4150 train_time:147122ms step_avg:131.36ms
+step:1121/4150 train_time:147354ms step_avg:131.45ms
+step:1122/4150 train_time:147590ms step_avg:131.54ms
+step:1123/4150 train_time:147823ms step_avg:131.63ms
+step:1124/4150 train_time:148060ms step_avg:131.73ms
+step:1125/4150 train_time:148293ms step_avg:131.82ms
+step:1126/4150 train_time:148528ms step_avg:131.91ms
+step:1127/4150 train_time:148760ms step_avg:132.00ms
+step:1128/4150 train_time:148996ms step_avg:132.09ms
+step:1129/4150 train_time:149229ms step_avg:132.18ms
+step:1130/4150 train_time:149465ms step_avg:132.27ms
+step:1131/4150 train_time:149696ms step_avg:132.36ms
+step:1132/4150 train_time:149930ms step_avg:132.45ms
+step:1133/4150 train_time:150160ms step_avg:132.53ms
+step:1134/4150 train_time:150394ms step_avg:132.62ms
+step:1135/4150 train_time:150625ms step_avg:132.71ms
+step:1136/4150 train_time:150859ms step_avg:132.80ms
+step:1137/4150 train_time:151093ms step_avg:132.89ms
+step:1138/4150 train_time:151330ms step_avg:132.98ms
+step:1139/4150 train_time:151560ms step_avg:133.06ms
+step:1140/4150 train_time:151797ms step_avg:133.15ms
+step:1141/4150 train_time:152031ms step_avg:133.24ms
+step:1142/4150 train_time:152268ms step_avg:133.33ms
+step:1143/4150 train_time:152499ms step_avg:133.42ms
+step:1144/4150 train_time:152732ms step_avg:133.51ms
+step:1145/4150 train_time:152964ms step_avg:133.59ms
+step:1146/4150 train_time:153199ms step_avg:133.68ms
+step:1147/4150 train_time:153429ms step_avg:133.77ms
+step:1148/4150 train_time:153663ms step_avg:133.85ms
+step:1149/4150 train_time:153893ms step_avg:133.94ms
+step:1150/4150 train_time:154130ms step_avg:134.03ms
+step:1151/4150 train_time:154360ms step_avg:134.11ms
+step:1152/4150 train_time:154593ms step_avg:134.20ms
+step:1153/4150 train_time:154824ms step_avg:134.28ms
+step:1154/4150 train_time:155061ms step_avg:134.37ms
+step:1155/4150 train_time:155293ms step_avg:134.45ms
+step:1156/4150 train_time:155529ms step_avg:134.54ms
+step:1157/4150 train_time:155761ms step_avg:134.62ms
+step:1158/4150 train_time:155993ms step_avg:134.71ms
+step:1159/4150 train_time:156223ms step_avg:134.79ms
+step:1160/4150 train_time:156458ms step_avg:134.88ms
+step:1161/4150 train_time:156691ms step_avg:134.96ms
+step:1162/4150 train_time:156928ms step_avg:135.05ms
+step:1163/4150 train_time:157160ms step_avg:135.13ms
+step:1164/4150 train_time:157396ms step_avg:135.22ms
+step:1165/4150 train_time:157628ms step_avg:135.30ms
+step:1166/4150 train_time:157861ms step_avg:135.39ms
+step:1167/4150 train_time:158091ms step_avg:135.47ms
+step:1168/4150 train_time:158324ms step_avg:135.55ms
+step:1169/4150 train_time:158554ms step_avg:135.63ms
+step:1170/4150 train_time:158788ms step_avg:135.72ms
+step:1171/4150 train_time:159018ms step_avg:135.80ms
+step:1172/4150 train_time:159255ms step_avg:135.88ms
+step:1173/4150 train_time:159488ms step_avg:135.97ms
+step:1174/4150 train_time:159721ms step_avg:136.05ms
+step:1175/4150 train_time:159953ms step_avg:136.13ms
+step:1176/4150 train_time:160187ms step_avg:136.21ms
+step:1177/4150 train_time:160420ms step_avg:136.30ms
+step:1178/4150 train_time:160654ms step_avg:136.38ms
+step:1179/4150 train_time:160884ms step_avg:136.46ms
+step:1180/4150 train_time:161119ms step_avg:136.54ms
+step:1181/4150 train_time:161351ms step_avg:136.62ms
+step:1182/4150 train_time:161587ms step_avg:136.71ms
+step:1183/4150 train_time:161819ms step_avg:136.79ms
+step:1184/4150 train_time:162052ms step_avg:136.87ms
+step:1185/4150 train_time:162285ms step_avg:136.95ms
+step:1186/4150 train_time:162520ms step_avg:137.03ms
+step:1187/4150 train_time:162750ms step_avg:137.11ms
+step:1188/4150 train_time:162985ms step_avg:137.19ms
+step:1189/4150 train_time:163216ms step_avg:137.27ms
+step:1190/4150 train_time:163452ms step_avg:137.35ms
+step:1191/4150 train_time:163682ms step_avg:137.43ms
+step:1192/4150 train_time:163918ms step_avg:137.51ms
+step:1193/4150 train_time:164150ms step_avg:137.59ms
+step:1194/4150 train_time:164387ms step_avg:137.68ms
+step:1195/4150 train_time:164617ms step_avg:137.75ms
+step:1196/4150 train_time:164852ms step_avg:137.84ms
+step:1197/4150 train_time:165084ms step_avg:137.91ms
+step:1198/4150 train_time:165319ms step_avg:138.00ms
+step:1199/4150 train_time:165550ms step_avg:138.07ms
+step:1200/4150 train_time:165783ms step_avg:138.15ms
+step:1201/4150 train_time:166014ms step_avg:138.23ms
+step:1202/4150 train_time:166250ms step_avg:138.31ms
+step:1203/4150 train_time:166481ms step_avg:138.39ms
+step:1204/4150 train_time:166716ms step_avg:138.47ms
+step:1205/4150 train_time:166950ms step_avg:138.55ms
+step:1206/4150 train_time:167185ms step_avg:138.63ms
+step:1207/4150 train_time:167417ms step_avg:138.71ms
+step:1208/4150 train_time:167653ms step_avg:138.79ms
+step:1209/4150 train_time:167884ms step_avg:138.86ms
+step:1210/4150 train_time:168120ms step_avg:138.94ms
+step:1211/4150 train_time:168350ms step_avg:139.02ms
+step:1212/4150 train_time:168586ms step_avg:139.10ms
+step:1213/4150 train_time:168817ms step_avg:139.17ms
+step:1214/4150 train_time:169051ms step_avg:139.25ms
+step:1215/4150 train_time:169282ms step_avg:139.33ms
+step:1216/4150 train_time:169516ms step_avg:139.40ms
+step:1217/4150 train_time:169750ms step_avg:139.48ms
+step:1218/4150 train_time:169983ms step_avg:139.56ms
+step:1219/4150 train_time:170216ms step_avg:139.64ms
+step:1220/4150 train_time:170452ms step_avg:139.71ms
+step:1221/4150 train_time:170684ms step_avg:139.79ms
+step:1222/4150 train_time:170918ms step_avg:139.87ms
+step:1223/4150 train_time:171149ms step_avg:139.94ms
+step:1224/4150 train_time:171384ms step_avg:140.02ms
+step:1225/4150 train_time:171615ms step_avg:140.09ms
+step:1226/4150 train_time:171850ms step_avg:140.17ms
+step:1227/4150 train_time:172082ms step_avg:140.25ms
+step:1228/4150 train_time:172317ms step_avg:140.32ms
+step:1229/4150 train_time:172549ms step_avg:140.40ms
+step:1230/4150 train_time:172785ms step_avg:140.48ms
+step:1231/4150 train_time:173015ms step_avg:140.55ms
+step:1232/4150 train_time:173250ms step_avg:140.62ms
+step:1233/4150 train_time:173482ms step_avg:140.70ms
+step:1234/4150 train_time:173715ms step_avg:140.77ms
+step:1235/4150 train_time:173947ms step_avg:140.85ms
+step:1236/4150 train_time:174182ms step_avg:140.92ms
+step:1237/4150 train_time:174417ms step_avg:141.00ms
+step:1238/4150 train_time:174651ms step_avg:141.08ms
+step:1239/4150 train_time:174884ms step_avg:141.15ms
+step:1240/4150 train_time:175118ms step_avg:141.22ms
+step:1241/4150 train_time:175351ms step_avg:141.30ms
+step:1242/4150 train_time:175586ms step_avg:141.37ms
+step:1243/4150 train_time:175817ms step_avg:141.45ms
+step:1244/4150 train_time:176055ms step_avg:141.52ms
+step:1245/4150 train_time:176286ms step_avg:141.59ms
+step:1246/4150 train_time:176519ms step_avg:141.67ms
+step:1247/4150 train_time:176750ms step_avg:141.74ms
+step:1248/4150 train_time:176984ms step_avg:141.81ms
+step:1249/4150 train_time:177215ms step_avg:141.89ms
+step:1250/4150 train_time:177448ms step_avg:141.96ms
+step:1250/4150 val_loss:3.3555 train_time:177662ms step_avg:142.13ms
+step:1251/4150 train_time:177685ms step_avg:142.03ms
+step:1252/4150 train_time:177921ms step_avg:142.11ms
+step:1253/4150 train_time:178153ms step_avg:142.18ms
+step:1254/4150 train_time:178386ms step_avg:142.25ms
+step:1255/4150 train_time:178616ms step_avg:142.32ms
+step:1256/4150 train_time:178851ms step_avg:142.40ms
+step:1257/4150 train_time:179085ms step_avg:142.47ms
+step:1258/4150 train_time:179318ms step_avg:142.54ms
+step:1259/4150 train_time:179548ms step_avg:142.61ms
+step:1260/4150 train_time:179782ms step_avg:142.68ms
+step:1261/4150 train_time:180016ms step_avg:142.76ms
+step:1262/4150 train_time:180253ms step_avg:142.83ms
+step:1263/4150 train_time:180482ms step_avg:142.90ms
+step:1264/4150 train_time:180717ms step_avg:142.97ms
+step:1265/4150 train_time:180949ms step_avg:143.04ms
+step:1266/4150 train_time:181185ms step_avg:143.12ms
+step:1267/4150 train_time:181416ms step_avg:143.19ms
+step:1268/4150 train_time:181647ms step_avg:143.25ms
+step:1269/4150 train_time:181883ms step_avg:143.33ms
+step:1270/4150 train_time:182118ms step_avg:143.40ms
+step:1271/4150 train_time:182353ms step_avg:143.47ms
+step:1272/4150 train_time:182587ms step_avg:143.54ms
+step:1273/4150 train_time:182819ms step_avg:143.61ms
+step:1274/4150 train_time:183053ms step_avg:143.68ms
+step:1275/4150 train_time:183286ms step_avg:143.75ms
+step:1276/4150 train_time:183522ms step_avg:143.83ms
+step:1277/4150 train_time:183750ms step_avg:143.89ms
+step:1278/4150 train_time:183985ms step_avg:143.96ms
+step:1279/4150 train_time:184218ms step_avg:144.03ms
+step:1280/4150 train_time:184454ms step_avg:144.10ms
+step:1281/4150 train_time:184685ms step_avg:144.17ms
+step:1282/4150 train_time:184921ms step_avg:144.24ms
+step:1283/4150 train_time:185155ms step_avg:144.31ms
+step:1284/4150 train_time:185391ms step_avg:144.39ms
+step:1285/4150 train_time:185623ms step_avg:144.45ms
+step:1286/4150 train_time:185858ms step_avg:144.52ms
+step:1287/4150 train_time:186092ms step_avg:144.59ms
+step:1288/4150 train_time:186328ms step_avg:144.66ms
+step:1289/4150 train_time:186559ms step_avg:144.73ms
+step:1290/4150 train_time:186793ms step_avg:144.80ms
+step:1291/4150 train_time:187025ms step_avg:144.87ms
+step:1292/4150 train_time:187260ms step_avg:144.94ms
+step:1293/4150 train_time:187492ms step_avg:145.01ms
+step:1294/4150 train_time:187726ms step_avg:145.07ms
+step:1295/4150 train_time:187957ms step_avg:145.14ms
+step:1296/4150 train_time:188193ms step_avg:145.21ms
+step:1297/4150 train_time:188423ms step_avg:145.28ms
+step:1298/4150 train_time:188659ms step_avg:145.35ms
+step:1299/4150 train_time:188889ms step_avg:145.41ms
+step:1300/4150 train_time:189122ms step_avg:145.48ms
+step:1301/4150 train_time:189357ms step_avg:145.55ms
+step:1302/4150 train_time:189591ms step_avg:145.62ms
+step:1303/4150 train_time:189821ms step_avg:145.68ms
+step:1304/4150 train_time:190055ms step_avg:145.75ms
+step:1305/4150 train_time:190290ms step_avg:145.82ms
+step:1306/4150 train_time:190525ms step_avg:145.88ms
+step:1307/4150 train_time:190755ms step_avg:145.95ms
+step:1308/4150 train_time:190989ms step_avg:146.02ms
+step:1309/4150 train_time:191221ms step_avg:146.08ms
+step:1310/4150 train_time:191457ms step_avg:146.15ms
+step:1311/4150 train_time:191688ms step_avg:146.21ms
+step:1312/4150 train_time:191922ms step_avg:146.28ms
+step:1313/4150 train_time:192153ms step_avg:146.35ms
+step:1314/4150 train_time:192389ms step_avg:146.41ms
+step:1315/4150 train_time:192620ms step_avg:146.48ms
+step:1316/4150 train_time:192854ms step_avg:146.55ms
+step:1317/4150 train_time:193085ms step_avg:146.61ms
+step:1318/4150 train_time:193320ms step_avg:146.68ms
+step:1319/4150 train_time:193550ms step_avg:146.74ms
+step:1320/4150 train_time:193788ms step_avg:146.81ms
+step:1321/4150 train_time:194021ms step_avg:146.87ms
+step:1322/4150 train_time:194254ms step_avg:146.94ms
+step:1323/4150 train_time:194488ms step_avg:147.01ms
+step:1324/4150 train_time:194723ms step_avg:147.07ms
+step:1325/4150 train_time:194956ms step_avg:147.14ms
+step:1326/4150 train_time:195190ms step_avg:147.20ms
+step:1327/4150 train_time:195422ms step_avg:147.27ms
+step:1328/4150 train_time:195657ms step_avg:147.33ms
+step:1329/4150 train_time:195889ms step_avg:147.40ms
+step:1330/4150 train_time:196124ms step_avg:147.46ms
+step:1331/4150 train_time:196354ms step_avg:147.52ms
+step:1332/4150 train_time:196588ms step_avg:147.59ms
+step:1333/4150 train_time:196820ms step_avg:147.65ms
+step:1334/4150 train_time:197053ms step_avg:147.72ms
+step:1335/4150 train_time:197284ms step_avg:147.78ms
+step:1336/4150 train_time:197519ms step_avg:147.84ms
+step:1337/4150 train_time:197752ms step_avg:147.91ms
+step:1338/4150 train_time:197985ms step_avg:147.97ms
+step:1339/4150 train_time:198216ms step_avg:148.03ms
+step:1340/4150 train_time:198451ms step_avg:148.10ms
+step:1341/4150 train_time:198682ms step_avg:148.16ms
+step:1342/4150 train_time:198916ms step_avg:148.22ms
+step:1343/4150 train_time:199147ms step_avg:148.29ms
+step:1344/4150 train_time:199382ms step_avg:148.35ms
+step:1345/4150 train_time:199612ms step_avg:148.41ms
+step:1346/4150 train_time:199848ms step_avg:148.48ms
+step:1347/4150 train_time:200078ms step_avg:148.54ms
+step:1348/4150 train_time:200312ms step_avg:148.60ms
+step:1349/4150 train_time:200542ms step_avg:148.66ms
+step:1350/4150 train_time:200777ms step_avg:148.72ms
+step:1351/4150 train_time:201010ms step_avg:148.79ms
+step:1352/4150 train_time:201244ms step_avg:148.85ms
+step:1353/4150 train_time:201475ms step_avg:148.91ms
+step:1354/4150 train_time:201709ms step_avg:148.97ms
+step:1355/4150 train_time:201941ms step_avg:149.03ms
+step:1356/4150 train_time:202177ms step_avg:149.10ms
+step:1357/4150 train_time:202409ms step_avg:149.16ms
+step:1358/4150 train_time:202645ms step_avg:149.22ms
+step:1359/4150 train_time:202876ms step_avg:149.28ms
+step:1360/4150 train_time:203109ms step_avg:149.34ms
+step:1361/4150 train_time:203339ms step_avg:149.40ms
+step:1362/4150 train_time:203574ms step_avg:149.47ms
+step:1363/4150 train_time:203807ms step_avg:149.53ms
+step:1364/4150 train_time:204038ms step_avg:149.59ms
+step:1365/4150 train_time:204272ms step_avg:149.65ms
+step:1366/4150 train_time:204508ms step_avg:149.71ms
+step:1367/4150 train_time:204740ms step_avg:149.77ms
+step:1368/4150 train_time:204975ms step_avg:149.84ms
+step:1369/4150 train_time:205208ms step_avg:149.90ms
+step:1370/4150 train_time:205442ms step_avg:149.96ms
+step:1371/4150 train_time:205673ms step_avg:150.02ms
+step:1372/4150 train_time:205910ms step_avg:150.08ms
+step:1373/4150 train_time:206142ms step_avg:150.14ms
+step:1374/4150 train_time:206376ms step_avg:150.20ms
+step:1375/4150 train_time:206608ms step_avg:150.26ms
+step:1376/4150 train_time:206841ms step_avg:150.32ms
+step:1377/4150 train_time:207075ms step_avg:150.38ms
+step:1378/4150 train_time:207312ms step_avg:150.44ms
+step:1379/4150 train_time:207544ms step_avg:150.50ms
+step:1380/4150 train_time:207778ms step_avg:150.56ms
+step:1381/4150 train_time:208012ms step_avg:150.62ms
+step:1382/4150 train_time:208249ms step_avg:150.69ms
+step:1383/4150 train_time:208479ms step_avg:150.74ms
+step:1384/4150 train_time:208715ms step_avg:150.81ms
+step:1385/4150 train_time:208946ms step_avg:150.86ms
+step:1386/4150 train_time:209182ms step_avg:150.93ms
+step:1387/4150 train_time:209412ms step_avg:150.98ms
+step:1388/4150 train_time:209646ms step_avg:151.04ms
+step:1389/4150 train_time:209877ms step_avg:151.10ms
+step:1390/4150 train_time:210114ms step_avg:151.16ms
+step:1391/4150 train_time:210348ms step_avg:151.22ms
+step:1392/4150 train_time:210582ms step_avg:151.28ms
+step:1393/4150 train_time:210815ms step_avg:151.34ms
+step:1394/4150 train_time:211050ms step_avg:151.40ms
+step:1395/4150 train_time:211283ms step_avg:151.46ms
+step:1396/4150 train_time:211518ms step_avg:151.52ms
+step:1397/4150 train_time:211753ms step_avg:151.58ms
+step:1398/4150 train_time:211988ms step_avg:151.64ms
+step:1399/4150 train_time:212220ms step_avg:151.69ms
+step:1400/4150 train_time:212455ms step_avg:151.75ms
+step:1401/4150 train_time:212688ms step_avg:151.81ms
+step:1402/4150 train_time:212924ms step_avg:151.87ms
+step:1403/4150 train_time:213157ms step_avg:151.93ms
+step:1404/4150 train_time:213392ms step_avg:151.99ms
+step:1405/4150 train_time:213623ms step_avg:152.04ms
+step:1406/4150 train_time:213859ms step_avg:152.10ms
+step:1407/4150 train_time:214092ms step_avg:152.16ms
+step:1408/4150 train_time:214330ms step_avg:152.22ms
+step:1409/4150 train_time:214561ms step_avg:152.28ms
+step:1410/4150 train_time:214795ms step_avg:152.34ms
+step:1411/4150 train_time:215029ms step_avg:152.39ms
+step:1412/4150 train_time:215264ms step_avg:152.45ms
+step:1413/4150 train_time:215496ms step_avg:152.51ms
+step:1414/4150 train_time:215731ms step_avg:152.57ms
+step:1415/4150 train_time:215961ms step_avg:152.62ms
+step:1416/4150 train_time:216196ms step_avg:152.68ms
+step:1417/4150 train_time:216428ms step_avg:152.74ms
+step:1418/4150 train_time:216665ms step_avg:152.80ms
+step:1419/4150 train_time:216898ms step_avg:152.85ms
+step:1420/4150 train_time:217131ms step_avg:152.91ms
+step:1421/4150 train_time:217364ms step_avg:152.97ms
+step:1422/4150 train_time:217599ms step_avg:153.02ms
+step:1423/4150 train_time:217834ms step_avg:153.08ms
+step:1424/4150 train_time:218070ms step_avg:153.14ms
+step:1425/4150 train_time:218302ms step_avg:153.19ms
+step:1426/4150 train_time:218537ms step_avg:153.25ms
+step:1427/4150 train_time:218770ms step_avg:153.31ms
+step:1428/4150 train_time:219009ms step_avg:153.37ms
+step:1429/4150 train_time:219241ms step_avg:153.42ms
+step:1430/4150 train_time:219477ms step_avg:153.48ms
+step:1431/4150 train_time:219709ms step_avg:153.54ms
+step:1432/4150 train_time:219947ms step_avg:153.59ms
+step:1433/4150 train_time:220179ms step_avg:153.65ms
+step:1434/4150 train_time:220415ms step_avg:153.71ms
+step:1435/4150 train_time:220650ms step_avg:153.76ms
+step:1436/4150 train_time:220884ms step_avg:153.82ms
+step:1437/4150 train_time:221115ms step_avg:153.87ms
+step:1438/4150 train_time:221351ms step_avg:153.93ms
+step:1439/4150 train_time:221582ms step_avg:153.98ms
+step:1440/4150 train_time:221820ms step_avg:154.04ms
+step:1441/4150 train_time:222053ms step_avg:154.10ms
+step:1442/4150 train_time:222288ms step_avg:154.15ms
+step:1443/4150 train_time:222521ms step_avg:154.21ms
+step:1444/4150 train_time:222758ms step_avg:154.26ms
+step:1445/4150 train_time:222991ms step_avg:154.32ms
+step:1446/4150 train_time:223226ms step_avg:154.37ms
+step:1447/4150 train_time:223456ms step_avg:154.43ms
+step:1448/4150 train_time:223691ms step_avg:154.48ms
+step:1449/4150 train_time:223923ms step_avg:154.54ms
+step:1450/4150 train_time:224157ms step_avg:154.59ms
+step:1451/4150 train_time:224388ms step_avg:154.64ms
+step:1452/4150 train_time:224625ms step_avg:154.70ms
+step:1453/4150 train_time:224860ms step_avg:154.76ms
+step:1454/4150 train_time:225097ms step_avg:154.81ms
+step:1455/4150 train_time:225333ms step_avg:154.87ms
+step:1456/4150 train_time:225569ms step_avg:154.92ms
+step:1457/4150 train_time:225804ms step_avg:154.98ms
+step:1458/4150 train_time:226038ms step_avg:155.03ms
+step:1459/4150 train_time:226271ms step_avg:155.09ms
+step:1460/4150 train_time:226507ms step_avg:155.14ms
+step:1461/4150 train_time:226740ms step_avg:155.20ms
+step:1462/4150 train_time:226976ms step_avg:155.25ms
+step:1463/4150 train_time:227209ms step_avg:155.30ms
+step:1464/4150 train_time:227445ms step_avg:155.36ms
+step:1465/4150 train_time:227675ms step_avg:155.41ms
+step:1466/4150 train_time:227913ms step_avg:155.47ms
+step:1467/4150 train_time:228144ms step_avg:155.52ms
+step:1468/4150 train_time:228380ms step_avg:155.57ms
+step:1469/4150 train_time:228612ms step_avg:155.62ms
+step:1470/4150 train_time:228847ms step_avg:155.68ms
+step:1471/4150 train_time:229079ms step_avg:155.73ms
+step:1472/4150 train_time:229317ms step_avg:155.79ms
+step:1473/4150 train_time:229549ms step_avg:155.84ms
+step:1474/4150 train_time:229786ms step_avg:155.89ms
+step:1475/4150 train_time:230018ms step_avg:155.94ms
+step:1476/4150 train_time:230253ms step_avg:156.00ms
+step:1477/4150 train_time:230486ms step_avg:156.05ms
+step:1478/4150 train_time:230720ms step_avg:156.10ms
+step:1479/4150 train_time:230955ms step_avg:156.16ms
+step:1480/4150 train_time:231189ms step_avg:156.21ms
+step:1481/4150 train_time:231422ms step_avg:156.26ms
+step:1482/4150 train_time:231659ms step_avg:156.32ms
+step:1483/4150 train_time:231893ms step_avg:156.37ms
+step:1484/4150 train_time:232131ms step_avg:156.42ms
+step:1485/4150 train_time:232363ms step_avg:156.47ms
+step:1486/4150 train_time:232599ms step_avg:156.53ms
+step:1487/4150 train_time:232831ms step_avg:156.58ms
+step:1488/4150 train_time:233066ms step_avg:156.63ms
+step:1489/4150 train_time:233297ms step_avg:156.68ms
+step:1490/4150 train_time:233533ms step_avg:156.73ms
+step:1491/4150 train_time:233765ms step_avg:156.78ms
+step:1492/4150 train_time:234000ms step_avg:156.84ms
+step:1493/4150 train_time:234232ms step_avg:156.89ms
+step:1494/4150 train_time:234467ms step_avg:156.94ms
+step:1495/4150 train_time:234700ms step_avg:156.99ms
+step:1496/4150 train_time:234936ms step_avg:157.04ms
+step:1497/4150 train_time:235171ms step_avg:157.09ms
+step:1498/4150 train_time:235407ms step_avg:157.15ms
+step:1499/4150 train_time:235640ms step_avg:157.20ms
+step:1500/4150 train_time:235876ms step_avg:157.25ms
+step:1500/4150 val_loss:3.2908 train_time:236091ms step_avg:157.39ms
+step:1501/4150 train_time:236114ms step_avg:157.30ms
+step:1502/4150 train_time:236352ms step_avg:157.36ms
+step:1503/4150 train_time:236585ms step_avg:157.41ms
+step:1504/4150 train_time:236818ms step_avg:157.46ms
+step:1505/4150 train_time:237048ms step_avg:157.51ms
+step:1506/4150 train_time:237284ms step_avg:157.56ms
+step:1507/4150 train_time:237520ms step_avg:157.61ms
+step:1508/4150 train_time:237754ms step_avg:157.66ms
+step:1509/4150 train_time:237984ms step_avg:157.71ms
+step:1510/4150 train_time:238220ms step_avg:157.76ms
+step:1511/4150 train_time:238454ms step_avg:157.81ms
+step:1512/4150 train_time:238690ms step_avg:157.86ms
+step:1513/4150 train_time:238922ms step_avg:157.91ms
+step:1514/4150 train_time:239155ms step_avg:157.96ms
+step:1515/4150 train_time:239387ms step_avg:158.01ms
+step:1516/4150 train_time:239625ms step_avg:158.06ms
+step:1517/4150 train_time:239854ms step_avg:158.11ms
+step:1518/4150 train_time:240088ms step_avg:158.16ms
+step:1519/4150 train_time:240321ms step_avg:158.21ms
+step:1520/4150 train_time:240555ms step_avg:158.26ms
+step:1521/4150 train_time:240787ms step_avg:158.31ms
+step:1522/4150 train_time:241021ms step_avg:158.36ms
+step:1523/4150 train_time:241253ms step_avg:158.41ms
+step:1524/4150 train_time:241488ms step_avg:158.46ms
+step:1525/4150 train_time:241721ms step_avg:158.51ms
+step:1526/4150 train_time:241957ms step_avg:158.56ms
+step:1527/4150 train_time:242189ms step_avg:158.60ms
+step:1528/4150 train_time:242423ms step_avg:158.65ms
+step:1529/4150 train_time:242656ms step_avg:158.70ms
+step:1530/4150 train_time:242890ms step_avg:158.75ms
+step:1531/4150 train_time:243121ms step_avg:158.80ms
+step:1532/4150 train_time:243359ms step_avg:158.85ms
+step:1533/4150 train_time:243590ms step_avg:158.90ms
+step:1534/4150 train_time:243827ms step_avg:158.95ms
+step:1535/4150 train_time:244058ms step_avg:159.00ms
+step:1536/4150 train_time:244293ms step_avg:159.05ms
+step:1537/4150 train_time:244525ms step_avg:159.09ms
+step:1538/4150 train_time:244761ms step_avg:159.14ms
+step:1539/4150 train_time:244993ms step_avg:159.19ms
+step:1540/4150 train_time:245228ms step_avg:159.24ms
+step:1541/4150 train_time:245460ms step_avg:159.29ms
+step:1542/4150 train_time:245695ms step_avg:159.34ms
+step:1543/4150 train_time:245928ms step_avg:159.38ms
+step:1544/4150 train_time:246163ms step_avg:159.43ms
+step:1545/4150 train_time:246395ms step_avg:159.48ms
+step:1546/4150 train_time:246632ms step_avg:159.53ms
+step:1547/4150 train_time:246863ms step_avg:159.58ms
+step:1548/4150 train_time:247100ms step_avg:159.63ms
+step:1549/4150 train_time:247331ms step_avg:159.67ms
+step:1550/4150 train_time:247565ms step_avg:159.72ms
+step:1551/4150 train_time:247798ms step_avg:159.77ms
+step:1552/4150 train_time:248034ms step_avg:159.82ms
+step:1553/4150 train_time:248266ms step_avg:159.86ms
+step:1554/4150 train_time:248500ms step_avg:159.91ms
+step:1555/4150 train_time:248734ms step_avg:159.96ms
+step:1556/4150 train_time:248970ms step_avg:160.01ms
+step:1557/4150 train_time:249204ms step_avg:160.05ms
+step:1558/4150 train_time:249441ms step_avg:160.10ms
+step:1559/4150 train_time:249672ms step_avg:160.15ms
+step:1560/4150 train_time:249906ms step_avg:160.20ms
+step:1561/4150 train_time:250141ms step_avg:160.24ms
+step:1562/4150 train_time:250376ms step_avg:160.29ms
+step:1563/4150 train_time:250609ms step_avg:160.34ms
+step:1564/4150 train_time:250844ms step_avg:160.39ms
+step:1565/4150 train_time:251077ms step_avg:160.43ms
+step:1566/4150 train_time:251314ms step_avg:160.48ms
+step:1567/4150 train_time:251546ms step_avg:160.53ms
+step:1568/4150 train_time:251781ms step_avg:160.57ms
+step:1569/4150 train_time:252011ms step_avg:160.62ms
+step:1570/4150 train_time:252247ms step_avg:160.67ms
+step:1571/4150 train_time:252480ms step_avg:160.71ms
+step:1572/4150 train_time:252714ms step_avg:160.76ms
+step:1573/4150 train_time:252944ms step_avg:160.80ms
+step:1574/4150 train_time:253181ms step_avg:160.85ms
+step:1575/4150 train_time:253414ms step_avg:160.90ms
+step:1576/4150 train_time:253649ms step_avg:160.94ms
+step:1577/4150 train_time:253883ms step_avg:160.99ms
+step:1578/4150 train_time:254120ms step_avg:161.04ms
+step:1579/4150 train_time:254352ms step_avg:161.08ms
+step:1580/4150 train_time:254587ms step_avg:161.13ms
+step:1581/4150 train_time:254821ms step_avg:161.18ms
+step:1582/4150 train_time:255059ms step_avg:161.23ms
+step:1583/4150 train_time:255292ms step_avg:161.27ms
+step:1584/4150 train_time:255526ms step_avg:161.32ms
+step:1585/4150 train_time:255758ms step_avg:161.36ms
+step:1586/4150 train_time:255996ms step_avg:161.41ms
+step:1587/4150 train_time:256229ms step_avg:161.45ms
+step:1588/4150 train_time:256462ms step_avg:161.50ms
+step:1589/4150 train_time:256692ms step_avg:161.54ms
+step:1590/4150 train_time:256927ms step_avg:161.59ms
+step:1591/4150 train_time:257158ms step_avg:161.63ms
+step:1592/4150 train_time:257392ms step_avg:161.68ms
+step:1593/4150 train_time:257624ms step_avg:161.72ms
+step:1594/4150 train_time:257859ms step_avg:161.77ms
+step:1595/4150 train_time:258090ms step_avg:161.81ms
+step:1596/4150 train_time:258327ms step_avg:161.86ms
+step:1597/4150 train_time:258560ms step_avg:161.90ms
+step:1598/4150 train_time:258794ms step_avg:161.95ms
+step:1599/4150 train_time:259028ms step_avg:161.99ms
+step:1600/4150 train_time:259261ms step_avg:162.04ms
+step:1601/4150 train_time:259492ms step_avg:162.08ms
+step:1602/4150 train_time:259728ms step_avg:162.13ms
+step:1603/4150 train_time:259960ms step_avg:162.17ms
+step:1604/4150 train_time:260194ms step_avg:162.22ms
+step:1605/4150 train_time:260425ms step_avg:162.26ms
+step:1606/4150 train_time:260662ms step_avg:162.31ms
+step:1607/4150 train_time:260897ms step_avg:162.35ms
+step:1608/4150 train_time:261131ms step_avg:162.40ms
+step:1609/4150 train_time:261362ms step_avg:162.44ms
+step:1610/4150 train_time:261595ms step_avg:162.48ms
+step:1611/4150 train_time:261827ms step_avg:162.52ms
+step:1612/4150 train_time:262064ms step_avg:162.57ms
+step:1613/4150 train_time:262296ms step_avg:162.61ms
+step:1614/4150 train_time:262531ms step_avg:162.66ms
+step:1615/4150 train_time:262761ms step_avg:162.70ms
+step:1616/4150 train_time:262997ms step_avg:162.75ms
+step:1617/4150 train_time:263228ms step_avg:162.79ms
+step:1618/4150 train_time:263462ms step_avg:162.83ms
+step:1619/4150 train_time:263692ms step_avg:162.87ms
+step:1620/4150 train_time:263928ms step_avg:162.92ms
+step:1621/4150 train_time:264161ms step_avg:162.96ms
+step:1622/4150 train_time:264397ms step_avg:163.01ms
+step:1623/4150 train_time:264630ms step_avg:163.05ms
+step:1624/4150 train_time:264865ms step_avg:163.09ms
+step:1625/4150 train_time:265098ms step_avg:163.14ms
+step:1626/4150 train_time:265334ms step_avg:163.18ms
+step:1627/4150 train_time:265567ms step_avg:163.22ms
+step:1628/4150 train_time:265801ms step_avg:163.27ms
+step:1629/4150 train_time:266032ms step_avg:163.31ms
+step:1630/4150 train_time:266266ms step_avg:163.35ms
+step:1631/4150 train_time:266499ms step_avg:163.40ms
+step:1632/4150 train_time:266735ms step_avg:163.44ms
+step:1633/4150 train_time:266966ms step_avg:163.48ms
+step:1634/4150 train_time:267202ms step_avg:163.53ms
+step:1635/4150 train_time:267434ms step_avg:163.57ms
+step:1636/4150 train_time:267669ms step_avg:163.61ms
+step:1637/4150 train_time:267904ms step_avg:163.66ms
+step:1638/4150 train_time:268140ms step_avg:163.70ms
+step:1639/4150 train_time:268373ms step_avg:163.74ms
+step:1640/4150 train_time:268610ms step_avg:163.79ms
+step:1641/4150 train_time:268845ms step_avg:163.83ms
+step:1642/4150 train_time:269081ms step_avg:163.87ms
+step:1643/4150 train_time:269312ms step_avg:163.91ms
+step:1644/4150 train_time:269547ms step_avg:163.96ms
+step:1645/4150 train_time:269779ms step_avg:164.00ms
+step:1646/4150 train_time:270016ms step_avg:164.04ms
+step:1647/4150 train_time:270246ms step_avg:164.08ms
+step:1648/4150 train_time:270481ms step_avg:164.13ms
+step:1649/4150 train_time:270712ms step_avg:164.17ms
+step:1650/4150 train_time:270948ms step_avg:164.21ms
+step:1651/4150 train_time:271179ms step_avg:164.25ms
+step:1652/4150 train_time:271412ms step_avg:164.29ms
+step:1653/4150 train_time:271643ms step_avg:164.33ms
+step:1654/4150 train_time:271877ms step_avg:164.38ms
+step:1655/4150 train_time:272109ms step_avg:164.42ms
+step:1656/4150 train_time:272344ms step_avg:164.46ms
+step:1657/4150 train_time:272579ms step_avg:164.50ms
+step:1658/4150 train_time:272814ms step_avg:164.54ms
+step:1659/4150 train_time:273046ms step_avg:164.58ms
+step:1660/4150 train_time:273281ms step_avg:164.63ms
+step:1661/4150 train_time:273515ms step_avg:164.67ms
+step:1662/4150 train_time:273748ms step_avg:164.71ms
+step:1663/4150 train_time:273982ms step_avg:164.75ms
+step:1664/4150 train_time:274218ms step_avg:164.79ms
+step:1665/4150 train_time:274449ms step_avg:164.83ms
+step:1666/4150 train_time:274686ms step_avg:164.88ms
+step:1667/4150 train_time:274920ms step_avg:164.92ms
+step:1668/4150 train_time:275153ms step_avg:164.96ms
+step:1669/4150 train_time:275385ms step_avg:165.00ms
+step:1670/4150 train_time:275621ms step_avg:165.04ms
+step:1671/4150 train_time:275852ms step_avg:165.08ms
+step:1672/4150 train_time:276087ms step_avg:165.12ms
+step:1673/4150 train_time:276319ms step_avg:165.16ms
+step:1674/4150 train_time:276556ms step_avg:165.21ms
+step:1675/4150 train_time:276786ms step_avg:165.25ms
+step:1676/4150 train_time:277019ms step_avg:165.29ms
+step:1677/4150 train_time:277250ms step_avg:165.32ms
+step:1678/4150 train_time:277484ms step_avg:165.37ms
+step:1679/4150 train_time:277717ms step_avg:165.41ms
+step:1680/4150 train_time:277952ms step_avg:165.45ms
+step:1681/4150 train_time:278183ms step_avg:165.49ms
+step:1682/4150 train_time:278421ms step_avg:165.53ms
+step:1683/4150 train_time:278652ms step_avg:165.57ms
+step:1684/4150 train_time:278888ms step_avg:165.61ms
+step:1685/4150 train_time:279123ms step_avg:165.65ms
+step:1686/4150 train_time:279360ms step_avg:165.69ms
+step:1687/4150 train_time:279592ms step_avg:165.73ms
+step:1688/4150 train_time:279828ms step_avg:165.77ms
+step:1689/4150 train_time:280059ms step_avg:165.81ms
+step:1690/4150 train_time:280295ms step_avg:165.85ms
+step:1691/4150 train_time:280530ms step_avg:165.90ms
+step:1692/4150 train_time:280765ms step_avg:165.94ms
+step:1693/4150 train_time:280997ms step_avg:165.98ms
+step:1694/4150 train_time:281233ms step_avg:166.02ms
+step:1695/4150 train_time:281464ms step_avg:166.06ms
+step:1696/4150 train_time:281700ms step_avg:166.10ms
+step:1697/4150 train_time:281932ms step_avg:166.14ms
+step:1698/4150 train_time:282167ms step_avg:166.18ms
+step:1699/4150 train_time:282401ms step_avg:166.22ms
+step:1700/4150 train_time:282637ms step_avg:166.26ms
+step:1701/4150 train_time:282869ms step_avg:166.30ms
+step:1702/4150 train_time:283103ms step_avg:166.34ms
+step:1703/4150 train_time:283338ms step_avg:166.38ms
+step:1704/4150 train_time:283574ms step_avg:166.42ms
+step:1705/4150 train_time:283806ms step_avg:166.45ms
+step:1706/4150 train_time:284040ms step_avg:166.49ms
+step:1707/4150 train_time:284272ms step_avg:166.53ms
+step:1708/4150 train_time:284508ms step_avg:166.57ms
+step:1709/4150 train_time:284741ms step_avg:166.61ms
+step:1710/4150 train_time:284977ms step_avg:166.65ms
+step:1711/4150 train_time:285211ms step_avg:166.69ms
+step:1712/4150 train_time:285446ms step_avg:166.73ms
+step:1713/4150 train_time:285682ms step_avg:166.77ms
+step:1714/4150 train_time:285920ms step_avg:166.81ms
+step:1715/4150 train_time:286150ms step_avg:166.85ms
+step:1716/4150 train_time:286384ms step_avg:166.89ms
+step:1717/4150 train_time:286618ms step_avg:166.93ms
+step:1718/4150 train_time:286855ms step_avg:166.97ms
+step:1719/4150 train_time:287088ms step_avg:167.01ms
+step:1720/4150 train_time:287324ms step_avg:167.05ms
+step:1721/4150 train_time:287564ms step_avg:167.09ms
+step:1722/4150 train_time:287801ms step_avg:167.13ms
+step:1723/4150 train_time:288030ms step_avg:167.17ms
+step:1724/4150 train_time:288267ms step_avg:167.21ms
+step:1725/4150 train_time:288503ms step_avg:167.25ms
+step:1726/4150 train_time:288741ms step_avg:167.29ms
+step:1727/4150 train_time:288973ms step_avg:167.33ms
+step:1728/4150 train_time:289208ms step_avg:167.37ms
+step:1729/4150 train_time:289443ms step_avg:167.40ms
+step:1730/4150 train_time:289680ms step_avg:167.45ms
+step:1731/4150 train_time:289914ms step_avg:167.48ms
+step:1732/4150 train_time:290148ms step_avg:167.52ms
+step:1733/4150 train_time:290380ms step_avg:167.56ms
+step:1734/4150 train_time:290617ms step_avg:167.60ms
+step:1735/4150 train_time:290850ms step_avg:167.64ms
+step:1736/4150 train_time:291086ms step_avg:167.68ms
+step:1737/4150 train_time:291317ms step_avg:167.71ms
+step:1738/4150 train_time:291554ms step_avg:167.75ms
+step:1739/4150 train_time:291788ms step_avg:167.79ms
+step:1740/4150 train_time:292023ms step_avg:167.83ms
+step:1741/4150 train_time:292256ms step_avg:167.87ms
+step:1742/4150 train_time:292494ms step_avg:167.91ms
+step:1743/4150 train_time:292727ms step_avg:167.94ms
+step:1744/4150 train_time:292961ms step_avg:167.98ms
+step:1745/4150 train_time:293193ms step_avg:168.02ms
+step:1746/4150 train_time:293428ms step_avg:168.06ms
+step:1747/4150 train_time:293659ms step_avg:168.09ms
+step:1748/4150 train_time:293897ms step_avg:168.13ms
+step:1749/4150 train_time:294132ms step_avg:168.17ms
+step:1750/4150 train_time:294369ms step_avg:168.21ms
+step:1750/4150 val_loss:3.2312 train_time:294584ms step_avg:168.33ms
+step:1751/4150 train_time:294606ms step_avg:168.25ms
+step:1752/4150 train_time:294850ms step_avg:168.29ms
+step:1753/4150 train_time:295080ms step_avg:168.33ms
+step:1754/4150 train_time:295313ms step_avg:168.37ms
+step:1755/4150 train_time:295544ms step_avg:168.40ms
+step:1756/4150 train_time:295783ms step_avg:168.44ms
+step:1757/4150 train_time:296021ms step_avg:168.48ms
+step:1758/4150 train_time:296258ms step_avg:168.52ms
+step:1759/4150 train_time:296490ms step_avg:168.56ms
+step:1760/4150 train_time:296729ms step_avg:168.60ms
+step:1761/4150 train_time:296964ms step_avg:168.63ms
+step:1762/4150 train_time:297199ms step_avg:168.67ms
+step:1763/4150 train_time:297432ms step_avg:168.71ms
+step:1764/4150 train_time:297669ms step_avg:168.75ms
+step:1765/4150 train_time:297904ms step_avg:168.78ms
+step:1766/4150 train_time:298141ms step_avg:168.82ms
+step:1767/4150 train_time:298372ms step_avg:168.86ms
+step:1768/4150 train_time:298607ms step_avg:168.90ms
+step:1769/4150 train_time:298843ms step_avg:168.93ms
+step:1770/4150 train_time:299081ms step_avg:168.97ms
+step:1771/4150 train_time:299311ms step_avg:169.01ms
+step:1772/4150 train_time:299545ms step_avg:169.04ms
+step:1773/4150 train_time:299778ms step_avg:169.08ms
+step:1774/4150 train_time:300015ms step_avg:169.12ms
+step:1775/4150 train_time:300247ms step_avg:169.15ms
+step:1776/4150 train_time:300482ms step_avg:169.19ms
+step:1777/4150 train_time:300715ms step_avg:169.23ms
+step:1778/4150 train_time:300951ms step_avg:169.26ms
+step:1779/4150 train_time:301184ms step_avg:169.30ms
+step:1780/4150 train_time:301421ms step_avg:169.34ms
+step:1781/4150 train_time:301655ms step_avg:169.37ms
+step:1782/4150 train_time:301891ms step_avg:169.41ms
+step:1783/4150 train_time:302126ms step_avg:169.45ms
+step:1784/4150 train_time:302362ms step_avg:169.49ms
+step:1785/4150 train_time:302593ms step_avg:169.52ms
+step:1786/4150 train_time:302829ms step_avg:169.56ms
+step:1787/4150 train_time:303061ms step_avg:169.59ms
+step:1788/4150 train_time:303297ms step_avg:169.63ms
+step:1789/4150 train_time:303530ms step_avg:169.66ms
+step:1790/4150 train_time:303765ms step_avg:169.70ms
+step:1791/4150 train_time:303999ms step_avg:169.74ms
+step:1792/4150 train_time:304235ms step_avg:169.77ms
+step:1793/4150 train_time:304466ms step_avg:169.81ms
+step:1794/4150 train_time:304703ms step_avg:169.85ms
+step:1795/4150 train_time:304936ms step_avg:169.88ms
+step:1796/4150 train_time:305172ms step_avg:169.92ms
+step:1797/4150 train_time:305404ms step_avg:169.95ms
+step:1798/4150 train_time:305641ms step_avg:169.99ms
+step:1799/4150 train_time:305874ms step_avg:170.02ms
+step:1800/4150 train_time:306112ms step_avg:170.06ms
+step:1801/4150 train_time:306346ms step_avg:170.10ms
+step:1802/4150 train_time:306585ms step_avg:170.14ms
+step:1803/4150 train_time:306818ms step_avg:170.17ms
+step:1804/4150 train_time:307051ms step_avg:170.21ms
+step:1805/4150 train_time:307286ms step_avg:170.24ms
+step:1806/4150 train_time:307524ms step_avg:170.28ms
+step:1807/4150 train_time:307756ms step_avg:170.31ms
+step:1808/4150 train_time:307993ms step_avg:170.35ms
+step:1809/4150 train_time:308226ms step_avg:170.38ms
+step:1810/4150 train_time:308462ms step_avg:170.42ms
+step:1811/4150 train_time:308696ms step_avg:170.46ms
+step:1812/4150 train_time:308932ms step_avg:170.49ms
+step:1813/4150 train_time:309165ms step_avg:170.53ms
+step:1814/4150 train_time:309401ms step_avg:170.56ms
+step:1815/4150 train_time:309635ms step_avg:170.60ms
+step:1816/4150 train_time:309871ms step_avg:170.63ms
+step:1817/4150 train_time:310105ms step_avg:170.67ms
+step:1818/4150 train_time:310341ms step_avg:170.70ms
+step:1819/4150 train_time:310574ms step_avg:170.74ms
+step:1820/4150 train_time:310811ms step_avg:170.78ms
+step:1821/4150 train_time:311044ms step_avg:170.81ms
+step:1822/4150 train_time:311280ms step_avg:170.85ms
+step:1823/4150 train_time:311515ms step_avg:170.88ms
+step:1824/4150 train_time:311753ms step_avg:170.92ms
+step:1825/4150 train_time:311988ms step_avg:170.95ms
+step:1826/4150 train_time:312224ms step_avg:170.99ms
+step:1827/4150 train_time:312457ms step_avg:171.02ms
+step:1828/4150 train_time:312693ms step_avg:171.06ms
+step:1829/4150 train_time:312924ms step_avg:171.09ms
+step:1830/4150 train_time:313162ms step_avg:171.13ms
+step:1831/4150 train_time:313394ms step_avg:171.16ms
+step:1832/4150 train_time:313631ms step_avg:171.20ms
+step:1833/4150 train_time:313863ms step_avg:171.23ms
+step:1834/4150 train_time:314103ms step_avg:171.27ms
+step:1835/4150 train_time:314335ms step_avg:171.30ms
+step:1836/4150 train_time:314571ms step_avg:171.34ms
+step:1837/4150 train_time:314803ms step_avg:171.37ms
+step:1838/4150 train_time:315040ms step_avg:171.40ms
+step:1839/4150 train_time:315274ms step_avg:171.44ms
+step:1840/4150 train_time:315511ms step_avg:171.47ms
+step:1841/4150 train_time:315745ms step_avg:171.51ms
+step:1842/4150 train_time:315982ms step_avg:171.54ms
+step:1843/4150 train_time:316216ms step_avg:171.58ms
+step:1844/4150 train_time:316452ms step_avg:171.61ms
+step:1845/4150 train_time:316684ms step_avg:171.64ms
+step:1846/4150 train_time:316925ms step_avg:171.68ms
+step:1847/4150 train_time:317157ms step_avg:171.71ms
+step:1848/4150 train_time:317391ms step_avg:171.75ms
+step:1849/4150 train_time:317624ms step_avg:171.78ms
+step:1850/4150 train_time:317859ms step_avg:171.82ms
+step:1851/4150 train_time:318092ms step_avg:171.85ms
+step:1852/4150 train_time:318328ms step_avg:171.88ms
+step:1853/4150 train_time:318562ms step_avg:171.92ms
+step:1854/4150 train_time:318797ms step_avg:171.95ms
+step:1855/4150 train_time:319031ms step_avg:171.98ms
+step:1856/4150 train_time:319267ms step_avg:172.02ms
+step:1857/4150 train_time:319500ms step_avg:172.05ms
+step:1858/4150 train_time:319735ms step_avg:172.09ms
+step:1859/4150 train_time:319967ms step_avg:172.12ms
+step:1860/4150 train_time:320202ms step_avg:172.15ms
+step:1861/4150 train_time:320434ms step_avg:172.18ms
+step:1862/4150 train_time:320669ms step_avg:172.22ms
+step:1863/4150 train_time:320903ms step_avg:172.25ms
+step:1864/4150 train_time:321138ms step_avg:172.28ms
+step:1865/4150 train_time:321371ms step_avg:172.32ms
+step:1866/4150 train_time:321609ms step_avg:172.35ms
+step:1867/4150 train_time:321843ms step_avg:172.39ms
+step:1868/4150 train_time:322078ms step_avg:172.42ms
+step:1869/4150 train_time:322310ms step_avg:172.45ms
+step:1870/4150 train_time:322547ms step_avg:172.48ms
+step:1871/4150 train_time:322779ms step_avg:172.52ms
+step:1872/4150 train_time:323017ms step_avg:172.55ms
+step:1873/4150 train_time:323250ms step_avg:172.58ms
+step:1874/4150 train_time:323483ms step_avg:172.62ms
+step:1875/4150 train_time:323718ms step_avg:172.65ms
+step:1876/4150 train_time:323953ms step_avg:172.68ms
+step:1877/4150 train_time:324190ms step_avg:172.72ms
+step:1878/4150 train_time:324429ms step_avg:172.75ms
+step:1879/4150 train_time:324661ms step_avg:172.78ms
+step:1880/4150 train_time:324896ms step_avg:172.82ms
+step:1881/4150 train_time:325129ms step_avg:172.85ms
+step:1882/4150 train_time:325366ms step_avg:172.88ms
+step:1883/4150 train_time:325600ms step_avg:172.92ms
+step:1884/4150 train_time:325836ms step_avg:172.95ms
+step:1885/4150 train_time:326071ms step_avg:172.98ms
+step:1886/4150 train_time:326306ms step_avg:173.01ms
+step:1887/4150 train_time:326542ms step_avg:173.05ms
+step:1888/4150 train_time:326775ms step_avg:173.08ms
+step:1889/4150 train_time:327009ms step_avg:173.11ms
+step:1890/4150 train_time:327243ms step_avg:173.14ms
+step:1891/4150 train_time:327477ms step_avg:173.18ms
+step:1892/4150 train_time:327713ms step_avg:173.21ms
+step:1893/4150 train_time:327949ms step_avg:173.24ms
+step:1894/4150 train_time:328187ms step_avg:173.28ms
+step:1895/4150 train_time:328419ms step_avg:173.31ms
+step:1896/4150 train_time:328653ms step_avg:173.34ms
+step:1897/4150 train_time:328888ms step_avg:173.37ms
+step:1898/4150 train_time:329127ms step_avg:173.41ms
+step:1899/4150 train_time:329359ms step_avg:173.44ms
+step:1900/4150 train_time:329595ms step_avg:173.47ms
+step:1901/4150 train_time:329828ms step_avg:173.50ms
+step:1902/4150 train_time:330067ms step_avg:173.54ms
+step:1903/4150 train_time:330299ms step_avg:173.57ms
+step:1904/4150 train_time:330533ms step_avg:173.60ms
+step:1905/4150 train_time:330763ms step_avg:173.63ms
+step:1906/4150 train_time:331003ms step_avg:173.66ms
+step:1907/4150 train_time:331233ms step_avg:173.69ms
+step:1908/4150 train_time:331470ms step_avg:173.73ms
+step:1909/4150 train_time:331702ms step_avg:173.76ms
+step:1910/4150 train_time:331939ms step_avg:173.79ms
+step:1911/4150 train_time:332171ms step_avg:173.82ms
+step:1912/4150 train_time:332409ms step_avg:173.85ms
+step:1913/4150 train_time:332642ms step_avg:173.89ms
+step:1914/4150 train_time:332878ms step_avg:173.92ms
+step:1915/4150 train_time:333112ms step_avg:173.95ms
+step:1916/4150 train_time:333345ms step_avg:173.98ms
+step:1917/4150 train_time:333577ms step_avg:174.01ms
+step:1918/4150 train_time:333815ms step_avg:174.04ms
+step:1919/4150 train_time:334049ms step_avg:174.07ms
+step:1920/4150 train_time:334286ms step_avg:174.11ms
+step:1921/4150 train_time:334518ms step_avg:174.14ms
+step:1922/4150 train_time:334752ms step_avg:174.17ms
+step:1923/4150 train_time:334986ms step_avg:174.20ms
+step:1924/4150 train_time:335222ms step_avg:174.23ms
+step:1925/4150 train_time:335453ms step_avg:174.26ms
+step:1926/4150 train_time:335689ms step_avg:174.29ms
+step:1927/4150 train_time:335922ms step_avg:174.32ms
+step:1928/4150 train_time:336160ms step_avg:174.36ms
+step:1929/4150 train_time:336392ms step_avg:174.39ms
+step:1930/4150 train_time:336629ms step_avg:174.42ms
+step:1931/4150 train_time:336863ms step_avg:174.45ms
+step:1932/4150 train_time:337099ms step_avg:174.48ms
+step:1933/4150 train_time:337331ms step_avg:174.51ms
+step:1934/4150 train_time:337567ms step_avg:174.54ms
+step:1935/4150 train_time:337798ms step_avg:174.57ms
+step:1936/4150 train_time:338035ms step_avg:174.61ms
+step:1937/4150 train_time:338268ms step_avg:174.64ms
+step:1938/4150 train_time:338504ms step_avg:174.67ms
+step:1939/4150 train_time:338736ms step_avg:174.70ms
+step:1940/4150 train_time:338973ms step_avg:174.73ms
+step:1941/4150 train_time:339205ms step_avg:174.76ms
+step:1942/4150 train_time:339444ms step_avg:174.79ms
+step:1943/4150 train_time:339675ms step_avg:174.82ms
+step:1944/4150 train_time:339909ms step_avg:174.85ms
+step:1945/4150 train_time:340142ms step_avg:174.88ms
+step:1946/4150 train_time:340376ms step_avg:174.91ms
+step:1947/4150 train_time:340608ms step_avg:174.94ms
+step:1948/4150 train_time:340844ms step_avg:174.97ms
+step:1949/4150 train_time:341076ms step_avg:175.00ms
+step:1950/4150 train_time:341311ms step_avg:175.03ms
+step:1951/4150 train_time:341544ms step_avg:175.06ms
+step:1952/4150 train_time:341782ms step_avg:175.09ms
+step:1953/4150 train_time:342015ms step_avg:175.12ms
+step:1954/4150 train_time:342250ms step_avg:175.15ms
+step:1955/4150 train_time:342481ms step_avg:175.18ms
+step:1956/4150 train_time:342716ms step_avg:175.21ms
+step:1957/4150 train_time:342950ms step_avg:175.24ms
+step:1958/4150 train_time:343186ms step_avg:175.27ms
+step:1959/4150 train_time:343417ms step_avg:175.30ms
+step:1960/4150 train_time:343653ms step_avg:175.33ms
+step:1961/4150 train_time:343889ms step_avg:175.36ms
+step:1962/4150 train_time:344127ms step_avg:175.40ms
+step:1963/4150 train_time:344361ms step_avg:175.43ms
+step:1964/4150 train_time:344599ms step_avg:175.46ms
+step:1965/4150 train_time:344831ms step_avg:175.49ms
+step:1966/4150 train_time:345068ms step_avg:175.52ms
+step:1967/4150 train_time:345303ms step_avg:175.55ms
+step:1968/4150 train_time:345539ms step_avg:175.58ms
+step:1969/4150 train_time:345770ms step_avg:175.61ms
+step:1970/4150 train_time:346009ms step_avg:175.64ms
+step:1971/4150 train_time:346243ms step_avg:175.67ms
+step:1972/4150 train_time:346479ms step_avg:175.70ms
+step:1973/4150 train_time:346713ms step_avg:175.73ms
+step:1974/4150 train_time:346949ms step_avg:175.76ms
+step:1975/4150 train_time:347183ms step_avg:175.79ms
+step:1976/4150 train_time:347420ms step_avg:175.82ms
+step:1977/4150 train_time:347651ms step_avg:175.85ms
+step:1978/4150 train_time:347886ms step_avg:175.88ms
+step:1979/4150 train_time:348121ms step_avg:175.91ms
+step:1980/4150 train_time:348356ms step_avg:175.94ms
+step:1981/4150 train_time:348589ms step_avg:175.97ms
+step:1982/4150 train_time:348824ms step_avg:176.00ms
+step:1983/4150 train_time:349057ms step_avg:176.02ms
+step:1984/4150 train_time:349293ms step_avg:176.06ms
+step:1985/4150 train_time:349525ms step_avg:176.08ms
+step:1986/4150 train_time:349760ms step_avg:176.11ms
+step:1987/4150 train_time:349993ms step_avg:176.14ms
+step:1988/4150 train_time:350229ms step_avg:176.17ms
+step:1989/4150 train_time:350464ms step_avg:176.20ms
+step:1990/4150 train_time:350701ms step_avg:176.23ms
+step:1991/4150 train_time:350932ms step_avg:176.26ms
+step:1992/4150 train_time:351169ms step_avg:176.29ms
+step:1993/4150 train_time:351402ms step_avg:176.32ms
+step:1994/4150 train_time:351638ms step_avg:176.35ms
+step:1995/4150 train_time:351870ms step_avg:176.38ms
+step:1996/4150 train_time:352106ms step_avg:176.41ms
+step:1997/4150 train_time:352339ms step_avg:176.43ms
+step:1998/4150 train_time:352574ms step_avg:176.46ms
+step:1999/4150 train_time:352805ms step_avg:176.49ms
+step:2000/4150 train_time:353040ms step_avg:176.52ms
+step:2000/4150 val_loss:3.1850 train_time:353254ms step_avg:176.63ms
+step:2001/4150 train_time:353276ms step_avg:176.55ms
+step:2002/4150 train_time:353519ms step_avg:176.58ms
+step:2003/4150 train_time:353755ms step_avg:176.61ms
+step:2004/4150 train_time:353987ms step_avg:176.64ms
+step:2005/4150 train_time:354219ms step_avg:176.67ms
+step:2006/4150 train_time:354456ms step_avg:176.70ms
+step:2007/4150 train_time:354692ms step_avg:176.73ms
+step:2008/4150 train_time:354927ms step_avg:176.76ms
+step:2009/4150 train_time:355159ms step_avg:176.78ms
+step:2010/4150 train_time:355396ms step_avg:176.81ms
+step:2011/4150 train_time:355633ms step_avg:176.84ms
+step:2012/4150 train_time:355870ms step_avg:176.87ms
+step:2013/4150 train_time:356100ms step_avg:176.90ms
+step:2014/4150 train_time:356337ms step_avg:176.93ms
+step:2015/4150 train_time:356572ms step_avg:176.96ms
+step:2016/4150 train_time:356810ms step_avg:176.99ms
+step:2017/4150 train_time:357042ms step_avg:177.02ms
+step:2018/4150 train_time:357277ms step_avg:177.05ms
+step:2019/4150 train_time:357509ms step_avg:177.07ms
+step:2020/4150 train_time:357747ms step_avg:177.10ms
+step:2021/4150 train_time:357979ms step_avg:177.13ms
+step:2022/4150 train_time:358213ms step_avg:177.16ms
+step:2023/4150 train_time:358446ms step_avg:177.19ms
+step:2024/4150 train_time:358683ms step_avg:177.21ms
+step:2025/4150 train_time:358917ms step_avg:177.24ms
+step:2026/4150 train_time:359153ms step_avg:177.27ms
+step:2027/4150 train_time:359384ms step_avg:177.30ms
+step:2028/4150 train_time:359622ms step_avg:177.33ms
+step:2029/4150 train_time:359855ms step_avg:177.36ms
+step:2030/4150 train_time:360089ms step_avg:177.38ms
+step:2031/4150 train_time:360322ms step_avg:177.41ms
+step:2032/4150 train_time:360559ms step_avg:177.44ms
+step:2033/4150 train_time:360795ms step_avg:177.47ms
+step:2034/4150 train_time:361035ms step_avg:177.50ms
+step:2035/4150 train_time:361268ms step_avg:177.53ms
+step:2036/4150 train_time:361502ms step_avg:177.55ms
+step:2037/4150 train_time:361736ms step_avg:177.58ms
+step:2038/4150 train_time:361971ms step_avg:177.61ms
+step:2039/4150 train_time:362203ms step_avg:177.64ms
+step:2040/4150 train_time:362439ms step_avg:177.67ms
+step:2041/4150 train_time:362673ms step_avg:177.69ms
+step:2042/4150 train_time:362910ms step_avg:177.72ms
+step:2043/4150 train_time:363140ms step_avg:177.75ms
+step:2044/4150 train_time:363376ms step_avg:177.78ms
+step:2045/4150 train_time:363611ms step_avg:177.81ms
+step:2046/4150 train_time:363848ms step_avg:177.83ms
+step:2047/4150 train_time:364079ms step_avg:177.86ms
+step:2048/4150 train_time:364315ms step_avg:177.89ms
+step:2049/4150 train_time:364548ms step_avg:177.92ms
+step:2050/4150 train_time:364784ms step_avg:177.94ms
+step:2051/4150 train_time:365016ms step_avg:177.97ms
+step:2052/4150 train_time:365254ms step_avg:178.00ms
+step:2053/4150 train_time:365487ms step_avg:178.03ms
+step:2054/4150 train_time:365724ms step_avg:178.05ms
+step:2055/4150 train_time:365956ms step_avg:178.08ms
+step:2056/4150 train_time:366190ms step_avg:178.11ms
+step:2057/4150 train_time:366424ms step_avg:178.13ms
+step:2058/4150 train_time:366659ms step_avg:178.16ms
+step:2059/4150 train_time:366891ms step_avg:178.19ms
+step:2060/4150 train_time:367129ms step_avg:178.22ms
+step:2061/4150 train_time:367360ms step_avg:178.24ms
+step:2062/4150 train_time:367594ms step_avg:178.27ms
+step:2063/4150 train_time:367826ms step_avg:178.30ms
+step:2064/4150 train_time:368059ms step_avg:178.32ms
+step:2065/4150 train_time:368291ms step_avg:178.35ms
+step:2066/4150 train_time:368530ms step_avg:178.38ms
+step:2067/4150 train_time:368763ms step_avg:178.41ms
+step:2068/4150 train_time:368999ms step_avg:178.43ms
+step:2069/4150 train_time:369233ms step_avg:178.46ms
+step:2070/4150 train_time:369469ms step_avg:178.49ms
+step:2071/4150 train_time:369701ms step_avg:178.51ms
+step:2072/4150 train_time:369939ms step_avg:178.54ms
+step:2073/4150 train_time:370175ms step_avg:178.57ms
+step:2074/4150 train_time:370414ms step_avg:178.60ms
+step:2075/4150 train_time:370647ms step_avg:178.63ms
+step:2076/4150 train_time:370882ms step_avg:178.65ms
+step:2077/4150 train_time:371120ms step_avg:178.68ms
+step:2078/4150 train_time:371355ms step_avg:178.71ms
+step:2079/4150 train_time:371589ms step_avg:178.73ms
+step:2080/4150 train_time:371825ms step_avg:178.76ms
+step:2081/4150 train_time:372058ms step_avg:178.79ms
+step:2082/4150 train_time:372291ms step_avg:178.81ms
+step:2083/4150 train_time:372525ms step_avg:178.84ms
+step:2084/4150 train_time:372761ms step_avg:178.87ms
+step:2085/4150 train_time:372997ms step_avg:178.90ms
+step:2086/4150 train_time:373234ms step_avg:178.92ms
+step:2087/4150 train_time:373465ms step_avg:178.95ms
+step:2088/4150 train_time:373702ms step_avg:178.98ms
+step:2089/4150 train_time:373934ms step_avg:179.00ms
+step:2090/4150 train_time:374169ms step_avg:179.03ms
+step:2091/4150 train_time:374403ms step_avg:179.05ms
+step:2092/4150 train_time:374640ms step_avg:179.08ms
+step:2093/4150 train_time:374873ms step_avg:179.11ms
+step:2094/4150 train_time:375110ms step_avg:179.14ms
+step:2095/4150 train_time:375343ms step_avg:179.16ms
+step:2096/4150 train_time:375580ms step_avg:179.19ms
+step:2097/4150 train_time:375814ms step_avg:179.22ms
+step:2098/4150 train_time:376051ms step_avg:179.24ms
+step:2099/4150 train_time:376284ms step_avg:179.27ms
+step:2100/4150 train_time:376521ms step_avg:179.30ms
+step:2101/4150 train_time:376755ms step_avg:179.32ms
+step:2102/4150 train_time:376989ms step_avg:179.35ms
+step:2103/4150 train_time:377222ms step_avg:179.37ms
+step:2104/4150 train_time:377458ms step_avg:179.40ms
+step:2105/4150 train_time:377693ms step_avg:179.43ms
+step:2106/4150 train_time:377932ms step_avg:179.45ms
+step:2107/4150 train_time:378164ms step_avg:179.48ms
+step:2108/4150 train_time:378402ms step_avg:179.51ms
+step:2109/4150 train_time:378638ms step_avg:179.53ms
+step:2110/4150 train_time:378874ms step_avg:179.56ms
+step:2111/4150 train_time:379108ms step_avg:179.59ms
+step:2112/4150 train_time:379346ms step_avg:179.61ms
+step:2113/4150 train_time:379581ms step_avg:179.64ms
+step:2114/4150 train_time:379818ms step_avg:179.67ms
+step:2115/4150 train_time:380051ms step_avg:179.69ms
+step:2116/4150 train_time:380287ms step_avg:179.72ms
+step:2117/4150 train_time:380521ms step_avg:179.75ms
+step:2118/4150 train_time:380757ms step_avg:179.77ms
+step:2119/4150 train_time:380993ms step_avg:179.80ms
+step:2120/4150 train_time:381229ms step_avg:179.83ms
+step:2121/4150 train_time:381463ms step_avg:179.85ms
+step:2122/4150 train_time:381698ms step_avg:179.88ms
+step:2123/4150 train_time:381932ms step_avg:179.90ms
+step:2124/4150 train_time:382167ms step_avg:179.93ms
+step:2125/4150 train_time:382404ms step_avg:179.95ms
+step:2126/4150 train_time:382639ms step_avg:179.98ms
+step:2127/4150 train_time:382877ms step_avg:180.01ms
+step:2128/4150 train_time:383115ms step_avg:180.04ms
+step:2129/4150 train_time:383347ms step_avg:180.06ms
+step:2130/4150 train_time:383583ms step_avg:180.09ms
+step:2131/4150 train_time:383819ms step_avg:180.11ms
+step:2132/4150 train_time:384055ms step_avg:180.14ms
+step:2133/4150 train_time:384289ms step_avg:180.16ms
+step:2134/4150 train_time:384525ms step_avg:180.19ms
+step:2135/4150 train_time:384763ms step_avg:180.22ms
+step:2136/4150 train_time:384999ms step_avg:180.24ms
+step:2137/4150 train_time:385233ms step_avg:180.27ms
+step:2138/4150 train_time:385471ms step_avg:180.29ms
+step:2139/4150 train_time:385705ms step_avg:180.32ms
+step:2140/4150 train_time:385942ms step_avg:180.35ms
+step:2141/4150 train_time:386178ms step_avg:180.37ms
+step:2142/4150 train_time:386416ms step_avg:180.40ms
+step:2143/4150 train_time:386647ms step_avg:180.42ms
+step:2144/4150 train_time:386885ms step_avg:180.45ms
+step:2145/4150 train_time:387118ms step_avg:180.47ms
+step:2146/4150 train_time:387356ms step_avg:180.50ms
+step:2147/4150 train_time:387591ms step_avg:180.53ms
+step:2148/4150 train_time:387827ms step_avg:180.55ms
+step:2149/4150 train_time:388063ms step_avg:180.58ms
+step:2150/4150 train_time:388301ms step_avg:180.60ms
+step:2151/4150 train_time:388536ms step_avg:180.63ms
+step:2152/4150 train_time:388773ms step_avg:180.66ms
+step:2153/4150 train_time:389004ms step_avg:180.68ms
+step:2154/4150 train_time:389243ms step_avg:180.71ms
+step:2155/4150 train_time:389475ms step_avg:180.73ms
+step:2156/4150 train_time:389714ms step_avg:180.76ms
+step:2157/4150 train_time:389946ms step_avg:180.78ms
+step:2158/4150 train_time:390183ms step_avg:180.81ms
+step:2159/4150 train_time:390416ms step_avg:180.83ms
+step:2160/4150 train_time:390657ms step_avg:180.86ms
+step:2161/4150 train_time:390893ms step_avg:180.89ms
+step:2162/4150 train_time:391130ms step_avg:180.91ms
+step:2163/4150 train_time:391362ms step_avg:180.94ms
+step:2164/4150 train_time:391598ms step_avg:180.96ms
+step:2165/4150 train_time:391833ms step_avg:180.99ms
+step:2166/4150 train_time:392068ms step_avg:181.01ms
+step:2167/4150 train_time:392301ms step_avg:181.03ms
+step:2168/4150 train_time:392536ms step_avg:181.06ms
+step:2169/4150 train_time:392775ms step_avg:181.09ms
+step:2170/4150 train_time:393014ms step_avg:181.11ms
+step:2171/4150 train_time:393250ms step_avg:181.14ms
+step:2172/4150 train_time:393485ms step_avg:181.16ms
+step:2173/4150 train_time:393720ms step_avg:181.19ms
+step:2174/4150 train_time:393960ms step_avg:181.21ms
+step:2175/4150 train_time:394194ms step_avg:181.24ms
+step:2176/4150 train_time:394431ms step_avg:181.26ms
+step:2177/4150 train_time:394663ms step_avg:181.29ms
+step:2178/4150 train_time:394899ms step_avg:181.31ms
+step:2179/4150 train_time:395132ms step_avg:181.34ms
+step:2180/4150 train_time:395369ms step_avg:181.36ms
+step:2181/4150 train_time:395603ms step_avg:181.39ms
+step:2182/4150 train_time:395840ms step_avg:181.41ms
+step:2183/4150 train_time:396073ms step_avg:181.44ms
+step:2184/4150 train_time:396314ms step_avg:181.46ms
+step:2185/4150 train_time:396546ms step_avg:181.49ms
+step:2186/4150 train_time:396784ms step_avg:181.51ms
+step:2187/4150 train_time:397017ms step_avg:181.54ms
+step:2188/4150 train_time:397253ms step_avg:181.56ms
+step:2189/4150 train_time:397488ms step_avg:181.58ms
+step:2190/4150 train_time:397724ms step_avg:181.61ms
+step:2191/4150 train_time:397958ms step_avg:181.63ms
+step:2192/4150 train_time:398197ms step_avg:181.66ms
+step:2193/4150 train_time:398433ms step_avg:181.68ms
+step:2194/4150 train_time:398670ms step_avg:181.71ms
+step:2195/4150 train_time:398903ms step_avg:181.73ms
+step:2196/4150 train_time:399140ms step_avg:181.76ms
+step:2197/4150 train_time:399374ms step_avg:181.78ms
+step:2198/4150 train_time:399610ms step_avg:181.81ms
+step:2199/4150 train_time:399844ms step_avg:181.83ms
+step:2200/4150 train_time:400079ms step_avg:181.85ms
+step:2201/4150 train_time:400316ms step_avg:181.88ms
+step:2202/4150 train_time:400553ms step_avg:181.90ms
+step:2203/4150 train_time:400784ms step_avg:181.93ms
+step:2204/4150 train_time:401019ms step_avg:181.95ms
+step:2205/4150 train_time:401254ms step_avg:181.97ms
+step:2206/4150 train_time:401495ms step_avg:182.00ms
+step:2207/4150 train_time:401732ms step_avg:182.03ms
+step:2208/4150 train_time:401968ms step_avg:182.05ms
+step:2209/4150 train_time:402199ms step_avg:182.07ms
+step:2210/4150 train_time:402436ms step_avg:182.10ms
+step:2211/4150 train_time:402670ms step_avg:182.12ms
+step:2212/4150 train_time:402908ms step_avg:182.15ms
+step:2213/4150 train_time:403141ms step_avg:182.17ms
+step:2214/4150 train_time:403376ms step_avg:182.19ms
+step:2215/4150 train_time:403611ms step_avg:182.22ms
+step:2216/4150 train_time:403848ms step_avg:182.24ms
+step:2217/4150 train_time:404079ms step_avg:182.26ms
+step:2218/4150 train_time:404314ms step_avg:182.29ms
+step:2219/4150 train_time:404550ms step_avg:182.31ms
+step:2220/4150 train_time:404791ms step_avg:182.34ms
+step:2221/4150 train_time:405025ms step_avg:182.36ms
+step:2222/4150 train_time:405262ms step_avg:182.39ms
+step:2223/4150 train_time:405498ms step_avg:182.41ms
+step:2224/4150 train_time:405736ms step_avg:182.44ms
+step:2225/4150 train_time:405970ms step_avg:182.46ms
+step:2226/4150 train_time:406205ms step_avg:182.48ms
+step:2227/4150 train_time:406437ms step_avg:182.50ms
+step:2228/4150 train_time:406675ms step_avg:182.53ms
+step:2229/4150 train_time:406909ms step_avg:182.55ms
+step:2230/4150 train_time:407145ms step_avg:182.58ms
+step:2231/4150 train_time:407376ms step_avg:182.60ms
+step:2232/4150 train_time:407616ms step_avg:182.62ms
+step:2233/4150 train_time:407851ms step_avg:182.65ms
+step:2234/4150 train_time:408087ms step_avg:182.67ms
+step:2235/4150 train_time:408320ms step_avg:182.69ms
+step:2236/4150 train_time:408556ms step_avg:182.72ms
+step:2237/4150 train_time:408794ms step_avg:182.74ms
+step:2238/4150 train_time:409033ms step_avg:182.77ms
+step:2239/4150 train_time:409263ms step_avg:182.79ms
+step:2240/4150 train_time:409498ms step_avg:182.81ms
+step:2241/4150 train_time:409733ms step_avg:182.83ms
+step:2242/4150 train_time:409968ms step_avg:182.86ms
+step:2243/4150 train_time:410201ms step_avg:182.88ms
+step:2244/4150 train_time:410435ms step_avg:182.90ms
+step:2245/4150 train_time:410668ms step_avg:182.93ms
+step:2246/4150 train_time:410903ms step_avg:182.95ms
+step:2247/4150 train_time:411138ms step_avg:182.97ms
+step:2248/4150 train_time:411374ms step_avg:183.00ms
+step:2249/4150 train_time:411609ms step_avg:183.02ms
+step:2250/4150 train_time:411848ms step_avg:183.04ms
+step:2250/4150 val_loss:3.1443 train_time:412062ms step_avg:183.14ms
+step:2251/4150 train_time:412084ms step_avg:183.07ms
+step:2252/4150 train_time:412322ms step_avg:183.09ms
+step:2253/4150 train_time:412556ms step_avg:183.11ms
+step:2254/4150 train_time:412790ms step_avg:183.14ms
+step:2255/4150 train_time:413023ms step_avg:183.16ms
+step:2256/4150 train_time:413258ms step_avg:183.18ms
+step:2257/4150 train_time:413496ms step_avg:183.21ms
+step:2258/4150 train_time:413734ms step_avg:183.23ms
+step:2259/4150 train_time:413966ms step_avg:183.25ms
+step:2260/4150 train_time:414202ms step_avg:183.28ms
+step:2261/4150 train_time:414438ms step_avg:183.30ms
+step:2262/4150 train_time:414678ms step_avg:183.32ms
+step:2263/4150 train_time:414910ms step_avg:183.35ms
+step:2264/4150 train_time:415146ms step_avg:183.37ms
+step:2265/4150 train_time:415380ms step_avg:183.39ms
+step:2266/4150 train_time:415618ms step_avg:183.41ms
+step:2267/4150 train_time:415851ms step_avg:183.44ms
+step:2268/4150 train_time:416087ms step_avg:183.46ms
+step:2269/4150 train_time:416322ms step_avg:183.48ms
+step:2270/4150 train_time:416559ms step_avg:183.51ms
+step:2271/4150 train_time:416792ms step_avg:183.53ms
+step:2272/4150 train_time:417026ms step_avg:183.55ms
+step:2273/4150 train_time:417258ms step_avg:183.57ms
+step:2274/4150 train_time:417499ms step_avg:183.60ms
+step:2275/4150 train_time:417732ms step_avg:183.62ms
+step:2276/4150 train_time:417972ms step_avg:183.64ms
+step:2277/4150 train_time:418206ms step_avg:183.67ms
+step:2278/4150 train_time:418441ms step_avg:183.69ms
+step:2279/4150 train_time:418673ms step_avg:183.71ms
+step:2280/4150 train_time:418908ms step_avg:183.73ms
+step:2281/4150 train_time:419142ms step_avg:183.75ms
+step:2282/4150 train_time:419378ms step_avg:183.78ms
+step:2283/4150 train_time:419614ms step_avg:183.80ms
+step:2284/4150 train_time:419849ms step_avg:183.82ms
+step:2285/4150 train_time:420080ms step_avg:183.84ms
+step:2286/4150 train_time:420315ms step_avg:183.86ms
+step:2287/4150 train_time:420548ms step_avg:183.89ms
+step:2288/4150 train_time:420785ms step_avg:183.91ms
+step:2289/4150 train_time:421019ms step_avg:183.93ms
+step:2290/4150 train_time:421257ms step_avg:183.95ms
+step:2291/4150 train_time:421493ms step_avg:183.98ms
+step:2292/4150 train_time:421733ms step_avg:184.00ms
+step:2293/4150 train_time:421965ms step_avg:184.02ms
+step:2294/4150 train_time:422202ms step_avg:184.05ms
+step:2295/4150 train_time:422437ms step_avg:184.07ms
+step:2296/4150 train_time:422673ms step_avg:184.09ms
+step:2297/4150 train_time:422906ms step_avg:184.11ms
+step:2298/4150 train_time:423142ms step_avg:184.13ms
+step:2299/4150 train_time:423373ms step_avg:184.16ms
+step:2300/4150 train_time:423612ms step_avg:184.18ms
+step:2301/4150 train_time:423847ms step_avg:184.20ms
+step:2302/4150 train_time:424082ms step_avg:184.22ms
+step:2303/4150 train_time:424315ms step_avg:184.24ms
+step:2304/4150 train_time:424553ms step_avg:184.27ms
+step:2305/4150 train_time:424788ms step_avg:184.29ms
+step:2306/4150 train_time:425022ms step_avg:184.31ms
+step:2307/4150 train_time:425258ms step_avg:184.33ms
+step:2308/4150 train_time:425493ms step_avg:184.36ms
+step:2309/4150 train_time:425730ms step_avg:184.38ms
+step:2310/4150 train_time:425964ms step_avg:184.40ms
+step:2311/4150 train_time:426196ms step_avg:184.42ms
+step:2312/4150 train_time:426434ms step_avg:184.44ms
+step:2313/4150 train_time:426668ms step_avg:184.47ms
+step:2314/4150 train_time:426905ms step_avg:184.49ms
+step:2315/4150 train_time:427138ms step_avg:184.51ms
+step:2316/4150 train_time:427375ms step_avg:184.53ms
+step:2317/4150 train_time:427611ms step_avg:184.55ms
+step:2318/4150 train_time:427848ms step_avg:184.58ms
+step:2319/4150 train_time:428082ms step_avg:184.60ms
+step:2320/4150 train_time:428318ms step_avg:184.62ms
+step:2321/4150 train_time:428555ms step_avg:184.64ms
+step:2322/4150 train_time:428796ms step_avg:184.67ms
+step:2323/4150 train_time:429033ms step_avg:184.69ms
+step:2324/4150 train_time:429271ms step_avg:184.71ms
+step:2325/4150 train_time:429504ms step_avg:184.73ms
+step:2326/4150 train_time:429741ms step_avg:184.76ms
+step:2327/4150 train_time:429973ms step_avg:184.78ms
+step:2328/4150 train_time:430210ms step_avg:184.80ms
+step:2329/4150 train_time:430441ms step_avg:184.82ms
+step:2330/4150 train_time:430680ms step_avg:184.84ms
+step:2331/4150 train_time:430913ms step_avg:184.86ms
+step:2332/4150 train_time:431151ms step_avg:184.88ms
+step:2333/4150 train_time:431385ms step_avg:184.91ms
+step:2334/4150 train_time:431620ms step_avg:184.93ms
+step:2335/4150 train_time:431853ms step_avg:184.95ms
+step:2336/4150 train_time:432090ms step_avg:184.97ms
+step:2337/4150 train_time:432321ms step_avg:184.99ms
+step:2338/4150 train_time:432556ms step_avg:185.01ms
+step:2339/4150 train_time:432789ms step_avg:185.03ms
+step:2340/4150 train_time:433026ms step_avg:185.05ms
+step:2341/4150 train_time:433260ms step_avg:185.07ms
+step:2342/4150 train_time:433496ms step_avg:185.10ms
+step:2343/4150 train_time:433731ms step_avg:185.12ms
+step:2344/4150 train_time:433968ms step_avg:185.14ms
+step:2345/4150 train_time:434201ms step_avg:185.16ms
+step:2346/4150 train_time:434437ms step_avg:185.18ms
+step:2347/4150 train_time:434670ms step_avg:185.20ms
+step:2348/4150 train_time:434908ms step_avg:185.22ms
+step:2349/4150 train_time:435141ms step_avg:185.25ms
+step:2350/4150 train_time:435377ms step_avg:185.27ms
+step:2351/4150 train_time:435610ms step_avg:185.29ms
+step:2352/4150 train_time:435847ms step_avg:185.31ms
+step:2353/4150 train_time:436082ms step_avg:185.33ms
+step:2354/4150 train_time:436320ms step_avg:185.35ms
+step:2355/4150 train_time:436554ms step_avg:185.37ms
+step:2356/4150 train_time:436791ms step_avg:185.39ms
+step:2357/4150 train_time:437025ms step_avg:185.42ms
+step:2358/4150 train_time:437262ms step_avg:185.44ms
+step:2359/4150 train_time:437494ms step_avg:185.46ms
+step:2360/4150 train_time:437731ms step_avg:185.48ms
+step:2361/4150 train_time:437964ms step_avg:185.50ms
+step:2362/4150 train_time:438200ms step_avg:185.52ms
+step:2363/4150 train_time:438436ms step_avg:185.54ms
+step:2364/4150 train_time:438672ms step_avg:185.56ms
+step:2365/4150 train_time:438907ms step_avg:185.58ms
+step:2366/4150 train_time:439143ms step_avg:185.61ms
+step:2367/4150 train_time:439376ms step_avg:185.63ms
+step:2368/4150 train_time:439614ms step_avg:185.65ms
+step:2369/4150 train_time:439850ms step_avg:185.67ms
+step:2370/4150 train_time:440086ms step_avg:185.69ms
+step:2371/4150 train_time:440319ms step_avg:185.71ms
+step:2372/4150 train_time:440555ms step_avg:185.73ms
+step:2373/4150 train_time:440789ms step_avg:185.75ms
+step:2374/4150 train_time:441027ms step_avg:185.77ms
+step:2375/4150 train_time:441260ms step_avg:185.79ms
+step:2376/4150 train_time:441497ms step_avg:185.82ms
+step:2377/4150 train_time:441729ms step_avg:185.83ms
+step:2378/4150 train_time:441969ms step_avg:185.86ms
+step:2379/4150 train_time:442203ms step_avg:185.88ms
+step:2380/4150 train_time:442438ms step_avg:185.90ms
+step:2381/4150 train_time:442671ms step_avg:185.92ms
+step:2382/4150 train_time:442912ms step_avg:185.94ms
+step:2383/4150 train_time:443149ms step_avg:185.96ms
+step:2384/4150 train_time:443384ms step_avg:185.98ms
+step:2385/4150 train_time:443615ms step_avg:186.00ms
+step:2386/4150 train_time:443852ms step_avg:186.02ms
+step:2387/4150 train_time:444087ms step_avg:186.04ms
+step:2388/4150 train_time:444321ms step_avg:186.06ms
+step:2389/4150 train_time:444553ms step_avg:186.08ms
+step:2390/4150 train_time:444793ms step_avg:186.11ms
+step:2391/4150 train_time:445027ms step_avg:186.13ms
+step:2392/4150 train_time:445260ms step_avg:186.15ms
+step:2393/4150 train_time:445495ms step_avg:186.17ms
+step:2394/4150 train_time:445732ms step_avg:186.19ms
+step:2395/4150 train_time:445967ms step_avg:186.21ms
+step:2396/4150 train_time:446205ms step_avg:186.23ms
+step:2397/4150 train_time:446438ms step_avg:186.25ms
+step:2398/4150 train_time:446672ms step_avg:186.27ms
+step:2399/4150 train_time:446905ms step_avg:186.29ms
+step:2400/4150 train_time:447140ms step_avg:186.31ms
+step:2401/4150 train_time:447375ms step_avg:186.33ms
+step:2402/4150 train_time:447610ms step_avg:186.35ms
+step:2403/4150 train_time:447839ms step_avg:186.37ms
+step:2404/4150 train_time:448077ms step_avg:186.39ms
+step:2405/4150 train_time:448314ms step_avg:186.41ms
+step:2406/4150 train_time:448550ms step_avg:186.43ms
+step:2407/4150 train_time:448784ms step_avg:186.45ms
+step:2408/4150 train_time:449019ms step_avg:186.47ms
+step:2409/4150 train_time:449255ms step_avg:186.49ms
+step:2410/4150 train_time:449496ms step_avg:186.51ms
+step:2411/4150 train_time:449734ms step_avg:186.53ms
+step:2412/4150 train_time:449972ms step_avg:186.56ms
+step:2413/4150 train_time:450208ms step_avg:186.58ms
+step:2414/4150 train_time:450445ms step_avg:186.60ms
+step:2415/4150 train_time:450679ms step_avg:186.62ms
+step:2416/4150 train_time:450915ms step_avg:186.64ms
+step:2417/4150 train_time:451155ms step_avg:186.66ms
+step:2418/4150 train_time:451394ms step_avg:186.68ms
+step:2419/4150 train_time:451626ms step_avg:186.70ms
+step:2420/4150 train_time:451862ms step_avg:186.72ms
+step:2421/4150 train_time:452098ms step_avg:186.74ms
+step:2422/4150 train_time:452339ms step_avg:186.76ms
+step:2423/4150 train_time:452573ms step_avg:186.78ms
+step:2424/4150 train_time:452808ms step_avg:186.80ms
+step:2425/4150 train_time:453042ms step_avg:186.82ms
+step:2426/4150 train_time:453281ms step_avg:186.84ms
+step:2427/4150 train_time:453515ms step_avg:186.86ms
+step:2428/4150 train_time:453752ms step_avg:186.88ms
+step:2429/4150 train_time:453987ms step_avg:186.90ms
+step:2430/4150 train_time:454226ms step_avg:186.92ms
+step:2431/4150 train_time:454461ms step_avg:186.94ms
+step:2432/4150 train_time:454701ms step_avg:186.97ms
+step:2433/4150 train_time:454933ms step_avg:186.98ms
+step:2434/4150 train_time:455171ms step_avg:187.01ms
+step:2435/4150 train_time:455403ms step_avg:187.02ms
+step:2436/4150 train_time:455641ms step_avg:187.04ms
+step:2437/4150 train_time:455875ms step_avg:187.06ms
+step:2438/4150 train_time:456113ms step_avg:187.08ms
+step:2439/4150 train_time:456347ms step_avg:187.10ms
+step:2440/4150 train_time:456586ms step_avg:187.13ms
+step:2441/4150 train_time:456819ms step_avg:187.14ms
+step:2442/4150 train_time:457058ms step_avg:187.17ms
+step:2443/4150 train_time:457291ms step_avg:187.18ms
+step:2444/4150 train_time:457528ms step_avg:187.20ms
+step:2445/4150 train_time:457760ms step_avg:187.22ms
+step:2446/4150 train_time:457997ms step_avg:187.24ms
+step:2447/4150 train_time:458230ms step_avg:187.26ms
+step:2448/4150 train_time:458468ms step_avg:187.28ms
+step:2449/4150 train_time:458702ms step_avg:187.30ms
+step:2450/4150 train_time:458941ms step_avg:187.32ms
+step:2451/4150 train_time:459176ms step_avg:187.34ms
+step:2452/4150 train_time:459413ms step_avg:187.36ms
+step:2453/4150 train_time:459648ms step_avg:187.38ms
+step:2454/4150 train_time:459886ms step_avg:187.40ms
+step:2455/4150 train_time:460119ms step_avg:187.42ms
+step:2456/4150 train_time:460358ms step_avg:187.44ms
+step:2457/4150 train_time:460593ms step_avg:187.46ms
+step:2458/4150 train_time:460830ms step_avg:187.48ms
+step:2459/4150 train_time:461062ms step_avg:187.50ms
+step:2460/4150 train_time:461299ms step_avg:187.52ms
+step:2461/4150 train_time:461532ms step_avg:187.54ms
+step:2462/4150 train_time:461773ms step_avg:187.56ms
+step:2463/4150 train_time:462011ms step_avg:187.58ms
+step:2464/4150 train_time:462249ms step_avg:187.60ms
+step:2465/4150 train_time:462485ms step_avg:187.62ms
+step:2466/4150 train_time:462724ms step_avg:187.64ms
+step:2467/4150 train_time:462957ms step_avg:187.66ms
+step:2468/4150 train_time:463195ms step_avg:187.68ms
+step:2469/4150 train_time:463430ms step_avg:187.70ms
+step:2470/4150 train_time:463668ms step_avg:187.72ms
+step:2471/4150 train_time:463907ms step_avg:187.74ms
+step:2472/4150 train_time:464143ms step_avg:187.76ms
+step:2473/4150 train_time:464375ms step_avg:187.78ms
+step:2474/4150 train_time:464610ms step_avg:187.80ms
+step:2475/4150 train_time:464846ms step_avg:187.82ms
+step:2476/4150 train_time:465085ms step_avg:187.84ms
+step:2477/4150 train_time:465319ms step_avg:187.86ms
+step:2478/4150 train_time:465556ms step_avg:187.88ms
+step:2479/4150 train_time:465789ms step_avg:187.89ms
+step:2480/4150 train_time:466028ms step_avg:187.91ms
+step:2481/4150 train_time:466259ms step_avg:187.93ms
+step:2482/4150 train_time:466494ms step_avg:187.95ms
+step:2483/4150 train_time:466730ms step_avg:187.97ms
+step:2484/4150 train_time:466968ms step_avg:187.99ms
+step:2485/4150 train_time:467202ms step_avg:188.01ms
+step:2486/4150 train_time:467439ms step_avg:188.03ms
+step:2487/4150 train_time:467675ms step_avg:188.05ms
+step:2488/4150 train_time:467918ms step_avg:188.07ms
+step:2489/4150 train_time:468152ms step_avg:188.09ms
+step:2490/4150 train_time:468389ms step_avg:188.11ms
+step:2491/4150 train_time:468623ms step_avg:188.13ms
+step:2492/4150 train_time:468859ms step_avg:188.15ms
+step:2493/4150 train_time:469096ms step_avg:188.17ms
+step:2494/4150 train_time:469331ms step_avg:188.18ms
+step:2495/4150 train_time:469565ms step_avg:188.20ms
+step:2496/4150 train_time:469801ms step_avg:188.22ms
+step:2497/4150 train_time:470033ms step_avg:188.24ms
+step:2498/4150 train_time:470270ms step_avg:188.26ms
+step:2499/4150 train_time:470502ms step_avg:188.28ms
+step:2500/4150 train_time:470739ms step_avg:188.30ms
+step:2500/4150 val_loss:3.1072 train_time:470957ms step_avg:188.38ms
+step:2501/4150 train_time:470981ms step_avg:188.32ms
+step:2502/4150 train_time:471220ms step_avg:188.34ms
+step:2503/4150 train_time:471458ms step_avg:188.36ms
+step:2504/4150 train_time:471690ms step_avg:188.37ms
+step:2505/4150 train_time:471924ms step_avg:188.39ms
+step:2506/4150 train_time:472162ms step_avg:188.41ms
+step:2507/4150 train_time:472398ms step_avg:188.43ms
+step:2508/4150 train_time:472632ms step_avg:188.45ms
+step:2509/4150 train_time:472865ms step_avg:188.47ms
+step:2510/4150 train_time:473104ms step_avg:188.49ms
+step:2511/4150 train_time:473339ms step_avg:188.51ms
+step:2512/4150 train_time:473573ms step_avg:188.52ms
+step:2513/4150 train_time:473805ms step_avg:188.54ms
+step:2514/4150 train_time:474043ms step_avg:188.56ms
+step:2515/4150 train_time:474282ms step_avg:188.58ms
+step:2516/4150 train_time:474519ms step_avg:188.60ms
+step:2517/4150 train_time:474751ms step_avg:188.62ms
+step:2518/4150 train_time:474991ms step_avg:188.64ms
+step:2519/4150 train_time:475227ms step_avg:188.66ms
+step:2520/4150 train_time:475464ms step_avg:188.68ms
+step:2521/4150 train_time:475696ms step_avg:188.69ms
+step:2522/4150 train_time:475931ms step_avg:188.71ms
+step:2523/4150 train_time:476168ms step_avg:188.73ms
+step:2524/4150 train_time:476405ms step_avg:188.75ms
+step:2525/4150 train_time:476641ms step_avg:188.77ms
+step:2526/4150 train_time:476876ms step_avg:188.79ms
+step:2527/4150 train_time:477111ms step_avg:188.81ms
+step:2528/4150 train_time:477348ms step_avg:188.82ms
+step:2529/4150 train_time:477581ms step_avg:188.84ms
+step:2530/4150 train_time:477817ms step_avg:188.86ms
+step:2531/4150 train_time:478051ms step_avg:188.88ms
+step:2532/4150 train_time:478289ms step_avg:188.90ms
+step:2533/4150 train_time:478525ms step_avg:188.92ms
+step:2534/4150 train_time:478762ms step_avg:188.94ms
+step:2535/4150 train_time:478995ms step_avg:188.95ms
+step:2536/4150 train_time:479230ms step_avg:188.97ms
+step:2537/4150 train_time:479468ms step_avg:188.99ms
+step:2538/4150 train_time:479704ms step_avg:189.01ms
+step:2539/4150 train_time:479936ms step_avg:189.03ms
+step:2540/4150 train_time:480173ms step_avg:189.04ms
+step:2541/4150 train_time:480407ms step_avg:189.06ms
+step:2542/4150 train_time:480642ms step_avg:189.08ms
+step:2543/4150 train_time:480875ms step_avg:189.10ms
+step:2544/4150 train_time:481112ms step_avg:189.12ms
+step:2545/4150 train_time:481346ms step_avg:189.13ms
+step:2546/4150 train_time:481588ms step_avg:189.15ms
+step:2547/4150 train_time:481823ms step_avg:189.17ms
+step:2548/4150 train_time:482061ms step_avg:189.19ms
+step:2549/4150 train_time:482297ms step_avg:189.21ms
+step:2550/4150 train_time:482532ms step_avg:189.23ms
+step:2551/4150 train_time:482767ms step_avg:189.25ms
+step:2552/4150 train_time:483007ms step_avg:189.27ms
+step:2553/4150 train_time:483239ms step_avg:189.28ms
+step:2554/4150 train_time:483477ms step_avg:189.30ms
+step:2555/4150 train_time:483711ms step_avg:189.32ms
+step:2556/4150 train_time:483947ms step_avg:189.34ms
+step:2557/4150 train_time:484180ms step_avg:189.35ms
+step:2558/4150 train_time:484418ms step_avg:189.37ms
+step:2559/4150 train_time:484653ms step_avg:189.39ms
+step:2560/4150 train_time:484890ms step_avg:189.41ms
+step:2561/4150 train_time:485125ms step_avg:189.43ms
+step:2562/4150 train_time:485360ms step_avg:189.45ms
+step:2563/4150 train_time:485593ms step_avg:189.46ms
+step:2564/4150 train_time:485832ms step_avg:189.48ms
+step:2565/4150 train_time:486071ms step_avg:189.50ms
+step:2566/4150 train_time:486307ms step_avg:189.52ms
+step:2567/4150 train_time:486540ms step_avg:189.54ms
+step:2568/4150 train_time:486777ms step_avg:189.55ms
+step:2569/4150 train_time:487012ms step_avg:189.57ms
+step:2570/4150 train_time:487249ms step_avg:189.59ms
+step:2571/4150 train_time:487481ms step_avg:189.61ms
+step:2572/4150 train_time:487718ms step_avg:189.63ms
+step:2573/4150 train_time:487951ms step_avg:189.64ms
+step:2574/4150 train_time:488189ms step_avg:189.66ms
+step:2575/4150 train_time:488426ms step_avg:189.68ms
+step:2576/4150 train_time:488664ms step_avg:189.70ms
+step:2577/4150 train_time:488900ms step_avg:189.72ms
+step:2578/4150 train_time:489137ms step_avg:189.74ms
+step:2579/4150 train_time:489373ms step_avg:189.75ms
+step:2580/4150 train_time:489608ms step_avg:189.77ms
+step:2581/4150 train_time:489844ms step_avg:189.79ms
+step:2582/4150 train_time:490082ms step_avg:189.81ms
+step:2583/4150 train_time:490313ms step_avg:189.82ms
+step:2584/4150 train_time:490550ms step_avg:189.84ms
+step:2585/4150 train_time:490783ms step_avg:189.86ms
+step:2586/4150 train_time:491023ms step_avg:189.88ms
+step:2587/4150 train_time:491256ms step_avg:189.89ms
+step:2588/4150 train_time:491492ms step_avg:189.91ms
+step:2589/4150 train_time:491727ms step_avg:189.93ms
+step:2590/4150 train_time:491968ms step_avg:189.95ms
+step:2591/4150 train_time:492203ms step_avg:189.97ms
+step:2592/4150 train_time:492439ms step_avg:189.98ms
+step:2593/4150 train_time:492672ms step_avg:190.00ms
+step:2594/4150 train_time:492909ms step_avg:190.02ms
+step:2595/4150 train_time:493147ms step_avg:190.04ms
+step:2596/4150 train_time:493387ms step_avg:190.06ms
+step:2597/4150 train_time:493620ms step_avg:190.07ms
+step:2598/4150 train_time:493857ms step_avg:190.09ms
+step:2599/4150 train_time:494088ms step_avg:190.11ms
+step:2600/4150 train_time:494330ms step_avg:190.13ms
+step:2601/4150 train_time:494563ms step_avg:190.14ms
+step:2602/4150 train_time:494799ms step_avg:190.16ms
+step:2603/4150 train_time:495036ms step_avg:190.18ms
+step:2604/4150 train_time:495272ms step_avg:190.20ms
+step:2605/4150 train_time:495505ms step_avg:190.21ms
+step:2606/4150 train_time:495742ms step_avg:190.23ms
+step:2607/4150 train_time:495977ms step_avg:190.25ms
+step:2608/4150 train_time:496214ms step_avg:190.27ms
+step:2609/4150 train_time:496447ms step_avg:190.28ms
+step:2610/4150 train_time:496682ms step_avg:190.30ms
+step:2611/4150 train_time:496914ms step_avg:190.32ms
+step:2612/4150 train_time:497153ms step_avg:190.33ms
+step:2613/4150 train_time:497388ms step_avg:190.35ms
+step:2614/4150 train_time:497624ms step_avg:190.37ms
+step:2615/4150 train_time:497858ms step_avg:190.39ms
+step:2616/4150 train_time:498094ms step_avg:190.40ms
+step:2617/4150 train_time:498328ms step_avg:190.42ms
+step:2618/4150 train_time:498568ms step_avg:190.44ms
+step:2619/4150 train_time:498801ms step_avg:190.45ms
+step:2620/4150 train_time:499040ms step_avg:190.47ms
+step:2621/4150 train_time:499271ms step_avg:190.49ms
+step:2622/4150 train_time:499513ms step_avg:190.51ms
+step:2623/4150 train_time:499747ms step_avg:190.53ms
+step:2624/4150 train_time:499991ms step_avg:190.55ms
+step:2625/4150 train_time:500226ms step_avg:190.56ms
+step:2626/4150 train_time:500465ms step_avg:190.58ms
+step:2627/4150 train_time:500698ms step_avg:190.60ms
+step:2628/4150 train_time:500934ms step_avg:190.61ms
+step:2629/4150 train_time:501168ms step_avg:190.63ms
+step:2630/4150 train_time:501405ms step_avg:190.65ms
+step:2631/4150 train_time:501638ms step_avg:190.66ms
+step:2632/4150 train_time:501876ms step_avg:190.68ms
+step:2633/4150 train_time:502110ms step_avg:190.70ms
+step:2634/4150 train_time:502346ms step_avg:190.72ms
+step:2635/4150 train_time:502581ms step_avg:190.73ms
+step:2636/4150 train_time:502818ms step_avg:190.75ms
+step:2637/4150 train_time:503049ms step_avg:190.77ms
+step:2638/4150 train_time:503290ms step_avg:190.78ms
+step:2639/4150 train_time:503525ms step_avg:190.80ms
+step:2640/4150 train_time:503765ms step_avg:190.82ms
+step:2641/4150 train_time:503998ms step_avg:190.84ms
+step:2642/4150 train_time:504236ms step_avg:190.85ms
+step:2643/4150 train_time:504471ms step_avg:190.87ms
+step:2644/4150 train_time:504710ms step_avg:190.89ms
+step:2645/4150 train_time:504945ms step_avg:190.91ms
+step:2646/4150 train_time:505183ms step_avg:190.92ms
+step:2647/4150 train_time:505418ms step_avg:190.94ms
+step:2648/4150 train_time:505656ms step_avg:190.96ms
+step:2649/4150 train_time:505890ms step_avg:190.97ms
+step:2650/4150 train_time:506126ms step_avg:190.99ms
+step:2651/4150 train_time:506358ms step_avg:191.01ms
+step:2652/4150 train_time:506597ms step_avg:191.02ms
+step:2653/4150 train_time:506835ms step_avg:191.04ms
+step:2654/4150 train_time:507071ms step_avg:191.06ms
+step:2655/4150 train_time:507304ms step_avg:191.07ms
+step:2656/4150 train_time:507541ms step_avg:191.09ms
+step:2657/4150 train_time:507777ms step_avg:191.11ms
+step:2658/4150 train_time:508015ms step_avg:191.13ms
+step:2659/4150 train_time:508248ms step_avg:191.14ms
+step:2660/4150 train_time:508485ms step_avg:191.16ms
+step:2661/4150 train_time:508720ms step_avg:191.18ms
+step:2662/4150 train_time:508957ms step_avg:191.19ms
+step:2663/4150 train_time:509190ms step_avg:191.21ms
+step:2664/4150 train_time:509428ms step_avg:191.23ms
+step:2665/4150 train_time:509661ms step_avg:191.24ms
+step:2666/4150 train_time:509898ms step_avg:191.26ms
+step:2667/4150 train_time:510131ms step_avg:191.28ms
+step:2668/4150 train_time:510368ms step_avg:191.29ms
+step:2669/4150 train_time:510603ms step_avg:191.31ms
+step:2670/4150 train_time:510839ms step_avg:191.33ms
+step:2671/4150 train_time:511075ms step_avg:191.34ms
+step:2672/4150 train_time:511313ms step_avg:191.36ms
+step:2673/4150 train_time:511552ms step_avg:191.38ms
+step:2674/4150 train_time:511787ms step_avg:191.39ms
+step:2675/4150 train_time:512021ms step_avg:191.41ms
+step:2676/4150 train_time:512257ms step_avg:191.43ms
+step:2677/4150 train_time:512490ms step_avg:191.44ms
+step:2678/4150 train_time:512726ms step_avg:191.46ms
+step:2679/4150 train_time:512958ms step_avg:191.47ms
+step:2680/4150 train_time:513196ms step_avg:191.49ms
+step:2681/4150 train_time:513431ms step_avg:191.51ms
+step:2682/4150 train_time:513668ms step_avg:191.52ms
+step:2683/4150 train_time:513902ms step_avg:191.54ms
+step:2684/4150 train_time:514141ms step_avg:191.56ms
+step:2685/4150 train_time:514375ms step_avg:191.57ms
+step:2686/4150 train_time:514612ms step_avg:191.59ms
+step:2687/4150 train_time:514849ms step_avg:191.61ms
+step:2688/4150 train_time:515086ms step_avg:191.62ms
+step:2689/4150 train_time:515321ms step_avg:191.64ms
+step:2690/4150 train_time:515557ms step_avg:191.66ms
+step:2691/4150 train_time:515792ms step_avg:191.67ms
+step:2692/4150 train_time:516029ms step_avg:191.69ms
+step:2693/4150 train_time:516263ms step_avg:191.71ms
+step:2694/4150 train_time:516503ms step_avg:191.72ms
+step:2695/4150 train_time:516737ms step_avg:191.74ms
+step:2696/4150 train_time:516974ms step_avg:191.76ms
+step:2697/4150 train_time:517212ms step_avg:191.77ms
+step:2698/4150 train_time:517450ms step_avg:191.79ms
+step:2699/4150 train_time:517683ms step_avg:191.81ms
+step:2700/4150 train_time:517920ms step_avg:191.82ms
+step:2701/4150 train_time:518152ms step_avg:191.84ms
+step:2702/4150 train_time:518391ms step_avg:191.85ms
+step:2703/4150 train_time:518629ms step_avg:191.87ms
+step:2704/4150 train_time:518868ms step_avg:191.89ms
+step:2705/4150 train_time:519104ms step_avg:191.91ms
+step:2706/4150 train_time:519340ms step_avg:191.92ms
+step:2707/4150 train_time:519575ms step_avg:191.94ms
+step:2708/4150 train_time:519812ms step_avg:191.95ms
+step:2709/4150 train_time:520047ms step_avg:191.97ms
+step:2710/4150 train_time:520285ms step_avg:191.99ms
+step:2711/4150 train_time:520518ms step_avg:192.00ms
+step:2712/4150 train_time:520755ms step_avg:192.02ms
+step:2713/4150 train_time:520989ms step_avg:192.03ms
+step:2714/4150 train_time:521227ms step_avg:192.05ms
+step:2715/4150 train_time:521462ms step_avg:192.07ms
+step:2716/4150 train_time:521699ms step_avg:192.08ms
+step:2717/4150 train_time:521930ms step_avg:192.10ms
+step:2718/4150 train_time:522167ms step_avg:192.11ms
+step:2719/4150 train_time:522399ms step_avg:192.13ms
+step:2720/4150 train_time:522635ms step_avg:192.15ms
+step:2721/4150 train_time:522868ms step_avg:192.16ms
+step:2722/4150 train_time:523106ms step_avg:192.18ms
+step:2723/4150 train_time:523338ms step_avg:192.19ms
+step:2724/4150 train_time:523575ms step_avg:192.21ms
+step:2725/4150 train_time:523812ms step_avg:192.22ms
+step:2726/4150 train_time:524049ms step_avg:192.24ms
+step:2727/4150 train_time:524285ms step_avg:192.26ms
+step:2728/4150 train_time:524520ms step_avg:192.27ms
+step:2729/4150 train_time:524753ms step_avg:192.29ms
+step:2730/4150 train_time:524994ms step_avg:192.31ms
+step:2731/4150 train_time:525231ms step_avg:192.32ms
+step:2732/4150 train_time:525467ms step_avg:192.34ms
+step:2733/4150 train_time:525700ms step_avg:192.35ms
+step:2734/4150 train_time:525936ms step_avg:192.37ms
+step:2735/4150 train_time:526169ms step_avg:192.38ms
+step:2736/4150 train_time:526405ms step_avg:192.40ms
+step:2737/4150 train_time:526639ms step_avg:192.41ms
+step:2738/4150 train_time:526875ms step_avg:192.43ms
+step:2739/4150 train_time:527114ms step_avg:192.45ms
+step:2740/4150 train_time:527353ms step_avg:192.46ms
+step:2741/4150 train_time:527588ms step_avg:192.48ms
+step:2742/4150 train_time:527824ms step_avg:192.50ms
+step:2743/4150 train_time:528059ms step_avg:192.51ms
+step:2744/4150 train_time:528295ms step_avg:192.53ms
+step:2745/4150 train_time:528531ms step_avg:192.54ms
+step:2746/4150 train_time:528767ms step_avg:192.56ms
+step:2747/4150 train_time:529001ms step_avg:192.57ms
+step:2748/4150 train_time:529237ms step_avg:192.59ms
+step:2749/4150 train_time:529474ms step_avg:192.61ms
+step:2750/4150 train_time:529712ms step_avg:192.62ms
+step:2750/4150 val_loss:3.0926 train_time:529932ms step_avg:192.70ms
+step:2751/4150 train_time:529956ms step_avg:192.64ms
+step:2752/4150 train_time:530195ms step_avg:192.66ms
+step:2753/4150 train_time:530430ms step_avg:192.67ms
+step:2754/4150 train_time:530667ms step_avg:192.69ms
+step:2755/4150 train_time:530900ms step_avg:192.70ms
+step:2756/4150 train_time:531139ms step_avg:192.72ms
+step:2757/4150 train_time:531374ms step_avg:192.74ms
+step:2758/4150 train_time:531611ms step_avg:192.75ms
+step:2759/4150 train_time:531843ms step_avg:192.77ms
+step:2760/4150 train_time:532082ms step_avg:192.78ms
+step:2761/4150 train_time:532320ms step_avg:192.80ms
+step:2762/4150 train_time:532557ms step_avg:192.82ms
+step:2763/4150 train_time:532789ms step_avg:192.83ms
+step:2764/4150 train_time:533026ms step_avg:192.85ms
+step:2765/4150 train_time:533264ms step_avg:192.86ms
+step:2766/4150 train_time:533502ms step_avg:192.88ms
+step:2767/4150 train_time:533736ms step_avg:192.89ms
+step:2768/4150 train_time:533972ms step_avg:192.91ms
+step:2769/4150 train_time:534207ms step_avg:192.92ms
+step:2770/4150 train_time:534444ms step_avg:192.94ms
+step:2771/4150 train_time:534679ms step_avg:192.96ms
+step:2772/4150 train_time:534915ms step_avg:192.97ms
+step:2773/4150 train_time:535147ms step_avg:192.98ms
+step:2774/4150 train_time:535385ms step_avg:193.00ms
+step:2775/4150 train_time:535619ms step_avg:193.02ms
+step:2776/4150 train_time:535860ms step_avg:193.03ms
+step:2777/4150 train_time:536096ms step_avg:193.05ms
+step:2778/4150 train_time:536334ms step_avg:193.06ms
+step:2779/4150 train_time:536571ms step_avg:193.08ms
+step:2780/4150 train_time:536807ms step_avg:193.10ms
+step:2781/4150 train_time:537040ms step_avg:193.11ms
+step:2782/4150 train_time:537278ms step_avg:193.13ms
+step:2783/4150 train_time:537512ms step_avg:193.14ms
+step:2784/4150 train_time:537750ms step_avg:193.16ms
+step:2785/4150 train_time:537981ms step_avg:193.17ms
+step:2786/4150 train_time:538217ms step_avg:193.19ms
+step:2787/4150 train_time:538453ms step_avg:193.20ms
+step:2788/4150 train_time:538693ms step_avg:193.22ms
+step:2789/4150 train_time:538927ms step_avg:193.23ms
+step:2790/4150 train_time:539163ms step_avg:193.25ms
+step:2791/4150 train_time:539399ms step_avg:193.26ms
+step:2792/4150 train_time:539638ms step_avg:193.28ms
+step:2793/4150 train_time:539874ms step_avg:193.30ms
+step:2794/4150 train_time:540109ms step_avg:193.31ms
+step:2795/4150 train_time:540346ms step_avg:193.33ms
+step:2796/4150 train_time:540584ms step_avg:193.34ms
+step:2797/4150 train_time:540819ms step_avg:193.36ms
+step:2798/4150 train_time:541055ms step_avg:193.37ms
+step:2799/4150 train_time:541292ms step_avg:193.39ms
+step:2800/4150 train_time:541531ms step_avg:193.40ms
+step:2801/4150 train_time:541766ms step_avg:193.42ms
+step:2802/4150 train_time:542003ms step_avg:193.43ms
+step:2803/4150 train_time:542238ms step_avg:193.45ms
+step:2804/4150 train_time:542474ms step_avg:193.46ms
+step:2805/4150 train_time:542706ms step_avg:193.48ms
+step:2806/4150 train_time:542946ms step_avg:193.49ms
+step:2807/4150 train_time:543180ms step_avg:193.51ms
+step:2808/4150 train_time:543417ms step_avg:193.52ms
+step:2809/4150 train_time:543654ms step_avg:193.54ms
+step:2810/4150 train_time:543895ms step_avg:193.56ms
+step:2811/4150 train_time:544130ms step_avg:193.57ms
+step:2812/4150 train_time:544366ms step_avg:193.59ms
+step:2813/4150 train_time:544599ms step_avg:193.60ms
+step:2814/4150 train_time:544838ms step_avg:193.62ms
+step:2815/4150 train_time:545076ms step_avg:193.63ms
+step:2816/4150 train_time:545317ms step_avg:193.65ms
+step:2817/4150 train_time:545549ms step_avg:193.66ms
+step:2818/4150 train_time:545787ms step_avg:193.68ms
+step:2819/4150 train_time:546019ms step_avg:193.69ms
+step:2820/4150 train_time:546258ms step_avg:193.71ms
+step:2821/4150 train_time:546493ms step_avg:193.72ms
+step:2822/4150 train_time:546733ms step_avg:193.74ms
+step:2823/4150 train_time:546965ms step_avg:193.75ms
+step:2824/4150 train_time:547202ms step_avg:193.77ms
+step:2825/4150 train_time:547443ms step_avg:193.79ms
+step:2826/4150 train_time:547677ms step_avg:193.80ms
+step:2827/4150 train_time:547910ms step_avg:193.81ms
+step:2828/4150 train_time:548148ms step_avg:193.83ms
+step:2829/4150 train_time:548381ms step_avg:193.84ms
+step:2830/4150 train_time:548619ms step_avg:193.86ms
+step:2831/4150 train_time:548855ms step_avg:193.87ms
+step:2832/4150 train_time:549096ms step_avg:193.89ms
+step:2833/4150 train_time:549331ms step_avg:193.90ms
+step:2834/4150 train_time:549568ms step_avg:193.92ms
+step:2835/4150 train_time:549803ms step_avg:193.93ms
+step:2836/4150 train_time:550043ms step_avg:193.95ms
+step:2837/4150 train_time:550276ms step_avg:193.96ms
+step:2838/4150 train_time:550517ms step_avg:193.98ms
+step:2839/4150 train_time:550755ms step_avg:194.00ms
+step:2840/4150 train_time:550993ms step_avg:194.01ms
+step:2841/4150 train_time:551226ms step_avg:194.03ms
+step:2842/4150 train_time:551461ms step_avg:194.04ms
+step:2843/4150 train_time:551697ms step_avg:194.05ms
+step:2844/4150 train_time:551939ms step_avg:194.07ms
+step:2845/4150 train_time:552173ms step_avg:194.09ms
+step:2846/4150 train_time:552409ms step_avg:194.10ms
+step:2847/4150 train_time:552645ms step_avg:194.11ms
+step:2848/4150 train_time:552884ms step_avg:194.13ms
+step:2849/4150 train_time:553117ms step_avg:194.14ms
+step:2850/4150 train_time:553353ms step_avg:194.16ms
+step:2851/4150 train_time:553587ms step_avg:194.17ms
+step:2852/4150 train_time:553824ms step_avg:194.19ms
+step:2853/4150 train_time:554060ms step_avg:194.20ms
+step:2854/4150 train_time:554296ms step_avg:194.22ms
+step:2855/4150 train_time:554533ms step_avg:194.23ms
+step:2856/4150 train_time:554770ms step_avg:194.25ms
+step:2857/4150 train_time:555005ms step_avg:194.26ms
+step:2858/4150 train_time:555240ms step_avg:194.28ms
+step:2859/4150 train_time:555475ms step_avg:194.29ms
+step:2860/4150 train_time:555713ms step_avg:194.31ms
+step:2861/4150 train_time:555948ms step_avg:194.32ms
+step:2862/4150 train_time:556190ms step_avg:194.34ms
+step:2863/4150 train_time:556426ms step_avg:194.35ms
+step:2864/4150 train_time:556662ms step_avg:194.37ms
+step:2865/4150 train_time:556897ms step_avg:194.38ms
+step:2866/4150 train_time:557137ms step_avg:194.40ms
+step:2867/4150 train_time:557370ms step_avg:194.41ms
+step:2868/4150 train_time:557607ms step_avg:194.42ms
+step:2869/4150 train_time:557840ms step_avg:194.44ms
+step:2870/4150 train_time:558082ms step_avg:194.45ms
+step:2871/4150 train_time:558320ms step_avg:194.47ms
+step:2872/4150 train_time:558557ms step_avg:194.48ms
+step:2873/4150 train_time:558792ms step_avg:194.50ms
+step:2874/4150 train_time:559030ms step_avg:194.51ms
+step:2875/4150 train_time:559267ms step_avg:194.53ms
+step:2876/4150 train_time:559502ms step_avg:194.54ms
+step:2877/4150 train_time:559737ms step_avg:194.56ms
+step:2878/4150 train_time:559979ms step_avg:194.57ms
+step:2879/4150 train_time:560213ms step_avg:194.59ms
+step:2880/4150 train_time:560452ms step_avg:194.60ms
+step:2881/4150 train_time:560685ms step_avg:194.61ms
+step:2882/4150 train_time:560922ms step_avg:194.63ms
+step:2883/4150 train_time:561160ms step_avg:194.64ms
+step:2884/4150 train_time:561398ms step_avg:194.66ms
+step:2885/4150 train_time:561630ms step_avg:194.67ms
+step:2886/4150 train_time:561867ms step_avg:194.69ms
+step:2887/4150 train_time:562103ms step_avg:194.70ms
+step:2888/4150 train_time:562343ms step_avg:194.72ms
+step:2889/4150 train_time:562575ms step_avg:194.73ms
+step:2890/4150 train_time:562813ms step_avg:194.74ms
+step:2891/4150 train_time:563046ms step_avg:194.76ms
+step:2892/4150 train_time:563285ms step_avg:194.77ms
+step:2893/4150 train_time:563519ms step_avg:194.79ms
+step:2894/4150 train_time:563754ms step_avg:194.80ms
+step:2895/4150 train_time:563987ms step_avg:194.81ms
+step:2896/4150 train_time:564225ms step_avg:194.83ms
+step:2897/4150 train_time:564462ms step_avg:194.84ms
+step:2898/4150 train_time:564697ms step_avg:194.86ms
+step:2899/4150 train_time:564934ms step_avg:194.87ms
+step:2900/4150 train_time:565171ms step_avg:194.89ms
+step:2901/4150 train_time:565407ms step_avg:194.90ms
+step:2902/4150 train_time:565646ms step_avg:194.92ms
+step:2903/4150 train_time:565878ms step_avg:194.93ms
+step:2904/4150 train_time:566116ms step_avg:194.94ms
+step:2905/4150 train_time:566351ms step_avg:194.96ms
+step:2906/4150 train_time:566588ms step_avg:194.97ms
+step:2907/4150 train_time:566822ms step_avg:194.99ms
+step:2908/4150 train_time:567059ms step_avg:195.00ms
+step:2909/4150 train_time:567297ms step_avg:195.01ms
+step:2910/4150 train_time:567538ms step_avg:195.03ms
+step:2911/4150 train_time:567772ms step_avg:195.04ms
+step:2912/4150 train_time:568008ms step_avg:195.06ms
+step:2913/4150 train_time:568239ms step_avg:195.07ms
+step:2914/4150 train_time:568478ms step_avg:195.09ms
+step:2915/4150 train_time:568712ms step_avg:195.10ms
+step:2916/4150 train_time:568949ms step_avg:195.11ms
+step:2917/4150 train_time:569183ms step_avg:195.13ms
+step:2918/4150 train_time:569421ms step_avg:195.14ms
+step:2919/4150 train_time:569659ms step_avg:195.16ms
+step:2920/4150 train_time:569894ms step_avg:195.17ms
+step:2921/4150 train_time:570128ms step_avg:195.18ms
+step:2922/4150 train_time:570363ms step_avg:195.20ms
+step:2923/4150 train_time:570598ms step_avg:195.21ms
+step:2924/4150 train_time:570838ms step_avg:195.23ms
+step:2925/4150 train_time:571072ms step_avg:195.24ms
+step:2926/4150 train_time:571308ms step_avg:195.25ms
+step:2927/4150 train_time:571542ms step_avg:195.27ms
+step:2928/4150 train_time:571782ms step_avg:195.28ms
+step:2929/4150 train_time:572017ms step_avg:195.29ms
+step:2930/4150 train_time:572256ms step_avg:195.31ms
+step:2931/4150 train_time:572491ms step_avg:195.32ms
+step:2932/4150 train_time:572731ms step_avg:195.34ms
+step:2933/4150 train_time:572967ms step_avg:195.35ms
+step:2934/4150 train_time:573207ms step_avg:195.37ms
+step:2935/4150 train_time:573439ms step_avg:195.38ms
+step:2936/4150 train_time:573678ms step_avg:195.39ms
+step:2937/4150 train_time:573914ms step_avg:195.41ms
+step:2938/4150 train_time:574151ms step_avg:195.42ms
+step:2939/4150 train_time:574388ms step_avg:195.44ms
+step:2940/4150 train_time:574626ms step_avg:195.45ms
+step:2941/4150 train_time:574864ms step_avg:195.47ms
+step:2942/4150 train_time:575100ms step_avg:195.48ms
+step:2943/4150 train_time:575339ms step_avg:195.49ms
+step:2944/4150 train_time:575575ms step_avg:195.51ms
+step:2945/4150 train_time:575809ms step_avg:195.52ms
+step:2946/4150 train_time:576047ms step_avg:195.54ms
+step:2947/4150 train_time:576281ms step_avg:195.55ms
+step:2948/4150 train_time:576517ms step_avg:195.56ms
+step:2949/4150 train_time:576748ms step_avg:195.57ms
+step:2950/4150 train_time:576986ms step_avg:195.59ms
+step:2951/4150 train_time:577220ms step_avg:195.60ms
+step:2952/4150 train_time:577457ms step_avg:195.62ms
+step:2953/4150 train_time:577692ms step_avg:195.63ms
+step:2954/4150 train_time:577933ms step_avg:195.64ms
+step:2955/4150 train_time:578166ms step_avg:195.66ms
+step:2956/4150 train_time:578407ms step_avg:195.67ms
+step:2957/4150 train_time:578639ms step_avg:195.68ms
+step:2958/4150 train_time:578876ms step_avg:195.70ms
+step:2959/4150 train_time:579115ms step_avg:195.71ms
+step:2960/4150 train_time:579352ms step_avg:195.73ms
+step:2961/4150 train_time:579586ms step_avg:195.74ms
+step:2962/4150 train_time:579824ms step_avg:195.75ms
+step:2963/4150 train_time:580055ms step_avg:195.77ms
+step:2964/4150 train_time:580296ms step_avg:195.78ms
+step:2965/4150 train_time:580530ms step_avg:195.79ms
+step:2966/4150 train_time:580766ms step_avg:195.81ms
+step:2967/4150 train_time:581003ms step_avg:195.82ms
+step:2968/4150 train_time:581242ms step_avg:195.84ms
+step:2969/4150 train_time:581480ms step_avg:195.85ms
+step:2970/4150 train_time:581720ms step_avg:195.87ms
+step:2971/4150 train_time:581953ms step_avg:195.88ms
+step:2972/4150 train_time:582191ms step_avg:195.89ms
+step:2973/4150 train_time:582425ms step_avg:195.90ms
+step:2974/4150 train_time:582662ms step_avg:195.92ms
+step:2975/4150 train_time:582896ms step_avg:195.93ms
+step:2976/4150 train_time:583136ms step_avg:195.95ms
+step:2977/4150 train_time:583370ms step_avg:195.96ms
+step:2978/4150 train_time:583605ms step_avg:195.97ms
+step:2979/4150 train_time:583838ms step_avg:195.98ms
+step:2980/4150 train_time:584078ms step_avg:196.00ms
+step:2981/4150 train_time:584314ms step_avg:196.01ms
+step:2982/4150 train_time:584550ms step_avg:196.03ms
+step:2983/4150 train_time:584784ms step_avg:196.04ms
+step:2984/4150 train_time:585022ms step_avg:196.05ms
+step:2985/4150 train_time:585259ms step_avg:196.07ms
+step:2986/4150 train_time:585498ms step_avg:196.08ms
+step:2987/4150 train_time:585735ms step_avg:196.09ms
+step:2988/4150 train_time:585978ms step_avg:196.11ms
+step:2989/4150 train_time:586213ms step_avg:196.12ms
+step:2990/4150 train_time:586451ms step_avg:196.14ms
+step:2991/4150 train_time:586684ms step_avg:196.15ms
+step:2992/4150 train_time:586922ms step_avg:196.16ms
+step:2993/4150 train_time:587154ms step_avg:196.18ms
+step:2994/4150 train_time:587392ms step_avg:196.19ms
+step:2995/4150 train_time:587627ms step_avg:196.20ms
+step:2996/4150 train_time:587861ms step_avg:196.22ms
+step:2997/4150 train_time:588095ms step_avg:196.23ms
+step:2998/4150 train_time:588332ms step_avg:196.24ms
+step:2999/4150 train_time:588566ms step_avg:196.25ms
+step:3000/4150 train_time:588805ms step_avg:196.27ms
+step:3000/4150 val_loss:3.0424 train_time:589020ms step_avg:196.34ms
+step:3001/4150 train_time:589042ms step_avg:196.28ms
+step:3002/4150 train_time:589282ms step_avg:196.30ms
+step:3003/4150 train_time:589517ms step_avg:196.31ms
+step:3004/4150 train_time:589752ms step_avg:196.32ms
+step:3005/4150 train_time:589986ms step_avg:196.33ms
+step:3006/4150 train_time:590224ms step_avg:196.35ms
+step:3007/4150 train_time:590463ms step_avg:196.36ms
+step:3008/4150 train_time:590700ms step_avg:196.38ms
+step:3009/4150 train_time:590932ms step_avg:196.39ms
+step:3010/4150 train_time:591170ms step_avg:196.40ms
+step:3011/4150 train_time:591405ms step_avg:196.41ms
+step:3012/4150 train_time:591642ms step_avg:196.43ms
+step:3013/4150 train_time:591875ms step_avg:196.44ms
+step:3014/4150 train_time:592116ms step_avg:196.46ms
+step:3015/4150 train_time:592355ms step_avg:196.47ms
+step:3016/4150 train_time:592591ms step_avg:196.48ms
+step:3017/4150 train_time:592825ms step_avg:196.49ms
+step:3018/4150 train_time:593061ms step_avg:196.51ms
+step:3019/4150 train_time:593298ms step_avg:196.52ms
+step:3020/4150 train_time:593535ms step_avg:196.53ms
+step:3021/4150 train_time:593769ms step_avg:196.55ms
+step:3022/4150 train_time:594005ms step_avg:196.56ms
+step:3023/4150 train_time:594243ms step_avg:196.57ms
+step:3024/4150 train_time:594482ms step_avg:196.59ms
+step:3025/4150 train_time:594713ms step_avg:196.60ms
+step:3026/4150 train_time:594949ms step_avg:196.61ms
+step:3027/4150 train_time:595183ms step_avg:196.62ms
+step:3028/4150 train_time:595422ms step_avg:196.64ms
+step:3029/4150 train_time:595655ms step_avg:196.65ms
+step:3030/4150 train_time:595893ms step_avg:196.66ms
+step:3031/4150 train_time:596127ms step_avg:196.68ms
+step:3032/4150 train_time:596364ms step_avg:196.69ms
+step:3033/4150 train_time:596599ms step_avg:196.70ms
+step:3034/4150 train_time:596836ms step_avg:196.72ms
+step:3035/4150 train_time:597073ms step_avg:196.73ms
+step:3036/4150 train_time:597309ms step_avg:196.74ms
+step:3037/4150 train_time:597543ms step_avg:196.75ms
+step:3038/4150 train_time:597780ms step_avg:196.77ms
+step:3039/4150 train_time:598013ms step_avg:196.78ms
+step:3040/4150 train_time:598254ms step_avg:196.79ms
+step:3041/4150 train_time:598490ms step_avg:196.81ms
+step:3042/4150 train_time:598726ms step_avg:196.82ms
+step:3043/4150 train_time:598960ms step_avg:196.83ms
+step:3044/4150 train_time:599198ms step_avg:196.85ms
+step:3045/4150 train_time:599436ms step_avg:196.86ms
+step:3046/4150 train_time:599675ms step_avg:196.87ms
+step:3047/4150 train_time:599910ms step_avg:196.89ms
+step:3048/4150 train_time:600150ms step_avg:196.90ms
+step:3049/4150 train_time:600383ms step_avg:196.91ms
+step:3050/4150 train_time:600621ms step_avg:196.92ms
+step:3051/4150 train_time:600855ms step_avg:196.94ms
+step:3052/4150 train_time:601095ms step_avg:196.95ms
+step:3053/4150 train_time:601330ms step_avg:196.96ms
+step:3054/4150 train_time:601568ms step_avg:196.98ms
+step:3055/4150 train_time:601802ms step_avg:196.99ms
+step:3056/4150 train_time:602039ms step_avg:197.00ms
+step:3057/4150 train_time:602276ms step_avg:197.02ms
+step:3058/4150 train_time:602512ms step_avg:197.03ms
+step:3059/4150 train_time:602748ms step_avg:197.04ms
+step:3060/4150 train_time:602988ms step_avg:197.05ms
+step:3061/4150 train_time:603223ms step_avg:197.07ms
+step:3062/4150 train_time:603461ms step_avg:197.08ms
+step:3063/4150 train_time:603699ms step_avg:197.09ms
+step:3064/4150 train_time:603939ms step_avg:197.11ms
+step:3065/4150 train_time:604175ms step_avg:197.12ms
+step:3066/4150 train_time:604414ms step_avg:197.13ms
+step:3067/4150 train_time:604649ms step_avg:197.15ms
+step:3068/4150 train_time:604886ms step_avg:197.16ms
+step:3069/4150 train_time:605120ms step_avg:197.17ms
+step:3070/4150 train_time:605356ms step_avg:197.18ms
+step:3071/4150 train_time:605589ms step_avg:197.20ms
+step:3072/4150 train_time:605828ms step_avg:197.21ms
+step:3073/4150 train_time:606060ms step_avg:197.22ms
+step:3074/4150 train_time:606299ms step_avg:197.23ms
+step:3075/4150 train_time:606535ms step_avg:197.25ms
+step:3076/4150 train_time:606773ms step_avg:197.26ms
+step:3077/4150 train_time:607006ms step_avg:197.27ms
+step:3078/4150 train_time:607246ms step_avg:197.29ms
+step:3079/4150 train_time:607483ms step_avg:197.30ms
+step:3080/4150 train_time:607717ms step_avg:197.31ms
+step:3081/4150 train_time:607949ms step_avg:197.32ms
+step:3082/4150 train_time:608190ms step_avg:197.34ms
+step:3083/4150 train_time:608423ms step_avg:197.35ms
+step:3084/4150 train_time:608662ms step_avg:197.36ms
+step:3085/4150 train_time:608897ms step_avg:197.37ms
+step:3086/4150 train_time:609133ms step_avg:197.39ms
+step:3087/4150 train_time:609370ms step_avg:197.40ms
+step:3088/4150 train_time:609607ms step_avg:197.41ms
+step:3089/4150 train_time:609838ms step_avg:197.42ms
+step:3090/4150 train_time:610076ms step_avg:197.44ms
+step:3091/4150 train_time:610312ms step_avg:197.45ms
+step:3092/4150 train_time:610551ms step_avg:197.46ms
+step:3093/4150 train_time:610785ms step_avg:197.47ms
+step:3094/4150 train_time:611022ms step_avg:197.49ms
+step:3095/4150 train_time:611255ms step_avg:197.50ms
+step:3096/4150 train_time:611493ms step_avg:197.51ms
+step:3097/4150 train_time:611731ms step_avg:197.52ms
+step:3098/4150 train_time:611969ms step_avg:197.54ms
+step:3099/4150 train_time:612202ms step_avg:197.55ms
+step:3100/4150 train_time:612438ms step_avg:197.56ms
+step:3101/4150 train_time:612673ms step_avg:197.57ms
+step:3102/4150 train_time:612909ms step_avg:197.59ms
+step:3103/4150 train_time:613143ms step_avg:197.60ms
+step:3104/4150 train_time:613379ms step_avg:197.61ms
+step:3105/4150 train_time:613612ms step_avg:197.62ms
+step:3106/4150 train_time:613849ms step_avg:197.63ms
+step:3107/4150 train_time:614083ms step_avg:197.65ms
+step:3108/4150 train_time:614323ms step_avg:197.66ms
+step:3109/4150 train_time:614558ms step_avg:197.67ms
+step:3110/4150 train_time:614798ms step_avg:197.68ms
+step:3111/4150 train_time:615033ms step_avg:197.70ms
+step:3112/4150 train_time:615269ms step_avg:197.71ms
+step:3113/4150 train_time:615502ms step_avg:197.72ms
+step:3114/4150 train_time:615742ms step_avg:197.73ms
+step:3115/4150 train_time:615980ms step_avg:197.75ms
+step:3116/4150 train_time:616217ms step_avg:197.76ms
+step:3117/4150 train_time:616453ms step_avg:197.77ms
+step:3118/4150 train_time:616690ms step_avg:197.78ms
+step:3119/4150 train_time:616924ms step_avg:197.80ms
+step:3120/4150 train_time:617167ms step_avg:197.81ms
+step:3121/4150 train_time:617403ms step_avg:197.82ms
+step:3122/4150 train_time:617641ms step_avg:197.83ms
+step:3123/4150 train_time:617874ms step_avg:197.85ms
+step:3124/4150 train_time:618111ms step_avg:197.86ms
+step:3125/4150 train_time:618345ms step_avg:197.87ms
+step:3126/4150 train_time:618581ms step_avg:197.88ms
+step:3127/4150 train_time:618817ms step_avg:197.89ms
+step:3128/4150 train_time:619055ms step_avg:197.91ms
+step:3129/4150 train_time:619287ms step_avg:197.92ms
+step:3130/4150 train_time:619529ms step_avg:197.93ms
+step:3131/4150 train_time:619763ms step_avg:197.94ms
+step:3132/4150 train_time:620000ms step_avg:197.96ms
+step:3133/4150 train_time:620238ms step_avg:197.97ms
+step:3134/4150 train_time:620474ms step_avg:197.98ms
+step:3135/4150 train_time:620707ms step_avg:197.99ms
+step:3136/4150 train_time:620946ms step_avg:198.01ms
+step:3137/4150 train_time:621182ms step_avg:198.02ms
+step:3138/4150 train_time:621419ms step_avg:198.03ms
+step:3139/4150 train_time:621655ms step_avg:198.04ms
+step:3140/4150 train_time:621894ms step_avg:198.06ms
+step:3141/4150 train_time:622128ms step_avg:198.07ms
+step:3142/4150 train_time:622369ms step_avg:198.08ms
+step:3143/4150 train_time:622601ms step_avg:198.09ms
+step:3144/4150 train_time:622842ms step_avg:198.10ms
+step:3145/4150 train_time:623078ms step_avg:198.12ms
+step:3146/4150 train_time:623315ms step_avg:198.13ms
+step:3147/4150 train_time:623549ms step_avg:198.14ms
+step:3148/4150 train_time:623788ms step_avg:198.15ms
+step:3149/4150 train_time:624022ms step_avg:198.17ms
+step:3150/4150 train_time:624262ms step_avg:198.18ms
+step:3151/4150 train_time:624495ms step_avg:198.19ms
+step:3152/4150 train_time:624732ms step_avg:198.20ms
+step:3153/4150 train_time:624967ms step_avg:198.21ms
+step:3154/4150 train_time:625205ms step_avg:198.23ms
+step:3155/4150 train_time:625440ms step_avg:198.24ms
+step:3156/4150 train_time:625675ms step_avg:198.25ms
+step:3157/4150 train_time:625913ms step_avg:198.26ms
+step:3158/4150 train_time:626153ms step_avg:198.28ms
+step:3159/4150 train_time:626387ms step_avg:198.29ms
+step:3160/4150 train_time:626629ms step_avg:198.30ms
+step:3161/4150 train_time:626864ms step_avg:198.31ms
+step:3162/4150 train_time:627101ms step_avg:198.32ms
+step:3163/4150 train_time:627339ms step_avg:198.34ms
+step:3164/4150 train_time:627579ms step_avg:198.35ms
+step:3165/4150 train_time:627814ms step_avg:198.36ms
+step:3166/4150 train_time:628047ms step_avg:198.37ms
+step:3167/4150 train_time:628283ms step_avg:198.38ms
+step:3168/4150 train_time:628521ms step_avg:198.40ms
+step:3169/4150 train_time:628753ms step_avg:198.41ms
+step:3170/4150 train_time:628991ms step_avg:198.42ms
+step:3171/4150 train_time:629224ms step_avg:198.43ms
+step:3172/4150 train_time:629462ms step_avg:198.44ms
+step:3173/4150 train_time:629700ms step_avg:198.46ms
+step:3174/4150 train_time:629938ms step_avg:198.47ms
+step:3175/4150 train_time:630174ms step_avg:198.48ms
+step:3176/4150 train_time:630413ms step_avg:198.49ms
+step:3177/4150 train_time:630647ms step_avg:198.50ms
+step:3178/4150 train_time:630884ms step_avg:198.52ms
+step:3179/4150 train_time:631119ms step_avg:198.53ms
+step:3180/4150 train_time:631357ms step_avg:198.54ms
+step:3181/4150 train_time:631592ms step_avg:198.55ms
+step:3182/4150 train_time:631831ms step_avg:198.56ms
+step:3183/4150 train_time:632068ms step_avg:198.58ms
+step:3184/4150 train_time:632306ms step_avg:198.59ms
+step:3185/4150 train_time:632538ms step_avg:198.60ms
+step:3186/4150 train_time:632775ms step_avg:198.61ms
+step:3187/4150 train_time:633011ms step_avg:198.62ms
+step:3188/4150 train_time:633248ms step_avg:198.63ms
+step:3189/4150 train_time:633484ms step_avg:198.65ms
+step:3190/4150 train_time:633722ms step_avg:198.66ms
+step:3191/4150 train_time:633955ms step_avg:198.67ms
+step:3192/4150 train_time:634191ms step_avg:198.68ms
+step:3193/4150 train_time:634425ms step_avg:198.69ms
+step:3194/4150 train_time:634660ms step_avg:198.70ms
+step:3195/4150 train_time:634897ms step_avg:198.72ms
+step:3196/4150 train_time:635132ms step_avg:198.73ms
+step:3197/4150 train_time:635366ms step_avg:198.74ms
+step:3198/4150 train_time:635607ms step_avg:198.75ms
+step:3199/4150 train_time:635844ms step_avg:198.76ms
+step:3200/4150 train_time:636079ms step_avg:198.77ms
+step:3201/4150 train_time:636315ms step_avg:198.79ms
+step:3202/4150 train_time:636550ms step_avg:198.80ms
+step:3203/4150 train_time:636785ms step_avg:198.81ms
+step:3204/4150 train_time:637023ms step_avg:198.82ms
+step:3205/4150 train_time:637259ms step_avg:198.83ms
+step:3206/4150 train_time:637498ms step_avg:198.85ms
+step:3207/4150 train_time:637730ms step_avg:198.86ms
+step:3208/4150 train_time:637970ms step_avg:198.87ms
+step:3209/4150 train_time:638205ms step_avg:198.88ms
+step:3210/4150 train_time:638442ms step_avg:198.89ms
+step:3211/4150 train_time:638677ms step_avg:198.90ms
+step:3212/4150 train_time:638915ms step_avg:198.92ms
+step:3213/4150 train_time:639148ms step_avg:198.93ms
+step:3214/4150 train_time:639388ms step_avg:198.94ms
+step:3215/4150 train_time:639622ms step_avg:198.95ms
+step:3216/4150 train_time:639858ms step_avg:198.96ms
+step:3217/4150 train_time:640095ms step_avg:198.97ms
+step:3218/4150 train_time:640330ms step_avg:198.98ms
+step:3219/4150 train_time:640566ms step_avg:199.00ms
+step:3220/4150 train_time:640803ms step_avg:199.01ms
+step:3221/4150 train_time:641036ms step_avg:199.02ms
+step:3222/4150 train_time:641272ms step_avg:199.03ms
+step:3223/4150 train_time:641508ms step_avg:199.04ms
+step:3224/4150 train_time:641747ms step_avg:199.05ms
+step:3225/4150 train_time:641980ms step_avg:199.06ms
+step:3226/4150 train_time:642218ms step_avg:199.08ms
+step:3227/4150 train_time:642452ms step_avg:199.09ms
+step:3228/4150 train_time:642689ms step_avg:199.10ms
+step:3229/4150 train_time:642924ms step_avg:199.11ms
+step:3230/4150 train_time:643160ms step_avg:199.12ms
+step:3231/4150 train_time:643395ms step_avg:199.13ms
+step:3232/4150 train_time:643634ms step_avg:199.14ms
+step:3233/4150 train_time:643869ms step_avg:199.16ms
+step:3234/4150 train_time:644107ms step_avg:199.17ms
+step:3235/4150 train_time:644340ms step_avg:199.18ms
+step:3236/4150 train_time:644575ms step_avg:199.19ms
+step:3237/4150 train_time:644808ms step_avg:199.20ms
+step:3238/4150 train_time:645047ms step_avg:199.21ms
+step:3239/4150 train_time:645282ms step_avg:199.22ms
+step:3240/4150 train_time:645519ms step_avg:199.23ms
+step:3241/4150 train_time:645754ms step_avg:199.25ms
+step:3242/4150 train_time:645994ms step_avg:199.26ms
+step:3243/4150 train_time:646231ms step_avg:199.27ms
+step:3244/4150 train_time:646465ms step_avg:199.28ms
+step:3245/4150 train_time:646701ms step_avg:199.29ms
+step:3246/4150 train_time:646938ms step_avg:199.30ms
+step:3247/4150 train_time:647175ms step_avg:199.31ms
+step:3248/4150 train_time:647412ms step_avg:199.33ms
+step:3249/4150 train_time:647650ms step_avg:199.34ms
+step:3250/4150 train_time:647885ms step_avg:199.35ms
+step:3250/4150 val_loss:3.0107 train_time:648104ms step_avg:199.42ms
+step:3251/4150 train_time:648127ms step_avg:199.36ms
+step:3252/4150 train_time:648368ms step_avg:199.38ms
+step:3253/4150 train_time:648605ms step_avg:199.39ms
+step:3254/4150 train_time:648840ms step_avg:199.40ms
+step:3255/4150 train_time:649072ms step_avg:199.41ms
+step:3256/4150 train_time:649312ms step_avg:199.42ms
+step:3257/4150 train_time:649553ms step_avg:199.43ms
+step:3258/4150 train_time:649787ms step_avg:199.44ms
+step:3259/4150 train_time:650017ms step_avg:199.45ms
+step:3260/4150 train_time:650255ms step_avg:199.46ms
+step:3261/4150 train_time:650494ms step_avg:199.48ms
+step:3262/4150 train_time:650731ms step_avg:199.49ms
+step:3263/4150 train_time:650968ms step_avg:199.50ms
+step:3264/4150 train_time:651206ms step_avg:199.51ms
+step:3265/4150 train_time:651443ms step_avg:199.52ms
+step:3266/4150 train_time:651684ms step_avg:199.54ms
+step:3267/4150 train_time:651921ms step_avg:199.55ms
+step:3268/4150 train_time:652157ms step_avg:199.56ms
+step:3269/4150 train_time:652390ms step_avg:199.57ms
+step:3270/4150 train_time:652628ms step_avg:199.58ms
+step:3271/4150 train_time:652864ms step_avg:199.59ms
+step:3272/4150 train_time:653103ms step_avg:199.60ms
+step:3273/4150 train_time:653337ms step_avg:199.61ms
+step:3274/4150 train_time:653576ms step_avg:199.63ms
+step:3275/4150 train_time:653810ms step_avg:199.64ms
+step:3276/4150 train_time:654053ms step_avg:199.65ms
+step:3277/4150 train_time:654291ms step_avg:199.66ms
+step:3278/4150 train_time:654527ms step_avg:199.67ms
+step:3279/4150 train_time:654763ms step_avg:199.68ms
+step:3280/4150 train_time:655000ms step_avg:199.70ms
+step:3281/4150 train_time:655235ms step_avg:199.71ms
+step:3282/4150 train_time:655473ms step_avg:199.72ms
+step:3283/4150 train_time:655708ms step_avg:199.73ms
+step:3284/4150 train_time:655946ms step_avg:199.74ms
+step:3285/4150 train_time:656179ms step_avg:199.75ms
+step:3286/4150 train_time:656416ms step_avg:199.76ms
+step:3287/4150 train_time:656652ms step_avg:199.77ms
+step:3288/4150 train_time:656890ms step_avg:199.78ms
+step:3289/4150 train_time:657125ms step_avg:199.79ms
+step:3290/4150 train_time:657362ms step_avg:199.81ms
+step:3291/4150 train_time:657603ms step_avg:199.82ms
+step:3292/4150 train_time:657839ms step_avg:199.83ms
+step:3293/4150 train_time:658073ms step_avg:199.84ms
+step:3294/4150 train_time:658313ms step_avg:199.85ms
+step:3295/4150 train_time:658554ms step_avg:199.86ms
+step:3296/4150 train_time:658788ms step_avg:199.88ms
+step:3297/4150 train_time:659022ms step_avg:199.89ms
+step:3298/4150 train_time:659260ms step_avg:199.90ms
+step:3299/4150 train_time:659496ms step_avg:199.91ms
+step:3300/4150 train_time:659732ms step_avg:199.92ms
+step:3301/4150 train_time:659966ms step_avg:199.93ms
+step:3302/4150 train_time:660203ms step_avg:199.94ms
+step:3303/4150 train_time:660439ms step_avg:199.95ms
+step:3304/4150 train_time:660676ms step_avg:199.96ms
+step:3305/4150 train_time:660907ms step_avg:199.97ms
+step:3306/4150 train_time:661142ms step_avg:199.98ms
+step:3307/4150 train_time:661378ms step_avg:199.99ms
+step:3308/4150 train_time:661617ms step_avg:200.00ms
+step:3309/4150 train_time:661852ms step_avg:200.02ms
+step:3310/4150 train_time:662087ms step_avg:200.03ms
+step:3311/4150 train_time:662324ms step_avg:200.04ms
+step:3312/4150 train_time:662559ms step_avg:200.05ms
+step:3313/4150 train_time:662795ms step_avg:200.06ms
+step:3314/4150 train_time:663032ms step_avg:200.07ms
+step:3315/4150 train_time:663273ms step_avg:200.08ms
+step:3316/4150 train_time:663507ms step_avg:200.09ms
+step:3317/4150 train_time:663742ms step_avg:200.10ms
+step:3318/4150 train_time:663980ms step_avg:200.11ms
+step:3319/4150 train_time:664218ms step_avg:200.13ms
+step:3320/4150 train_time:664457ms step_avg:200.14ms
+step:3321/4150 train_time:664692ms step_avg:200.15ms
+step:3322/4150 train_time:664928ms step_avg:200.16ms
+step:3323/4150 train_time:665163ms step_avg:200.17ms
+step:3324/4150 train_time:665400ms step_avg:200.18ms
+step:3325/4150 train_time:665635ms step_avg:200.19ms
+step:3326/4150 train_time:665872ms step_avg:200.20ms
+step:3327/4150 train_time:666107ms step_avg:200.21ms
+step:3328/4150 train_time:666344ms step_avg:200.22ms
+step:3329/4150 train_time:666578ms step_avg:200.23ms
+step:3330/4150 train_time:666816ms step_avg:200.25ms
+step:3331/4150 train_time:667050ms step_avg:200.26ms
+step:3332/4150 train_time:667292ms step_avg:200.27ms
+step:3333/4150 train_time:667527ms step_avg:200.28ms
+step:3334/4150 train_time:667763ms step_avg:200.29ms
+step:3335/4150 train_time:667998ms step_avg:200.30ms
+step:3336/4150 train_time:668235ms step_avg:200.31ms
+step:3337/4150 train_time:668471ms step_avg:200.32ms
+step:3338/4150 train_time:668705ms step_avg:200.33ms
+step:3339/4150 train_time:668939ms step_avg:200.34ms
+step:3340/4150 train_time:669176ms step_avg:200.35ms
+step:3341/4150 train_time:669414ms step_avg:200.36ms
+step:3342/4150 train_time:669653ms step_avg:200.38ms
+step:3343/4150 train_time:669890ms step_avg:200.39ms
+step:3344/4150 train_time:670128ms step_avg:200.40ms
+step:3345/4150 train_time:670363ms step_avg:200.41ms
+step:3346/4150 train_time:670603ms step_avg:200.42ms
+step:3347/4150 train_time:670834ms step_avg:200.43ms
+step:3348/4150 train_time:671070ms step_avg:200.44ms
+step:3349/4150 train_time:671306ms step_avg:200.45ms
+step:3350/4150 train_time:671546ms step_avg:200.46ms
+step:3351/4150 train_time:671778ms step_avg:200.47ms
+step:3352/4150 train_time:672021ms step_avg:200.48ms
+step:3353/4150 train_time:672253ms step_avg:200.49ms
+step:3354/4150 train_time:672489ms step_avg:200.50ms
+step:3355/4150 train_time:672723ms step_avg:200.51ms
+step:3356/4150 train_time:672964ms step_avg:200.53ms
+step:3357/4150 train_time:673200ms step_avg:200.54ms
+step:3358/4150 train_time:673435ms step_avg:200.55ms
+step:3359/4150 train_time:673672ms step_avg:200.56ms
+step:3360/4150 train_time:673909ms step_avg:200.57ms
+step:3361/4150 train_time:674145ms step_avg:200.58ms
+step:3362/4150 train_time:674384ms step_avg:200.59ms
+step:3363/4150 train_time:674621ms step_avg:200.60ms
+step:3364/4150 train_time:674859ms step_avg:200.61ms
+step:3365/4150 train_time:675096ms step_avg:200.62ms
+step:3366/4150 train_time:675334ms step_avg:200.63ms
+step:3367/4150 train_time:675565ms step_avg:200.64ms
+step:3368/4150 train_time:675803ms step_avg:200.65ms
+step:3369/4150 train_time:676037ms step_avg:200.66ms
+step:3370/4150 train_time:676277ms step_avg:200.68ms
+step:3371/4150 train_time:676509ms step_avg:200.68ms
+step:3372/4150 train_time:676744ms step_avg:200.70ms
+step:3373/4150 train_time:676977ms step_avg:200.70ms
+step:3374/4150 train_time:677217ms step_avg:200.72ms
+step:3375/4150 train_time:677451ms step_avg:200.73ms
+step:3376/4150 train_time:677691ms step_avg:200.74ms
+step:3377/4150 train_time:677926ms step_avg:200.75ms
+step:3378/4150 train_time:678165ms step_avg:200.76ms
+step:3379/4150 train_time:678400ms step_avg:200.77ms
+step:3380/4150 train_time:678636ms step_avg:200.78ms
+step:3381/4150 train_time:678872ms step_avg:200.79ms
+step:3382/4150 train_time:679108ms step_avg:200.80ms
+step:3383/4150 train_time:679341ms step_avg:200.81ms
+step:3384/4150 train_time:679577ms step_avg:200.82ms
+step:3385/4150 train_time:679816ms step_avg:200.83ms
+step:3386/4150 train_time:680054ms step_avg:200.84ms
+step:3387/4150 train_time:680290ms step_avg:200.85ms
+step:3388/4150 train_time:680528ms step_avg:200.86ms
+step:3389/4150 train_time:680762ms step_avg:200.87ms
+step:3390/4150 train_time:680999ms step_avg:200.88ms
+step:3391/4150 train_time:681234ms step_avg:200.89ms
+step:3392/4150 train_time:681474ms step_avg:200.91ms
+step:3393/4150 train_time:681711ms step_avg:200.92ms
+step:3394/4150 train_time:681947ms step_avg:200.93ms
+step:3395/4150 train_time:682182ms step_avg:200.94ms
+step:3396/4150 train_time:682418ms step_avg:200.95ms
+step:3397/4150 train_time:682653ms step_avg:200.96ms
+step:3398/4150 train_time:682890ms step_avg:200.97ms
+step:3399/4150 train_time:683123ms step_avg:200.98ms
+step:3400/4150 train_time:683363ms step_avg:200.99ms
+step:3401/4150 train_time:683599ms step_avg:201.00ms
+step:3402/4150 train_time:683836ms step_avg:201.01ms
+step:3403/4150 train_time:684073ms step_avg:201.02ms
+step:3404/4150 train_time:684311ms step_avg:201.03ms
+step:3405/4150 train_time:684544ms step_avg:201.04ms
+step:3406/4150 train_time:684782ms step_avg:201.05ms
+step:3407/4150 train_time:685015ms step_avg:201.06ms
+step:3408/4150 train_time:685254ms step_avg:201.07ms
+step:3409/4150 train_time:685489ms step_avg:201.08ms
+step:3410/4150 train_time:685732ms step_avg:201.09ms
+step:3411/4150 train_time:685965ms step_avg:201.10ms
+step:3412/4150 train_time:686207ms step_avg:201.12ms
+step:3413/4150 train_time:686442ms step_avg:201.13ms
+step:3414/4150 train_time:686680ms step_avg:201.14ms
+step:3415/4150 train_time:686915ms step_avg:201.15ms
+step:3416/4150 train_time:687151ms step_avg:201.16ms
+step:3417/4150 train_time:687384ms step_avg:201.17ms
+step:3418/4150 train_time:687624ms step_avg:201.18ms
+step:3419/4150 train_time:687859ms step_avg:201.19ms
+step:3420/4150 train_time:688095ms step_avg:201.20ms
+step:3421/4150 train_time:688333ms step_avg:201.21ms
+step:3422/4150 train_time:688569ms step_avg:201.22ms
+step:3423/4150 train_time:688804ms step_avg:201.23ms
+step:3424/4150 train_time:689041ms step_avg:201.24ms
+step:3425/4150 train_time:689276ms step_avg:201.25ms
+step:3426/4150 train_time:689512ms step_avg:201.26ms
+step:3427/4150 train_time:689747ms step_avg:201.27ms
+step:3428/4150 train_time:689983ms step_avg:201.28ms
+step:3429/4150 train_time:690219ms step_avg:201.29ms
+step:3430/4150 train_time:690457ms step_avg:201.30ms
+step:3431/4150 train_time:690693ms step_avg:201.31ms
+step:3432/4150 train_time:690930ms step_avg:201.32ms
+step:3433/4150 train_time:691164ms step_avg:201.33ms
+step:3434/4150 train_time:691401ms step_avg:201.34ms
+step:3435/4150 train_time:691635ms step_avg:201.35ms
+step:3436/4150 train_time:691875ms step_avg:201.36ms
+step:3437/4150 train_time:692112ms step_avg:201.37ms
+step:3438/4150 train_time:692351ms step_avg:201.38ms
+step:3439/4150 train_time:692584ms step_avg:201.39ms
+step:3440/4150 train_time:692822ms step_avg:201.40ms
+step:3441/4150 train_time:693059ms step_avg:201.41ms
+step:3442/4150 train_time:693296ms step_avg:201.42ms
+step:3443/4150 train_time:693530ms step_avg:201.43ms
+step:3444/4150 train_time:693765ms step_avg:201.44ms
+step:3445/4150 train_time:694000ms step_avg:201.45ms
+step:3446/4150 train_time:694235ms step_avg:201.46ms
+step:3447/4150 train_time:694470ms step_avg:201.47ms
+step:3448/4150 train_time:694707ms step_avg:201.48ms
+step:3449/4150 train_time:694941ms step_avg:201.49ms
+step:3450/4150 train_time:695179ms step_avg:201.50ms
+step:3451/4150 train_time:695410ms step_avg:201.51ms
+step:3452/4150 train_time:695648ms step_avg:201.52ms
+step:3453/4150 train_time:695886ms step_avg:201.53ms
+step:3454/4150 train_time:696125ms step_avg:201.54ms
+step:3455/4150 train_time:696359ms step_avg:201.55ms
+step:3456/4150 train_time:696598ms step_avg:201.56ms
+step:3457/4150 train_time:696830ms step_avg:201.57ms
+step:3458/4150 train_time:697068ms step_avg:201.58ms
+step:3459/4150 train_time:697303ms step_avg:201.59ms
+step:3460/4150 train_time:697541ms step_avg:201.60ms
+step:3461/4150 train_time:697775ms step_avg:201.61ms
+step:3462/4150 train_time:698013ms step_avg:201.62ms
+step:3463/4150 train_time:698246ms step_avg:201.63ms
+step:3464/4150 train_time:698484ms step_avg:201.64ms
+step:3465/4150 train_time:698718ms step_avg:201.65ms
+step:3466/4150 train_time:698956ms step_avg:201.66ms
+step:3467/4150 train_time:699192ms step_avg:201.67ms
+step:3468/4150 train_time:699430ms step_avg:201.68ms
+step:3469/4150 train_time:699662ms step_avg:201.69ms
+step:3470/4150 train_time:699899ms step_avg:201.70ms
+step:3471/4150 train_time:700134ms step_avg:201.71ms
+step:3472/4150 train_time:700372ms step_avg:201.72ms
+step:3473/4150 train_time:700606ms step_avg:201.73ms
+step:3474/4150 train_time:700842ms step_avg:201.74ms
+step:3475/4150 train_time:701078ms step_avg:201.75ms
+step:3476/4150 train_time:701315ms step_avg:201.76ms
+step:3477/4150 train_time:701550ms step_avg:201.77ms
+step:3478/4150 train_time:701788ms step_avg:201.78ms
+step:3479/4150 train_time:702022ms step_avg:201.79ms
+step:3480/4150 train_time:702263ms step_avg:201.80ms
+step:3481/4150 train_time:702498ms step_avg:201.81ms
+step:3482/4150 train_time:702732ms step_avg:201.82ms
+step:3483/4150 train_time:702968ms step_avg:201.83ms
+step:3484/4150 train_time:703205ms step_avg:201.84ms
+step:3485/4150 train_time:703443ms step_avg:201.85ms
+step:3486/4150 train_time:703683ms step_avg:201.86ms
+step:3487/4150 train_time:703917ms step_avg:201.87ms
+step:3488/4150 train_time:704155ms step_avg:201.88ms
+step:3489/4150 train_time:704391ms step_avg:201.89ms
+step:3490/4150 train_time:704627ms step_avg:201.90ms
+step:3491/4150 train_time:704861ms step_avg:201.91ms
+step:3492/4150 train_time:705097ms step_avg:201.92ms
+step:3493/4150 train_time:705329ms step_avg:201.93ms
+step:3494/4150 train_time:705569ms step_avg:201.94ms
+step:3495/4150 train_time:705804ms step_avg:201.95ms
+step:3496/4150 train_time:706043ms step_avg:201.96ms
+step:3497/4150 train_time:706279ms step_avg:201.97ms
+step:3498/4150 train_time:706518ms step_avg:201.98ms
+step:3499/4150 train_time:706752ms step_avg:201.99ms
+step:3500/4150 train_time:706991ms step_avg:202.00ms
+step:3500/4150 val_loss:2.9795 train_time:707208ms step_avg:202.06ms
+step:3501/4150 train_time:707230ms step_avg:202.01ms
+step:3502/4150 train_time:707472ms step_avg:202.02ms
+step:3503/4150 train_time:707707ms step_avg:202.03ms
+step:3504/4150 train_time:707942ms step_avg:202.04ms
+step:3505/4150 train_time:708171ms step_avg:202.05ms
+step:3506/4150 train_time:708415ms step_avg:202.06ms
+step:3507/4150 train_time:708651ms step_avg:202.07ms
+step:3508/4150 train_time:708889ms step_avg:202.08ms
+step:3509/4150 train_time:709122ms step_avg:202.09ms
+step:3510/4150 train_time:709361ms step_avg:202.10ms
+step:3511/4150 train_time:709600ms step_avg:202.11ms
+step:3512/4150 train_time:709836ms step_avg:202.12ms
+step:3513/4150 train_time:710071ms step_avg:202.13ms
+step:3514/4150 train_time:710309ms step_avg:202.14ms
+step:3515/4150 train_time:710544ms step_avg:202.15ms
+step:3516/4150 train_time:710782ms step_avg:202.16ms
+step:3517/4150 train_time:711016ms step_avg:202.17ms
+step:3518/4150 train_time:711252ms step_avg:202.18ms
+step:3519/4150 train_time:711488ms step_avg:202.18ms
+step:3520/4150 train_time:711726ms step_avg:202.19ms
+step:3521/4150 train_time:711959ms step_avg:202.20ms
+step:3522/4150 train_time:712194ms step_avg:202.21ms
+step:3523/4150 train_time:712432ms step_avg:202.22ms
+step:3524/4150 train_time:712669ms step_avg:202.23ms
+step:3525/4150 train_time:712902ms step_avg:202.24ms
+step:3526/4150 train_time:713138ms step_avg:202.25ms
+step:3527/4150 train_time:713373ms step_avg:202.26ms
+step:3528/4150 train_time:713611ms step_avg:202.27ms
+step:3529/4150 train_time:713845ms step_avg:202.28ms
+step:3530/4150 train_time:714080ms step_avg:202.29ms
+step:3531/4150 train_time:714313ms step_avg:202.30ms
+step:3532/4150 train_time:714554ms step_avg:202.31ms
+step:3533/4150 train_time:714788ms step_avg:202.32ms
+step:3534/4150 train_time:715026ms step_avg:202.33ms
+step:3535/4150 train_time:715260ms step_avg:202.34ms
+step:3536/4150 train_time:715499ms step_avg:202.35ms
+step:3537/4150 train_time:715735ms step_avg:202.36ms
+step:3538/4150 train_time:715973ms step_avg:202.37ms
+step:3539/4150 train_time:716207ms step_avg:202.38ms
+step:3540/4150 train_time:716445ms step_avg:202.39ms
+step:3541/4150 train_time:716680ms step_avg:202.39ms
+step:3542/4150 train_time:716917ms step_avg:202.40ms
+step:3543/4150 train_time:717151ms step_avg:202.41ms
+step:3544/4150 train_time:717387ms step_avg:202.42ms
+step:3545/4150 train_time:717622ms step_avg:202.43ms
+step:3546/4150 train_time:717862ms step_avg:202.44ms
+step:3547/4150 train_time:718096ms step_avg:202.45ms
+step:3548/4150 train_time:718333ms step_avg:202.46ms
+step:3549/4150 train_time:718567ms step_avg:202.47ms
+step:3550/4150 train_time:718803ms step_avg:202.48ms
+step:3551/4150 train_time:719037ms step_avg:202.49ms
+step:3552/4150 train_time:719274ms step_avg:202.50ms
+step:3553/4150 train_time:719507ms step_avg:202.51ms
+step:3554/4150 train_time:719747ms step_avg:202.52ms
+step:3555/4150 train_time:719983ms step_avg:202.53ms
+step:3556/4150 train_time:720220ms step_avg:202.54ms
+step:3557/4150 train_time:720452ms step_avg:202.54ms
+step:3558/4150 train_time:720692ms step_avg:202.56ms
+step:3559/4150 train_time:720930ms step_avg:202.57ms
+step:3560/4150 train_time:721168ms step_avg:202.58ms
+step:3561/4150 train_time:721401ms step_avg:202.58ms
+step:3562/4150 train_time:721641ms step_avg:202.59ms
+step:3563/4150 train_time:721877ms step_avg:202.60ms
+step:3564/4150 train_time:722113ms step_avg:202.61ms
+step:3565/4150 train_time:722349ms step_avg:202.62ms
+step:3566/4150 train_time:722584ms step_avg:202.63ms
+step:3567/4150 train_time:722820ms step_avg:202.64ms
+step:3568/4150 train_time:723057ms step_avg:202.65ms
+step:3569/4150 train_time:723292ms step_avg:202.66ms
+step:3570/4150 train_time:723530ms step_avg:202.67ms
+step:3571/4150 train_time:723765ms step_avg:202.68ms
+step:3572/4150 train_time:724002ms step_avg:202.69ms
+step:3573/4150 train_time:724237ms step_avg:202.70ms
+step:3574/4150 train_time:724477ms step_avg:202.71ms
+step:3575/4150 train_time:724711ms step_avg:202.72ms
+step:3576/4150 train_time:724947ms step_avg:202.73ms
+step:3577/4150 train_time:725183ms step_avg:202.74ms
+step:3578/4150 train_time:725421ms step_avg:202.74ms
+step:3579/4150 train_time:725655ms step_avg:202.75ms
+step:3580/4150 train_time:725895ms step_avg:202.76ms
+step:3581/4150 train_time:726132ms step_avg:202.77ms
+step:3582/4150 train_time:726369ms step_avg:202.78ms
+step:3583/4150 train_time:726602ms step_avg:202.79ms
+step:3584/4150 train_time:726842ms step_avg:202.80ms
+step:3585/4150 train_time:727079ms step_avg:202.81ms
+step:3586/4150 train_time:727315ms step_avg:202.82ms
+step:3587/4150 train_time:727547ms step_avg:202.83ms
+step:3588/4150 train_time:727783ms step_avg:202.84ms
+step:3589/4150 train_time:728020ms step_avg:202.85ms
+step:3590/4150 train_time:728257ms step_avg:202.86ms
+step:3591/4150 train_time:728493ms step_avg:202.87ms
+step:3592/4150 train_time:728731ms step_avg:202.88ms
+step:3593/4150 train_time:728966ms step_avg:202.89ms
+step:3594/4150 train_time:729205ms step_avg:202.90ms
+step:3595/4150 train_time:729439ms step_avg:202.90ms
+step:3596/4150 train_time:729675ms step_avg:202.91ms
+step:3597/4150 train_time:729909ms step_avg:202.92ms
+step:3598/4150 train_time:730148ms step_avg:202.93ms
+step:3599/4150 train_time:730382ms step_avg:202.94ms
+step:3600/4150 train_time:730618ms step_avg:202.95ms
+step:3601/4150 train_time:730852ms step_avg:202.96ms
+step:3602/4150 train_time:731091ms step_avg:202.97ms
+step:3603/4150 train_time:731329ms step_avg:202.98ms
+step:3604/4150 train_time:731567ms step_avg:202.99ms
+step:3605/4150 train_time:731801ms step_avg:203.00ms
+step:3606/4150 train_time:732039ms step_avg:203.01ms
+step:3607/4150 train_time:732274ms step_avg:203.01ms
+step:3608/4150 train_time:732513ms step_avg:203.02ms
+step:3609/4150 train_time:732745ms step_avg:203.03ms
+step:3610/4150 train_time:732985ms step_avg:203.04ms
+step:3611/4150 train_time:733220ms step_avg:203.05ms
+step:3612/4150 train_time:733457ms step_avg:203.06ms
+step:3613/4150 train_time:733692ms step_avg:203.07ms
+step:3614/4150 train_time:733932ms step_avg:203.08ms
+step:3615/4150 train_time:734164ms step_avg:203.09ms
+step:3616/4150 train_time:734403ms step_avg:203.10ms
+step:3617/4150 train_time:734639ms step_avg:203.11ms
+step:3618/4150 train_time:734878ms step_avg:203.12ms
+step:3619/4150 train_time:735113ms step_avg:203.13ms
+step:3620/4150 train_time:735348ms step_avg:203.13ms
+step:3621/4150 train_time:735584ms step_avg:203.14ms
+step:3622/4150 train_time:735821ms step_avg:203.15ms
+step:3623/4150 train_time:736056ms step_avg:203.16ms
+step:3624/4150 train_time:736293ms step_avg:203.17ms
+step:3625/4150 train_time:736526ms step_avg:203.18ms
+step:3626/4150 train_time:736761ms step_avg:203.19ms
+step:3627/4150 train_time:736998ms step_avg:203.20ms
+step:3628/4150 train_time:737234ms step_avg:203.21ms
+step:3629/4150 train_time:737470ms step_avg:203.22ms
+step:3630/4150 train_time:737708ms step_avg:203.23ms
+step:3631/4150 train_time:737941ms step_avg:203.23ms
+step:3632/4150 train_time:738177ms step_avg:203.24ms
+step:3633/4150 train_time:738412ms step_avg:203.25ms
+step:3634/4150 train_time:738647ms step_avg:203.26ms
+step:3635/4150 train_time:738883ms step_avg:203.27ms
+step:3636/4150 train_time:739122ms step_avg:203.28ms
+step:3637/4150 train_time:739357ms step_avg:203.29ms
+step:3638/4150 train_time:739593ms step_avg:203.30ms
+step:3639/4150 train_time:739828ms step_avg:203.31ms
+step:3640/4150 train_time:740068ms step_avg:203.32ms
+step:3641/4150 train_time:740302ms step_avg:203.32ms
+step:3642/4150 train_time:740541ms step_avg:203.33ms
+step:3643/4150 train_time:740774ms step_avg:203.34ms
+step:3644/4150 train_time:741014ms step_avg:203.35ms
+step:3645/4150 train_time:741247ms step_avg:203.36ms
+step:3646/4150 train_time:741485ms step_avg:203.37ms
+step:3647/4150 train_time:741718ms step_avg:203.38ms
+step:3648/4150 train_time:741954ms step_avg:203.39ms
+step:3649/4150 train_time:742187ms step_avg:203.39ms
+step:3650/4150 train_time:742427ms step_avg:203.40ms
+step:3651/4150 train_time:742661ms step_avg:203.41ms
+step:3652/4150 train_time:742900ms step_avg:203.42ms
+step:3653/4150 train_time:743133ms step_avg:203.43ms
+step:3654/4150 train_time:743370ms step_avg:203.44ms
+step:3655/4150 train_time:743605ms step_avg:203.45ms
+step:3656/4150 train_time:743845ms step_avg:203.46ms
+step:3657/4150 train_time:744082ms step_avg:203.47ms
+step:3658/4150 train_time:744319ms step_avg:203.48ms
+step:3659/4150 train_time:744552ms step_avg:203.49ms
+step:3660/4150 train_time:744791ms step_avg:203.49ms
+step:3661/4150 train_time:745023ms step_avg:203.50ms
+step:3662/4150 train_time:745261ms step_avg:203.51ms
+step:3663/4150 train_time:745497ms step_avg:203.52ms
+step:3664/4150 train_time:745734ms step_avg:203.53ms
+step:3665/4150 train_time:745970ms step_avg:203.54ms
+step:3666/4150 train_time:746209ms step_avg:203.55ms
+step:3667/4150 train_time:746443ms step_avg:203.56ms
+step:3668/4150 train_time:746683ms step_avg:203.57ms
+step:3669/4150 train_time:746918ms step_avg:203.58ms
+step:3670/4150 train_time:747156ms step_avg:203.58ms
+step:3671/4150 train_time:747389ms step_avg:203.59ms
+step:3672/4150 train_time:747625ms step_avg:203.60ms
+step:3673/4150 train_time:747861ms step_avg:203.61ms
+step:3674/4150 train_time:748101ms step_avg:203.62ms
+step:3675/4150 train_time:748338ms step_avg:203.63ms
+step:3676/4150 train_time:748576ms step_avg:203.64ms
+step:3677/4150 train_time:748815ms step_avg:203.65ms
+step:3678/4150 train_time:749051ms step_avg:203.66ms
+step:3679/4150 train_time:749287ms step_avg:203.67ms
+step:3680/4150 train_time:749522ms step_avg:203.67ms
+step:3681/4150 train_time:749756ms step_avg:203.68ms
+step:3682/4150 train_time:749996ms step_avg:203.69ms
+step:3683/4150 train_time:750229ms step_avg:203.70ms
+step:3684/4150 train_time:750467ms step_avg:203.71ms
+step:3685/4150 train_time:750700ms step_avg:203.72ms
+step:3686/4150 train_time:750938ms step_avg:203.73ms
+step:3687/4150 train_time:751170ms step_avg:203.73ms
+step:3688/4150 train_time:751410ms step_avg:203.74ms
+step:3689/4150 train_time:751644ms step_avg:203.75ms
+step:3690/4150 train_time:751883ms step_avg:203.76ms
+step:3691/4150 train_time:752117ms step_avg:203.77ms
+step:3692/4150 train_time:752353ms step_avg:203.78ms
+step:3693/4150 train_time:752588ms step_avg:203.79ms
+step:3694/4150 train_time:752824ms step_avg:203.80ms
+step:3695/4150 train_time:753056ms step_avg:203.80ms
+step:3696/4150 train_time:753296ms step_avg:203.81ms
+step:3697/4150 train_time:753527ms step_avg:203.82ms
+step:3698/4150 train_time:753768ms step_avg:203.83ms
+step:3699/4150 train_time:754004ms step_avg:203.84ms
+step:3700/4150 train_time:754241ms step_avg:203.85ms
+step:3701/4150 train_time:754477ms step_avg:203.86ms
+step:3702/4150 train_time:754713ms step_avg:203.87ms
+step:3703/4150 train_time:754946ms step_avg:203.87ms
+step:3704/4150 train_time:755185ms step_avg:203.88ms
+step:3705/4150 train_time:755419ms step_avg:203.89ms
+step:3706/4150 train_time:755656ms step_avg:203.90ms
+step:3707/4150 train_time:755889ms step_avg:203.91ms
+step:3708/4150 train_time:756126ms step_avg:203.92ms
+step:3709/4150 train_time:756362ms step_avg:203.93ms
+step:3710/4150 train_time:756600ms step_avg:203.94ms
+step:3711/4150 train_time:756834ms step_avg:203.94ms
+step:3712/4150 train_time:757072ms step_avg:203.95ms
+step:3713/4150 train_time:757304ms step_avg:203.96ms
+step:3714/4150 train_time:757542ms step_avg:203.97ms
+step:3715/4150 train_time:757779ms step_avg:203.98ms
+step:3716/4150 train_time:758016ms step_avg:203.99ms
+step:3717/4150 train_time:758251ms step_avg:204.00ms
+step:3718/4150 train_time:758485ms step_avg:204.00ms
+step:3719/4150 train_time:758722ms step_avg:204.01ms
+step:3720/4150 train_time:758962ms step_avg:204.02ms
+step:3721/4150 train_time:759196ms step_avg:204.03ms
+step:3722/4150 train_time:759433ms step_avg:204.04ms
+step:3723/4150 train_time:759666ms step_avg:204.05ms
+step:3724/4150 train_time:759907ms step_avg:204.06ms
+step:3725/4150 train_time:760143ms step_avg:204.07ms
+step:3726/4150 train_time:760380ms step_avg:204.07ms
+step:3727/4150 train_time:760615ms step_avg:204.08ms
+step:3728/4150 train_time:760854ms step_avg:204.09ms
+step:3729/4150 train_time:761093ms step_avg:204.10ms
+step:3730/4150 train_time:761330ms step_avg:204.11ms
+step:3731/4150 train_time:761567ms step_avg:204.12ms
+step:3732/4150 train_time:761807ms step_avg:204.13ms
+step:3733/4150 train_time:762042ms step_avg:204.14ms
+step:3734/4150 train_time:762282ms step_avg:204.15ms
+step:3735/4150 train_time:762517ms step_avg:204.15ms
+step:3736/4150 train_time:762756ms step_avg:204.16ms
+step:3737/4150 train_time:762989ms step_avg:204.17ms
+step:3738/4150 train_time:763232ms step_avg:204.18ms
+step:3739/4150 train_time:763467ms step_avg:204.19ms
+step:3740/4150 train_time:763707ms step_avg:204.20ms
+step:3741/4150 train_time:763944ms step_avg:204.21ms
+step:3742/4150 train_time:764180ms step_avg:204.22ms
+step:3743/4150 train_time:764413ms step_avg:204.22ms
+step:3744/4150 train_time:764649ms step_avg:204.23ms
+step:3745/4150 train_time:764886ms step_avg:204.24ms
+step:3746/4150 train_time:765122ms step_avg:204.25ms
+step:3747/4150 train_time:765358ms step_avg:204.26ms
+step:3748/4150 train_time:765594ms step_avg:204.27ms
+step:3749/4150 train_time:765829ms step_avg:204.28ms
+step:3750/4150 train_time:766067ms step_avg:204.28ms
+step:3750/4150 val_loss:2.9521 train_time:766283ms step_avg:204.34ms
+step:3751/4150 train_time:766306ms step_avg:204.29ms
+step:3752/4150 train_time:766545ms step_avg:204.30ms
+step:3753/4150 train_time:766778ms step_avg:204.31ms
+step:3754/4150 train_time:767014ms step_avg:204.32ms
+step:3755/4150 train_time:767249ms step_avg:204.33ms
+step:3756/4150 train_time:767488ms step_avg:204.34ms
+step:3757/4150 train_time:767726ms step_avg:204.35ms
+step:3758/4150 train_time:767961ms step_avg:204.35ms
+step:3759/4150 train_time:768194ms step_avg:204.36ms
+step:3760/4150 train_time:768434ms step_avg:204.37ms
+step:3761/4150 train_time:768670ms step_avg:204.38ms
+step:3762/4150 train_time:768904ms step_avg:204.39ms
+step:3763/4150 train_time:769135ms step_avg:204.39ms
+step:3764/4150 train_time:769370ms step_avg:204.40ms
+step:3765/4150 train_time:769609ms step_avg:204.41ms
+step:3766/4150 train_time:769848ms step_avg:204.42ms
+step:3767/4150 train_time:770081ms step_avg:204.43ms
+step:3768/4150 train_time:770318ms step_avg:204.44ms
+step:3769/4150 train_time:770553ms step_avg:204.45ms
+step:3770/4150 train_time:770791ms step_avg:204.45ms
+step:3771/4150 train_time:771024ms step_avg:204.46ms
+step:3772/4150 train_time:771261ms step_avg:204.47ms
+step:3773/4150 train_time:771497ms step_avg:204.48ms
+step:3774/4150 train_time:771736ms step_avg:204.49ms
+step:3775/4150 train_time:771972ms step_avg:204.50ms
+step:3776/4150 train_time:772214ms step_avg:204.51ms
+step:3777/4150 train_time:772449ms step_avg:204.51ms
+step:3778/4150 train_time:772689ms step_avg:204.52ms
+step:3779/4150 train_time:772923ms step_avg:204.53ms
+step:3780/4150 train_time:773158ms step_avg:204.54ms
+step:3781/4150 train_time:773392ms step_avg:204.55ms
+step:3782/4150 train_time:773632ms step_avg:204.56ms
+step:3783/4150 train_time:773865ms step_avg:204.56ms
+step:3784/4150 train_time:774101ms step_avg:204.57ms
+step:3785/4150 train_time:774337ms step_avg:204.58ms
+step:3786/4150 train_time:774577ms step_avg:204.59ms
+step:3787/4150 train_time:774812ms step_avg:204.60ms
+step:3788/4150 train_time:775049ms step_avg:204.61ms
+step:3789/4150 train_time:775284ms step_avg:204.61ms
+step:3790/4150 train_time:775523ms step_avg:204.62ms
+step:3791/4150 train_time:775762ms step_avg:204.63ms
+step:3792/4150 train_time:775998ms step_avg:204.64ms
+step:3793/4150 train_time:776232ms step_avg:204.65ms
+step:3794/4150 train_time:776469ms step_avg:204.66ms
+step:3795/4150 train_time:776706ms step_avg:204.67ms
+step:3796/4150 train_time:776943ms step_avg:204.67ms
+step:3797/4150 train_time:777175ms step_avg:204.68ms
+step:3798/4150 train_time:777413ms step_avg:204.69ms
+step:3799/4150 train_time:777648ms step_avg:204.70ms
+step:3800/4150 train_time:777885ms step_avg:204.71ms
+step:3801/4150 train_time:778119ms step_avg:204.71ms
+step:3802/4150 train_time:778360ms step_avg:204.72ms
+step:3803/4150 train_time:778595ms step_avg:204.73ms
+step:3804/4150 train_time:778833ms step_avg:204.74ms
+step:3805/4150 train_time:779068ms step_avg:204.75ms
+step:3806/4150 train_time:779306ms step_avg:204.76ms
+step:3807/4150 train_time:779539ms step_avg:204.76ms
+step:3808/4150 train_time:779778ms step_avg:204.77ms
+step:3809/4150 train_time:780011ms step_avg:204.78ms
+step:3810/4150 train_time:780249ms step_avg:204.79ms
+step:3811/4150 train_time:780483ms step_avg:204.80ms
+step:3812/4150 train_time:780719ms step_avg:204.81ms
+step:3813/4150 train_time:780955ms step_avg:204.81ms
+step:3814/4150 train_time:781193ms step_avg:204.82ms
+step:3815/4150 train_time:781424ms step_avg:204.83ms
+step:3816/4150 train_time:781660ms step_avg:204.84ms
+step:3817/4150 train_time:781895ms step_avg:204.85ms
+step:3818/4150 train_time:782136ms step_avg:204.85ms
+step:3819/4150 train_time:782367ms step_avg:204.86ms
+step:3820/4150 train_time:782601ms step_avg:204.87ms
+step:3821/4150 train_time:782836ms step_avg:204.88ms
+step:3822/4150 train_time:783076ms step_avg:204.89ms
+step:3823/4150 train_time:783311ms step_avg:204.89ms
+step:3824/4150 train_time:783548ms step_avg:204.90ms
+step:3825/4150 train_time:783780ms step_avg:204.91ms
+step:3826/4150 train_time:784022ms step_avg:204.92ms
+step:3827/4150 train_time:784256ms step_avg:204.93ms
+step:3828/4150 train_time:784494ms step_avg:204.94ms
+step:3829/4150 train_time:784727ms step_avg:204.94ms
+step:3830/4150 train_time:784965ms step_avg:204.95ms
+step:3831/4150 train_time:785201ms step_avg:204.96ms
+step:3832/4150 train_time:785441ms step_avg:204.97ms
+step:3833/4150 train_time:785674ms step_avg:204.98ms
+step:3834/4150 train_time:785912ms step_avg:204.98ms
+step:3835/4150 train_time:786145ms step_avg:204.99ms
+step:3836/4150 train_time:786384ms step_avg:205.00ms
+step:3837/4150 train_time:786621ms step_avg:205.01ms
+step:3838/4150 train_time:786859ms step_avg:205.02ms
+step:3839/4150 train_time:787096ms step_avg:205.03ms
+step:3840/4150 train_time:787334ms step_avg:205.04ms
+step:3841/4150 train_time:787568ms step_avg:205.04ms
+step:3842/4150 train_time:787806ms step_avg:205.05ms
+step:3843/4150 train_time:788039ms step_avg:205.06ms
+step:3844/4150 train_time:788276ms step_avg:205.07ms
+step:3845/4150 train_time:788511ms step_avg:205.07ms
+step:3846/4150 train_time:788749ms step_avg:205.08ms
+step:3847/4150 train_time:788983ms step_avg:205.09ms
+step:3848/4150 train_time:789221ms step_avg:205.10ms
+step:3849/4150 train_time:789455ms step_avg:205.11ms
+step:3850/4150 train_time:789691ms step_avg:205.11ms
+step:3851/4150 train_time:789925ms step_avg:205.12ms
+step:3852/4150 train_time:790163ms step_avg:205.13ms
+step:3853/4150 train_time:790399ms step_avg:205.14ms
+step:3854/4150 train_time:790640ms step_avg:205.15ms
+step:3855/4150 train_time:790874ms step_avg:205.16ms
+step:3856/4150 train_time:791110ms step_avg:205.16ms
+step:3857/4150 train_time:791343ms step_avg:205.17ms
+step:3858/4150 train_time:791581ms step_avg:205.18ms
+step:3859/4150 train_time:791814ms step_avg:205.19ms
+step:3860/4150 train_time:792053ms step_avg:205.19ms
+step:3861/4150 train_time:792287ms step_avg:205.20ms
+step:3862/4150 train_time:792523ms step_avg:205.21ms
+step:3863/4150 train_time:792758ms step_avg:205.22ms
+step:3864/4150 train_time:792998ms step_avg:205.23ms
+step:3865/4150 train_time:793236ms step_avg:205.24ms
+step:3866/4150 train_time:793476ms step_avg:205.24ms
+step:3867/4150 train_time:793709ms step_avg:205.25ms
+step:3868/4150 train_time:793950ms step_avg:205.26ms
+step:3869/4150 train_time:794184ms step_avg:205.27ms
+step:3870/4150 train_time:794420ms step_avg:205.28ms
+step:3871/4150 train_time:794657ms step_avg:205.28ms
+step:3872/4150 train_time:794894ms step_avg:205.29ms
+step:3873/4150 train_time:795128ms step_avg:205.30ms
+step:3874/4150 train_time:795364ms step_avg:205.31ms
+step:3875/4150 train_time:795599ms step_avg:205.32ms
+step:3876/4150 train_time:795839ms step_avg:205.32ms
+step:3877/4150 train_time:796075ms step_avg:205.33ms
+step:3878/4150 train_time:796315ms step_avg:205.34ms
+step:3879/4150 train_time:796550ms step_avg:205.35ms
+step:3880/4150 train_time:796786ms step_avg:205.36ms
+step:3881/4150 train_time:797021ms step_avg:205.36ms
+step:3882/4150 train_time:797256ms step_avg:205.37ms
+step:3883/4150 train_time:797493ms step_avg:205.38ms
+step:3884/4150 train_time:797728ms step_avg:205.39ms
+step:3885/4150 train_time:797962ms step_avg:205.40ms
+step:3886/4150 train_time:798202ms step_avg:205.40ms
+step:3887/4150 train_time:798435ms step_avg:205.41ms
+step:3888/4150 train_time:798672ms step_avg:205.42ms
+step:3889/4150 train_time:798906ms step_avg:205.43ms
+step:3890/4150 train_time:799144ms step_avg:205.44ms
+step:3891/4150 train_time:799381ms step_avg:205.44ms
+step:3892/4150 train_time:799617ms step_avg:205.45ms
+step:3893/4150 train_time:799853ms step_avg:205.46ms
+step:3894/4150 train_time:800090ms step_avg:205.47ms
+step:3895/4150 train_time:800326ms step_avg:205.48ms
+step:3896/4150 train_time:800564ms step_avg:205.48ms
+step:3897/4150 train_time:800801ms step_avg:205.49ms
+step:3898/4150 train_time:801038ms step_avg:205.50ms
+step:3899/4150 train_time:801274ms step_avg:205.51ms
+step:3900/4150 train_time:801513ms step_avg:205.52ms
+step:3901/4150 train_time:801749ms step_avg:205.52ms
+step:3902/4150 train_time:801987ms step_avg:205.53ms
+step:3903/4150 train_time:802221ms step_avg:205.54ms
+step:3904/4150 train_time:802458ms step_avg:205.55ms
+step:3905/4150 train_time:802692ms step_avg:205.55ms
+step:3906/4150 train_time:802930ms step_avg:205.56ms
+step:3907/4150 train_time:803165ms step_avg:205.57ms
+step:3908/4150 train_time:803402ms step_avg:205.58ms
+step:3909/4150 train_time:803640ms step_avg:205.59ms
+step:3910/4150 train_time:803879ms step_avg:205.60ms
+step:3911/4150 train_time:804115ms step_avg:205.60ms
+step:3912/4150 train_time:804349ms step_avg:205.61ms
+step:3913/4150 train_time:804585ms step_avg:205.62ms
+step:3914/4150 train_time:804824ms step_avg:205.63ms
+step:3915/4150 train_time:805060ms step_avg:205.63ms
+step:3916/4150 train_time:805294ms step_avg:205.64ms
+step:3917/4150 train_time:805530ms step_avg:205.65ms
+step:3918/4150 train_time:805768ms step_avg:205.66ms
+step:3919/4150 train_time:806001ms step_avg:205.67ms
+step:3920/4150 train_time:806240ms step_avg:205.67ms
+step:3921/4150 train_time:806476ms step_avg:205.68ms
+step:3922/4150 train_time:806716ms step_avg:205.69ms
+step:3923/4150 train_time:806949ms step_avg:205.70ms
+step:3924/4150 train_time:807187ms step_avg:205.71ms
+step:3925/4150 train_time:807422ms step_avg:205.71ms
+step:3926/4150 train_time:807663ms step_avg:205.72ms
+step:3927/4150 train_time:807900ms step_avg:205.73ms
+step:3928/4150 train_time:808135ms step_avg:205.74ms
+step:3929/4150 train_time:808370ms step_avg:205.74ms
+step:3930/4150 train_time:808607ms step_avg:205.75ms
+step:3931/4150 train_time:808843ms step_avg:205.76ms
+step:3932/4150 train_time:809080ms step_avg:205.77ms
+step:3933/4150 train_time:809312ms step_avg:205.77ms
+step:3934/4150 train_time:809547ms step_avg:205.78ms
+step:3935/4150 train_time:809781ms step_avg:205.79ms
+step:3936/4150 train_time:810025ms step_avg:205.80ms
+step:3937/4150 train_time:810261ms step_avg:205.81ms
+step:3938/4150 train_time:810499ms step_avg:205.81ms
+step:3939/4150 train_time:810733ms step_avg:205.82ms
+step:3940/4150 train_time:810973ms step_avg:205.83ms
+step:3941/4150 train_time:811208ms step_avg:205.84ms
+step:3942/4150 train_time:811444ms step_avg:205.85ms
+step:3943/4150 train_time:811677ms step_avg:205.85ms
+step:3944/4150 train_time:811915ms step_avg:205.86ms
+step:3945/4150 train_time:812148ms step_avg:205.87ms
+step:3946/4150 train_time:812388ms step_avg:205.88ms
+step:3947/4150 train_time:812622ms step_avg:205.88ms
+step:3948/4150 train_time:812863ms step_avg:205.89ms
+step:3949/4150 train_time:813096ms step_avg:205.90ms
+step:3950/4150 train_time:813338ms step_avg:205.91ms
+step:3951/4150 train_time:813574ms step_avg:205.92ms
+step:3952/4150 train_time:813810ms step_avg:205.92ms
+step:3953/4150 train_time:814045ms step_avg:205.93ms
+step:3954/4150 train_time:814285ms step_avg:205.94ms
+step:3955/4150 train_time:814519ms step_avg:205.95ms
+step:3956/4150 train_time:814755ms step_avg:205.95ms
+step:3957/4150 train_time:814991ms step_avg:205.96ms
+step:3958/4150 train_time:815229ms step_avg:205.97ms
+step:3959/4150 train_time:815464ms step_avg:205.98ms
+step:3960/4150 train_time:815703ms step_avg:205.99ms
+step:3961/4150 train_time:815937ms step_avg:205.99ms
+step:3962/4150 train_time:816174ms step_avg:206.00ms
+step:3963/4150 train_time:816407ms step_avg:206.01ms
+step:3964/4150 train_time:816644ms step_avg:206.02ms
+step:3965/4150 train_time:816878ms step_avg:206.02ms
+step:3966/4150 train_time:817114ms step_avg:206.03ms
+step:3967/4150 train_time:817349ms step_avg:206.04ms
+step:3968/4150 train_time:817586ms step_avg:206.04ms
+step:3969/4150 train_time:817819ms step_avg:206.05ms
+step:3970/4150 train_time:818058ms step_avg:206.06ms
+step:3971/4150 train_time:818291ms step_avg:206.07ms
+step:3972/4150 train_time:818528ms step_avg:206.07ms
+step:3973/4150 train_time:818761ms step_avg:206.08ms
+step:3974/4150 train_time:818998ms step_avg:206.09ms
+step:3975/4150 train_time:819233ms step_avg:206.10ms
+step:3976/4150 train_time:819472ms step_avg:206.10ms
+step:3977/4150 train_time:819706ms step_avg:206.11ms
+step:3978/4150 train_time:819945ms step_avg:206.12ms
+step:3979/4150 train_time:820180ms step_avg:206.13ms
+step:3980/4150 train_time:820417ms step_avg:206.13ms
+step:3981/4150 train_time:820649ms step_avg:206.14ms
+step:3982/4150 train_time:820888ms step_avg:206.15ms
+step:3983/4150 train_time:821124ms step_avg:206.16ms
+step:3984/4150 train_time:821358ms step_avg:206.16ms
+step:3985/4150 train_time:821593ms step_avg:206.17ms
+step:3986/4150 train_time:821831ms step_avg:206.18ms
+step:3987/4150 train_time:822065ms step_avg:206.19ms
+step:3988/4150 train_time:822304ms step_avg:206.19ms
+step:3989/4150 train_time:822537ms step_avg:206.20ms
+step:3990/4150 train_time:822774ms step_avg:206.21ms
+step:3991/4150 train_time:823009ms step_avg:206.22ms
+step:3992/4150 train_time:823247ms step_avg:206.22ms
+step:3993/4150 train_time:823480ms step_avg:206.23ms
+step:3994/4150 train_time:823720ms step_avg:206.24ms
+step:3995/4150 train_time:823955ms step_avg:206.25ms
+step:3996/4150 train_time:824197ms step_avg:206.26ms
+step:3997/4150 train_time:824431ms step_avg:206.26ms
+step:3998/4150 train_time:824668ms step_avg:206.27ms
+step:3999/4150 train_time:824902ms step_avg:206.28ms
+step:4000/4150 train_time:825144ms step_avg:206.29ms
+step:4000/4150 val_loss:2.9290 train_time:825359ms step_avg:206.34ms
+step:4001/4150 train_time:825381ms step_avg:206.29ms
+step:4002/4150 train_time:825621ms step_avg:206.30ms
+step:4003/4150 train_time:825857ms step_avg:206.31ms
+step:4004/4150 train_time:826091ms step_avg:206.32ms
+step:4005/4150 train_time:826326ms step_avg:206.32ms
+step:4006/4150 train_time:826570ms step_avg:206.33ms
+step:4007/4150 train_time:826808ms step_avg:206.34ms
+step:4008/4150 train_time:827043ms step_avg:206.35ms
+step:4009/4150 train_time:827275ms step_avg:206.35ms
+step:4010/4150 train_time:827515ms step_avg:206.36ms
+step:4011/4150 train_time:827752ms step_avg:206.37ms
+step:4012/4150 train_time:827988ms step_avg:206.38ms
+step:4013/4150 train_time:828220ms step_avg:206.38ms
+step:4014/4150 train_time:828457ms step_avg:206.39ms
+step:4015/4150 train_time:828695ms step_avg:206.40ms
+step:4016/4150 train_time:828933ms step_avg:206.41ms
+step:4017/4150 train_time:829165ms step_avg:206.41ms
+step:4018/4150 train_time:829403ms step_avg:206.42ms
+step:4019/4150 train_time:829643ms step_avg:206.43ms
+step:4020/4150 train_time:829880ms step_avg:206.44ms
+step:4021/4150 train_time:830115ms step_avg:206.44ms
+step:4022/4150 train_time:830351ms step_avg:206.45ms
+step:4023/4150 train_time:830585ms step_avg:206.46ms
+step:4024/4150 train_time:830827ms step_avg:206.47ms
+step:4025/4150 train_time:831062ms step_avg:206.48ms
+step:4026/4150 train_time:831298ms step_avg:206.48ms
+step:4027/4150 train_time:831530ms step_avg:206.49ms
+step:4028/4150 train_time:831768ms step_avg:206.50ms
+step:4029/4150 train_time:832003ms step_avg:206.50ms
+step:4030/4150 train_time:832240ms step_avg:206.51ms
+step:4031/4150 train_time:832474ms step_avg:206.52ms
+step:4032/4150 train_time:832713ms step_avg:206.53ms
+step:4033/4150 train_time:832948ms step_avg:206.53ms
+step:4034/4150 train_time:833186ms step_avg:206.54ms
+step:4035/4150 train_time:833417ms step_avg:206.55ms
+step:4036/4150 train_time:833654ms step_avg:206.55ms
+step:4037/4150 train_time:833888ms step_avg:206.56ms
+step:4038/4150 train_time:834128ms step_avg:206.57ms
+step:4039/4150 train_time:834362ms step_avg:206.58ms
+step:4040/4150 train_time:834601ms step_avg:206.58ms
+step:4041/4150 train_time:834835ms step_avg:206.59ms
+step:4042/4150 train_time:835075ms step_avg:206.60ms
+step:4043/4150 train_time:835306ms step_avg:206.61ms
+step:4044/4150 train_time:835542ms step_avg:206.61ms
+step:4045/4150 train_time:835776ms step_avg:206.62ms
+step:4046/4150 train_time:836010ms step_avg:206.63ms
+step:4047/4150 train_time:836245ms step_avg:206.63ms
+step:4048/4150 train_time:836483ms step_avg:206.64ms
+step:4049/4150 train_time:836717ms step_avg:206.65ms
+step:4050/4150 train_time:836955ms step_avg:206.66ms
+step:4051/4150 train_time:837190ms step_avg:206.66ms
+step:4052/4150 train_time:837426ms step_avg:206.67ms
+step:4053/4150 train_time:837661ms step_avg:206.68ms
+step:4054/4150 train_time:837901ms step_avg:206.69ms
+step:4055/4150 train_time:838133ms step_avg:206.69ms
+step:4056/4150 train_time:838370ms step_avg:206.70ms
+step:4057/4150 train_time:838606ms step_avg:206.71ms
+step:4058/4150 train_time:838842ms step_avg:206.71ms
+step:4059/4150 train_time:839079ms step_avg:206.72ms
+step:4060/4150 train_time:839316ms step_avg:206.73ms
+step:4061/4150 train_time:839555ms step_avg:206.74ms
+step:4062/4150 train_time:839792ms step_avg:206.74ms
+step:4063/4150 train_time:840024ms step_avg:206.75ms
+step:4064/4150 train_time:840262ms step_avg:206.76ms
+step:4065/4150 train_time:840497ms step_avg:206.76ms
+step:4066/4150 train_time:840733ms step_avg:206.77ms
+step:4067/4150 train_time:840972ms step_avg:206.78ms
+step:4068/4150 train_time:841208ms step_avg:206.79ms
+step:4069/4150 train_time:841445ms step_avg:206.79ms
+step:4070/4150 train_time:841687ms step_avg:206.80ms
+step:4071/4150 train_time:841923ms step_avg:206.81ms
+step:4072/4150 train_time:842159ms step_avg:206.82ms
+step:4073/4150 train_time:842396ms step_avg:206.82ms
+step:4074/4150 train_time:842634ms step_avg:206.83ms
+step:4075/4150 train_time:842873ms step_avg:206.84ms
+step:4076/4150 train_time:843108ms step_avg:206.85ms
+step:4077/4150 train_time:843342ms step_avg:206.85ms
+step:4078/4150 train_time:843578ms step_avg:206.86ms
+step:4079/4150 train_time:843812ms step_avg:206.87ms
+step:4080/4150 train_time:844048ms step_avg:206.87ms
+step:4081/4150 train_time:844283ms step_avg:206.88ms
+step:4082/4150 train_time:844522ms step_avg:206.89ms
+step:4083/4150 train_time:844758ms step_avg:206.90ms
+step:4084/4150 train_time:844997ms step_avg:206.90ms
+step:4085/4150 train_time:845233ms step_avg:206.91ms
+step:4086/4150 train_time:845469ms step_avg:206.92ms
+step:4087/4150 train_time:845703ms step_avg:206.93ms
+step:4088/4150 train_time:845943ms step_avg:206.93ms
+step:4089/4150 train_time:846181ms step_avg:206.94ms
+step:4090/4150 train_time:846420ms step_avg:206.95ms
+step:4091/4150 train_time:846656ms step_avg:206.96ms
+step:4092/4150 train_time:846894ms step_avg:206.96ms
+step:4093/4150 train_time:847129ms step_avg:206.97ms
+step:4094/4150 train_time:847365ms step_avg:206.98ms
+step:4095/4150 train_time:847599ms step_avg:206.98ms
+step:4096/4150 train_time:847837ms step_avg:206.99ms
+step:4097/4150 train_time:848070ms step_avg:207.00ms
+step:4098/4150 train_time:848307ms step_avg:207.01ms
+step:4099/4150 train_time:848542ms step_avg:207.01ms
+step:4100/4150 train_time:848780ms step_avg:207.02ms
+step:4101/4150 train_time:849016ms step_avg:207.03ms
+step:4102/4150 train_time:849252ms step_avg:207.03ms
+step:4103/4150 train_time:849486ms step_avg:207.04ms
+step:4104/4150 train_time:849725ms step_avg:207.05ms
+step:4105/4150 train_time:849958ms step_avg:207.05ms
+step:4106/4150 train_time:850195ms step_avg:207.06ms
+step:4107/4150 train_time:850429ms step_avg:207.07ms
+step:4108/4150 train_time:850668ms step_avg:207.08ms
+step:4109/4150 train_time:850904ms step_avg:207.08ms
+step:4110/4150 train_time:851141ms step_avg:207.09ms
+step:4111/4150 train_time:851376ms step_avg:207.10ms
+step:4112/4150 train_time:851613ms step_avg:207.10ms
+step:4113/4150 train_time:851847ms step_avg:207.11ms
+step:4114/4150 train_time:852085ms step_avg:207.12ms
+step:4115/4150 train_time:852319ms step_avg:207.12ms
+step:4116/4150 train_time:852556ms step_avg:207.13ms
+step:4117/4150 train_time:852790ms step_avg:207.14ms
+step:4118/4150 train_time:853027ms step_avg:207.15ms
+step:4119/4150 train_time:853260ms step_avg:207.15ms
+step:4120/4150 train_time:853499ms step_avg:207.16ms
+step:4121/4150 train_time:853733ms step_avg:207.17ms
+step:4122/4150 train_time:853969ms step_avg:207.17ms
+step:4123/4150 train_time:854204ms step_avg:207.18ms
+step:4124/4150 train_time:854443ms step_avg:207.19ms
+step:4125/4150 train_time:854677ms step_avg:207.19ms
+step:4126/4150 train_time:854916ms step_avg:207.20ms
+step:4127/4150 train_time:855149ms step_avg:207.21ms
+step:4128/4150 train_time:855390ms step_avg:207.22ms
+step:4129/4150 train_time:855627ms step_avg:207.22ms
+step:4130/4150 train_time:855864ms step_avg:207.23ms
+step:4131/4150 train_time:856098ms step_avg:207.24ms
+step:4132/4150 train_time:856335ms step_avg:207.24ms
+step:4133/4150 train_time:856570ms step_avg:207.25ms
+step:4134/4150 train_time:856810ms step_avg:207.26ms
+step:4135/4150 train_time:857044ms step_avg:207.27ms
+step:4136/4150 train_time:857280ms step_avg:207.27ms
+step:4137/4150 train_time:857516ms step_avg:207.28ms
+step:4138/4150 train_time:857753ms step_avg:207.29ms
+step:4139/4150 train_time:857992ms step_avg:207.29ms
+step:4140/4150 train_time:858232ms step_avg:207.30ms
+step:4141/4150 train_time:858465ms step_avg:207.31ms
+step:4142/4150 train_time:858703ms step_avg:207.32ms
+step:4143/4150 train_time:858938ms step_avg:207.32ms
+step:4144/4150 train_time:859178ms step_avg:207.33ms
+step:4145/4150 train_time:859411ms step_avg:207.34ms
+step:4146/4150 train_time:859649ms step_avg:207.34ms
+step:4147/4150 train_time:859884ms step_avg:207.35ms
+step:4148/4150 train_time:860121ms step_avg:207.36ms
+step:4149/4150 train_time:860356ms step_avg:207.36ms
+step:4150/4150 train_time:860595ms step_avg:207.37ms
+step:4150/4150 val_loss:2.9179 train_time:860808ms step_avg:207.42ms
+peak memory allocated: 59977 MiB reserved: 60544 MiB

--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/cd28482e-229d-4c98-8c84-b5587e8908a4.txt
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/cd28482e-229d-4c98-8c84-b5587e8908a4.txt
@@ -1,0 +1,6376 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+import numpy as np
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
+
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = False # turn off fp8 for now -> requires tuning of scales which hasnt been done on medium track
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(16, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
+
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
+        self.yarn = Yarn(head_dim, max_seq_len)
+
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+        self.embed.weight.label = 'embed'
+
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
+        self.embed2.weight.label = 'embed2'
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [2, 4, 6]
+        skip_out = [9, 10, 11]
+        backout_layer = 11
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
+            short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
+
+        skip_idx = 0
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve_list[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
+            )
+            next_ve_gate = None
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
+                skip_idx += 1
+                x = x + skip_gate_out * skip_connections.pop()
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
+            else:
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                h_backout_snap = x
+
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
+        x = norm(x)
+
+        if not self.training:
+            loss = 0
+            for i in range(4):
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
+                logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+                loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
+            return loss
+
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return min(11,args.ws_schedule[ws_idx] // 2), args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/12:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/12:
+        lr_max = 1.73  # (24/8)**0.5
+    if x > 3/12:
+        lr_max = 2.0
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
+
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / (args.num_scheduled_iterations/4)
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        # only apply yarn for first few
+        if new_ws_long != self.ws_long and new_ws_long<=13:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
+                                524288, 524288, 524288, 524288,
+                                524288, 524288, 524288, 524288
+                               )
+    train_bs_extension: int = 32 * 2048 * 8
+    train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3/4
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11, 13,
+                          15, 17, 19, 21,
+                          23, 23, 23, 23)
+    ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
+    ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=16,
+    num_heads=8,
+    head_dim=128,
+    model_dim=1024,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Mon Apr 27 08:02:20 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   47C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   40C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   47C    P0            118W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   40C    P0            129W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   46C    P0            126W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   42C    P0            125W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          278984      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    1   N/A  N/A          278985      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    2   N/A  N/A          278986      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    3   N/A  N/A          278987      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    4   N/A  N/A          278988      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    5   N/A  N/A          278989      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    6   N/A  N/A          278990      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    7   N/A  N/A          278991      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 343, 344, 345, 687, 688, 689, 1031, 1032, 1033, 1374, 1375, 1376, 1718, 1719, 1720, 2062, 2063, 2064, 2406, 2407, 2408, 2749, 2750, 2751] for warmup
+Resetting Model
+step:0/4150 val_loss:10.8339 train_time:0ms step_avg:0.03ms
+step:1/4150 train_time:67ms step_avg:67.13ms
+step:2/4150 train_time:125ms step_avg:62.49ms
+step:3/4150 train_time:192ms step_avg:64.11ms
+step:4/4150 train_time:259ms step_avg:64.71ms
+step:5/4150 train_time:328ms step_avg:65.62ms
+step:6/4150 train_time:394ms step_avg:65.58ms
+step:7/4150 train_time:463ms step_avg:66.08ms
+step:8/4150 train_time:528ms step_avg:65.99ms
+step:9/4150 train_time:597ms step_avg:66.34ms
+step:10/4150 train_time:662ms step_avg:66.23ms
+step:11/4150 train_time:732ms step_avg:66.54ms
+step:12/4150 train_time:797ms step_avg:66.41ms
+step:13/4150 train_time:866ms step_avg:66.65ms
+step:14/4150 train_time:933ms step_avg:66.63ms
+step:15/4150 train_time:1003ms step_avg:66.83ms
+step:16/4150 train_time:1069ms step_avg:66.83ms
+step:17/4150 train_time:1139ms step_avg:66.99ms
+step:18/4150 train_time:1205ms step_avg:66.96ms
+step:19/4150 train_time:1276ms step_avg:67.15ms
+step:20/4150 train_time:1342ms step_avg:67.10ms
+step:21/4150 train_time:1412ms step_avg:67.23ms
+step:22/4150 train_time:1478ms step_avg:67.18ms
+step:23/4150 train_time:1547ms step_avg:67.25ms
+step:24/4150 train_time:1613ms step_avg:67.19ms
+step:25/4150 train_time:1683ms step_avg:67.32ms
+step:26/4150 train_time:1749ms step_avg:67.25ms
+step:27/4150 train_time:1818ms step_avg:67.33ms
+step:28/4150 train_time:1884ms step_avg:67.28ms
+step:29/4150 train_time:1954ms step_avg:67.37ms
+step:30/4150 train_time:2020ms step_avg:67.32ms
+step:31/4150 train_time:2090ms step_avg:67.41ms
+step:32/4150 train_time:2155ms step_avg:67.36ms
+step:33/4150 train_time:2226ms step_avg:67.44ms
+step:34/4150 train_time:2291ms step_avg:67.39ms
+step:35/4150 train_time:2361ms step_avg:67.47ms
+step:36/4150 train_time:2428ms step_avg:67.45ms
+step:37/4150 train_time:2498ms step_avg:67.51ms
+step:38/4150 train_time:2564ms step_avg:67.47ms
+step:39/4150 train_time:2634ms step_avg:67.54ms
+step:40/4150 train_time:2700ms step_avg:67.50ms
+step:41/4150 train_time:2770ms step_avg:67.56ms
+step:42/4150 train_time:2836ms step_avg:67.53ms
+step:43/4150 train_time:2906ms step_avg:67.58ms
+step:44/4150 train_time:2971ms step_avg:67.53ms
+step:45/4150 train_time:3041ms step_avg:67.58ms
+step:46/4150 train_time:3107ms step_avg:67.54ms
+step:47/4150 train_time:3177ms step_avg:67.59ms
+step:48/4150 train_time:3242ms step_avg:67.55ms
+step:49/4150 train_time:3312ms step_avg:67.58ms
+step:50/4150 train_time:3377ms step_avg:67.55ms
+step:51/4150 train_time:3447ms step_avg:67.59ms
+step:52/4150 train_time:3513ms step_avg:67.55ms
+step:53/4150 train_time:3583ms step_avg:67.60ms
+step:54/4150 train_time:3648ms step_avg:67.56ms
+step:55/4150 train_time:3718ms step_avg:67.60ms
+step:56/4150 train_time:3784ms step_avg:67.56ms
+step:57/4150 train_time:3854ms step_avg:67.61ms
+step:58/4150 train_time:3920ms step_avg:67.58ms
+step:59/4150 train_time:3989ms step_avg:67.62ms
+step:60/4150 train_time:4056ms step_avg:67.60ms
+step:61/4150 train_time:4125ms step_avg:67.63ms
+step:62/4150 train_time:4192ms step_avg:67.62ms
+step:63/4150 train_time:4262ms step_avg:67.65ms
+step:64/4150 train_time:4328ms step_avg:67.62ms
+step:65/4150 train_time:4399ms step_avg:67.67ms
+step:66/4150 train_time:4464ms step_avg:67.64ms
+step:67/4150 train_time:4534ms step_avg:67.67ms
+step:68/4150 train_time:4599ms step_avg:67.64ms
+step:69/4150 train_time:4669ms step_avg:67.67ms
+step:70/4150 train_time:4735ms step_avg:67.65ms
+step:71/4150 train_time:4804ms step_avg:67.67ms
+step:72/4150 train_time:4870ms step_avg:67.64ms
+step:73/4150 train_time:4940ms step_avg:67.67ms
+step:74/4150 train_time:5005ms step_avg:67.64ms
+step:75/4150 train_time:5075ms step_avg:67.67ms
+step:76/4150 train_time:5141ms step_avg:67.65ms
+step:77/4150 train_time:5211ms step_avg:67.67ms
+step:78/4150 train_time:5277ms step_avg:67.66ms
+step:79/4150 train_time:5347ms step_avg:67.68ms
+step:80/4150 train_time:5413ms step_avg:67.66ms
+step:81/4150 train_time:5482ms step_avg:67.68ms
+step:82/4150 train_time:5548ms step_avg:67.66ms
+step:83/4150 train_time:5618ms step_avg:67.68ms
+step:84/4150 train_time:5684ms step_avg:67.66ms
+step:85/4150 train_time:5753ms step_avg:67.69ms
+step:86/4150 train_time:5819ms step_avg:67.66ms
+step:87/4150 train_time:5889ms step_avg:67.69ms
+step:88/4150 train_time:5955ms step_avg:67.67ms
+step:89/4150 train_time:6025ms step_avg:67.69ms
+step:90/4150 train_time:6090ms step_avg:67.67ms
+step:91/4150 train_time:6160ms step_avg:67.69ms
+step:92/4150 train_time:6226ms step_avg:67.67ms
+step:93/4150 train_time:6296ms step_avg:67.69ms
+step:94/4150 train_time:6361ms step_avg:67.67ms
+step:95/4150 train_time:6432ms step_avg:67.70ms
+step:96/4150 train_time:6497ms step_avg:67.68ms
+step:97/4150 train_time:6567ms step_avg:67.70ms
+step:98/4150 train_time:6633ms step_avg:67.68ms
+step:99/4150 train_time:6702ms step_avg:67.70ms
+step:100/4150 train_time:6768ms step_avg:67.68ms
+step:101/4150 train_time:6838ms step_avg:67.70ms
+step:102/4150 train_time:6903ms step_avg:67.67ms
+step:103/4150 train_time:6972ms step_avg:67.69ms
+step:104/4150 train_time:7037ms step_avg:67.66ms
+step:105/4150 train_time:7107ms step_avg:67.68ms
+step:106/4150 train_time:7173ms step_avg:67.67ms
+step:107/4150 train_time:7243ms step_avg:67.69ms
+step:108/4150 train_time:7308ms step_avg:67.67ms
+step:109/4150 train_time:7378ms step_avg:67.69ms
+step:110/4150 train_time:7444ms step_avg:67.67ms
+step:111/4150 train_time:7513ms step_avg:67.69ms
+step:112/4150 train_time:7579ms step_avg:67.67ms
+step:113/4150 train_time:7649ms step_avg:67.69ms
+step:114/4150 train_time:7714ms step_avg:67.67ms
+step:115/4150 train_time:7784ms step_avg:67.69ms
+step:116/4150 train_time:7849ms step_avg:67.66ms
+step:117/4150 train_time:7918ms step_avg:67.68ms
+step:118/4150 train_time:7984ms step_avg:67.66ms
+step:119/4150 train_time:8053ms step_avg:67.67ms
+step:120/4150 train_time:8119ms step_avg:67.66ms
+step:121/4150 train_time:8189ms step_avg:67.68ms
+step:122/4150 train_time:8255ms step_avg:67.66ms
+step:123/4150 train_time:8324ms step_avg:67.68ms
+step:124/4150 train_time:8389ms step_avg:67.66ms
+step:125/4150 train_time:8460ms step_avg:67.68ms
+step:126/4150 train_time:8526ms step_avg:67.67ms
+step:127/4150 train_time:8596ms step_avg:67.68ms
+step:128/4150 train_time:8661ms step_avg:67.66ms
+step:129/4150 train_time:8731ms step_avg:67.68ms
+step:130/4150 train_time:8797ms step_avg:67.67ms
+step:131/4150 train_time:8866ms step_avg:67.68ms
+step:132/4150 train_time:8932ms step_avg:67.66ms
+step:133/4150 train_time:9001ms step_avg:67.67ms
+step:134/4150 train_time:9066ms step_avg:67.66ms
+step:135/4150 train_time:9136ms step_avg:67.67ms
+step:136/4150 train_time:9201ms step_avg:67.66ms
+step:137/4150 train_time:9271ms step_avg:67.67ms
+step:138/4150 train_time:9337ms step_avg:67.66ms
+step:139/4150 train_time:9406ms step_avg:67.67ms
+step:140/4150 train_time:9472ms step_avg:67.66ms
+step:141/4150 train_time:9541ms step_avg:67.67ms
+step:142/4150 train_time:9607ms step_avg:67.66ms
+step:143/4150 train_time:9677ms step_avg:67.67ms
+step:144/4150 train_time:9743ms step_avg:67.66ms
+step:145/4150 train_time:9812ms step_avg:67.67ms
+step:146/4150 train_time:9878ms step_avg:67.66ms
+step:147/4150 train_time:9946ms step_avg:67.66ms
+step:148/4150 train_time:10012ms step_avg:67.65ms
+step:149/4150 train_time:10081ms step_avg:67.66ms
+step:150/4150 train_time:10146ms step_avg:67.64ms
+step:151/4150 train_time:10216ms step_avg:67.65ms
+step:152/4150 train_time:10281ms step_avg:67.64ms
+step:153/4150 train_time:10350ms step_avg:67.65ms
+step:154/4150 train_time:10416ms step_avg:67.64ms
+step:155/4150 train_time:10486ms step_avg:67.65ms
+step:156/4150 train_time:10551ms step_avg:67.63ms
+step:157/4150 train_time:10620ms step_avg:67.64ms
+step:158/4150 train_time:10685ms step_avg:67.63ms
+step:159/4150 train_time:10755ms step_avg:67.64ms
+step:160/4150 train_time:10821ms step_avg:67.63ms
+step:161/4150 train_time:10890ms step_avg:67.64ms
+step:162/4150 train_time:10955ms step_avg:67.62ms
+step:163/4150 train_time:11023ms step_avg:67.63ms
+step:164/4150 train_time:11089ms step_avg:67.62ms
+step:165/4150 train_time:11158ms step_avg:67.63ms
+step:166/4150 train_time:11223ms step_avg:67.61ms
+step:167/4150 train_time:11292ms step_avg:67.62ms
+step:168/4150 train_time:11358ms step_avg:67.61ms
+step:169/4150 train_time:11427ms step_avg:67.61ms
+step:170/4150 train_time:11492ms step_avg:67.60ms
+step:171/4150 train_time:11562ms step_avg:67.61ms
+step:172/4150 train_time:11628ms step_avg:67.61ms
+step:173/4150 train_time:11698ms step_avg:67.62ms
+step:174/4150 train_time:11763ms step_avg:67.60ms
+step:175/4150 train_time:11833ms step_avg:67.62ms
+step:176/4150 train_time:11899ms step_avg:67.61ms
+step:177/4150 train_time:11969ms step_avg:67.62ms
+step:178/4150 train_time:12035ms step_avg:67.61ms
+step:179/4150 train_time:12104ms step_avg:67.62ms
+step:180/4150 train_time:12170ms step_avg:67.61ms
+step:181/4150 train_time:12240ms step_avg:67.62ms
+step:182/4150 train_time:12306ms step_avg:67.61ms
+step:183/4150 train_time:12375ms step_avg:67.62ms
+step:184/4150 train_time:12440ms step_avg:67.61ms
+step:185/4150 train_time:12510ms step_avg:67.62ms
+step:186/4150 train_time:12575ms step_avg:67.61ms
+step:187/4150 train_time:12645ms step_avg:67.62ms
+step:188/4150 train_time:12710ms step_avg:67.61ms
+step:189/4150 train_time:12779ms step_avg:67.61ms
+step:190/4150 train_time:12844ms step_avg:67.60ms
+step:191/4150 train_time:12913ms step_avg:67.61ms
+step:192/4150 train_time:12978ms step_avg:67.60ms
+step:193/4150 train_time:13048ms step_avg:67.60ms
+step:194/4150 train_time:13113ms step_avg:67.59ms
+step:195/4150 train_time:13182ms step_avg:67.60ms
+step:196/4150 train_time:13246ms step_avg:67.58ms
+step:197/4150 train_time:13316ms step_avg:67.59ms
+step:198/4150 train_time:13381ms step_avg:67.58ms
+step:199/4150 train_time:13450ms step_avg:67.59ms
+step:200/4150 train_time:13515ms step_avg:67.58ms
+step:201/4150 train_time:13585ms step_avg:67.59ms
+step:202/4150 train_time:13651ms step_avg:67.58ms
+step:203/4150 train_time:13719ms step_avg:67.58ms
+step:204/4150 train_time:13785ms step_avg:67.57ms
+step:205/4150 train_time:13854ms step_avg:67.58ms
+step:206/4150 train_time:13919ms step_avg:67.57ms
+step:207/4150 train_time:13988ms step_avg:67.58ms
+step:208/4150 train_time:14054ms step_avg:67.57ms
+step:209/4150 train_time:14123ms step_avg:67.57ms
+step:210/4150 train_time:14188ms step_avg:67.56ms
+step:211/4150 train_time:14258ms step_avg:67.57ms
+step:212/4150 train_time:14322ms step_avg:67.56ms
+step:213/4150 train_time:14392ms step_avg:67.57ms
+step:214/4150 train_time:14457ms step_avg:67.56ms
+step:215/4150 train_time:14526ms step_avg:67.56ms
+step:216/4150 train_time:14591ms step_avg:67.55ms
+step:217/4150 train_time:14660ms step_avg:67.56ms
+step:218/4150 train_time:14725ms step_avg:67.55ms
+step:219/4150 train_time:14794ms step_avg:67.55ms
+step:220/4150 train_time:14860ms step_avg:67.54ms
+step:221/4150 train_time:14929ms step_avg:67.55ms
+step:222/4150 train_time:14996ms step_avg:67.55ms
+step:223/4150 train_time:15065ms step_avg:67.56ms
+step:224/4150 train_time:15130ms step_avg:67.55ms
+step:225/4150 train_time:15201ms step_avg:67.56ms
+step:226/4150 train_time:15266ms step_avg:67.55ms
+step:227/4150 train_time:15335ms step_avg:67.55ms
+step:228/4150 train_time:15400ms step_avg:67.54ms
+step:229/4150 train_time:15469ms step_avg:67.55ms
+step:230/4150 train_time:15535ms step_avg:67.54ms
+step:231/4150 train_time:15604ms step_avg:67.55ms
+step:232/4150 train_time:15668ms step_avg:67.54ms
+step:233/4150 train_time:15737ms step_avg:67.54ms
+step:234/4150 train_time:15802ms step_avg:67.53ms
+step:235/4150 train_time:15872ms step_avg:67.54ms
+step:236/4150 train_time:15938ms step_avg:67.53ms
+step:237/4150 train_time:16007ms step_avg:67.54ms
+step:238/4150 train_time:16072ms step_avg:67.53ms
+step:239/4150 train_time:16142ms step_avg:67.54ms
+step:240/4150 train_time:16207ms step_avg:67.53ms
+step:241/4150 train_time:16276ms step_avg:67.53ms
+step:242/4150 train_time:16341ms step_avg:67.53ms
+step:243/4150 train_time:16411ms step_avg:67.53ms
+step:244/4150 train_time:16476ms step_avg:67.52ms
+step:245/4150 train_time:16545ms step_avg:67.53ms
+step:246/4150 train_time:16610ms step_avg:67.52ms
+step:247/4150 train_time:16679ms step_avg:67.53ms
+step:248/4150 train_time:16745ms step_avg:67.52ms
+step:249/4150 train_time:16814ms step_avg:67.53ms
+step:250/4150 train_time:16879ms step_avg:67.51ms
+step:250/4150 val_loss:4.4869 train_time:16944ms step_avg:67.77ms
+step:251/4150 train_time:16966ms step_avg:67.59ms
+step:252/4150 train_time:17017ms step_avg:67.53ms
+step:253/4150 train_time:17086ms step_avg:67.53ms
+step:254/4150 train_time:17152ms step_avg:67.53ms
+step:255/4150 train_time:17224ms step_avg:67.54ms
+step:256/4150 train_time:17291ms step_avg:67.54ms
+step:257/4150 train_time:17362ms step_avg:67.56ms
+step:258/4150 train_time:17427ms step_avg:67.55ms
+step:259/4150 train_time:17496ms step_avg:67.55ms
+step:260/4150 train_time:17561ms step_avg:67.54ms
+step:261/4150 train_time:17630ms step_avg:67.55ms
+step:262/4150 train_time:17695ms step_avg:67.54ms
+step:263/4150 train_time:17765ms step_avg:67.55ms
+step:264/4150 train_time:17829ms step_avg:67.54ms
+step:265/4150 train_time:17898ms step_avg:67.54ms
+step:266/4150 train_time:17963ms step_avg:67.53ms
+step:267/4150 train_time:18031ms step_avg:67.53ms
+step:268/4150 train_time:18096ms step_avg:67.52ms
+step:269/4150 train_time:18165ms step_avg:67.53ms
+step:270/4150 train_time:18230ms step_avg:67.52ms
+step:271/4150 train_time:18300ms step_avg:67.53ms
+step:272/4150 train_time:18365ms step_avg:67.52ms
+step:273/4150 train_time:18435ms step_avg:67.53ms
+step:274/4150 train_time:18501ms step_avg:67.52ms
+step:275/4150 train_time:18568ms step_avg:67.52ms
+step:276/4150 train_time:18634ms step_avg:67.51ms
+step:277/4150 train_time:18703ms step_avg:67.52ms
+step:278/4150 train_time:18768ms step_avg:67.51ms
+step:279/4150 train_time:18837ms step_avg:67.52ms
+step:280/4150 train_time:18902ms step_avg:67.51ms
+step:281/4150 train_time:18971ms step_avg:67.51ms
+step:282/4150 train_time:19036ms step_avg:67.50ms
+step:283/4150 train_time:19105ms step_avg:67.51ms
+step:284/4150 train_time:19170ms step_avg:67.50ms
+step:285/4150 train_time:19240ms step_avg:67.51ms
+step:286/4150 train_time:19306ms step_avg:67.50ms
+step:287/4150 train_time:19375ms step_avg:67.51ms
+step:288/4150 train_time:19440ms step_avg:67.50ms
+step:289/4150 train_time:19509ms step_avg:67.50ms
+step:290/4150 train_time:19574ms step_avg:67.50ms
+step:291/4150 train_time:19644ms step_avg:67.51ms
+step:292/4150 train_time:19709ms step_avg:67.50ms
+step:293/4150 train_time:19779ms step_avg:67.50ms
+step:294/4150 train_time:19844ms step_avg:67.50ms
+step:295/4150 train_time:19913ms step_avg:67.50ms
+step:296/4150 train_time:19978ms step_avg:67.49ms
+step:297/4150 train_time:20047ms step_avg:67.50ms
+step:298/4150 train_time:20111ms step_avg:67.49ms
+step:299/4150 train_time:20180ms step_avg:67.49ms
+step:300/4150 train_time:20245ms step_avg:67.48ms
+step:301/4150 train_time:20313ms step_avg:67.49ms
+step:302/4150 train_time:20379ms step_avg:67.48ms
+step:303/4150 train_time:20448ms step_avg:67.48ms
+step:304/4150 train_time:20513ms step_avg:67.48ms
+step:305/4150 train_time:20582ms step_avg:67.48ms
+step:306/4150 train_time:20647ms step_avg:67.47ms
+step:307/4150 train_time:20715ms step_avg:67.48ms
+step:308/4150 train_time:20780ms step_avg:67.47ms
+step:309/4150 train_time:20850ms step_avg:67.47ms
+step:310/4150 train_time:20915ms step_avg:67.47ms
+step:311/4150 train_time:20984ms step_avg:67.47ms
+step:312/4150 train_time:21049ms step_avg:67.46ms
+step:313/4150 train_time:21119ms step_avg:67.47ms
+step:314/4150 train_time:21184ms step_avg:67.46ms
+step:315/4150 train_time:21253ms step_avg:67.47ms
+step:316/4150 train_time:21319ms step_avg:67.46ms
+step:317/4150 train_time:21387ms step_avg:67.47ms
+step:318/4150 train_time:21453ms step_avg:67.46ms
+step:319/4150 train_time:21522ms step_avg:67.47ms
+step:320/4150 train_time:21587ms step_avg:67.46ms
+step:321/4150 train_time:21656ms step_avg:67.46ms
+step:322/4150 train_time:21721ms step_avg:67.46ms
+step:323/4150 train_time:21790ms step_avg:67.46ms
+step:324/4150 train_time:21854ms step_avg:67.45ms
+step:325/4150 train_time:21924ms step_avg:67.46ms
+step:326/4150 train_time:21989ms step_avg:67.45ms
+step:327/4150 train_time:22058ms step_avg:67.46ms
+step:328/4150 train_time:22122ms step_avg:67.45ms
+step:329/4150 train_time:22191ms step_avg:67.45ms
+step:330/4150 train_time:22257ms step_avg:67.45ms
+step:331/4150 train_time:22326ms step_avg:67.45ms
+step:332/4150 train_time:22391ms step_avg:67.44ms
+step:333/4150 train_time:22459ms step_avg:67.45ms
+step:334/4150 train_time:22525ms step_avg:67.44ms
+step:335/4150 train_time:22593ms step_avg:67.44ms
+step:336/4150 train_time:22658ms step_avg:67.44ms
+step:337/4150 train_time:22727ms step_avg:67.44ms
+step:338/4150 train_time:22792ms step_avg:67.43ms
+step:339/4150 train_time:22861ms step_avg:67.44ms
+step:340/4150 train_time:22926ms step_avg:67.43ms
+step:341/4150 train_time:22995ms step_avg:67.44ms
+step:342/4150 train_time:23061ms step_avg:67.43ms
+step:343/4150 train_time:23130ms step_avg:67.43ms
+step:344/4150 train_time:23196ms step_avg:67.43ms
+step:345/4150 train_time:23270ms step_avg:67.45ms
+step:346/4150 train_time:23393ms step_avg:67.61ms
+step:347/4150 train_time:23516ms step_avg:67.77ms
+step:348/4150 train_time:23637ms step_avg:67.92ms
+step:349/4150 train_time:23760ms step_avg:68.08ms
+step:350/4150 train_time:23881ms step_avg:68.23ms
+step:351/4150 train_time:24004ms step_avg:68.39ms
+step:352/4150 train_time:24126ms step_avg:68.54ms
+step:353/4150 train_time:24247ms step_avg:68.69ms
+step:354/4150 train_time:24369ms step_avg:68.84ms
+step:355/4150 train_time:24494ms step_avg:69.00ms
+step:356/4150 train_time:24615ms step_avg:69.14ms
+step:357/4150 train_time:24738ms step_avg:69.29ms
+step:358/4150 train_time:24859ms step_avg:69.44ms
+step:359/4150 train_time:24983ms step_avg:69.59ms
+step:360/4150 train_time:25103ms step_avg:69.73ms
+step:361/4150 train_time:25224ms step_avg:69.87ms
+step:362/4150 train_time:25344ms step_avg:70.01ms
+step:363/4150 train_time:25466ms step_avg:70.15ms
+step:364/4150 train_time:25586ms step_avg:70.29ms
+step:365/4150 train_time:25709ms step_avg:70.43ms
+step:366/4150 train_time:25829ms step_avg:70.57ms
+step:367/4150 train_time:25952ms step_avg:70.71ms
+step:368/4150 train_time:26073ms step_avg:70.85ms
+step:369/4150 train_time:26196ms step_avg:70.99ms
+step:370/4150 train_time:26316ms step_avg:71.13ms
+step:371/4150 train_time:26438ms step_avg:71.26ms
+step:372/4150 train_time:26560ms step_avg:71.40ms
+step:373/4150 train_time:26682ms step_avg:71.53ms
+step:374/4150 train_time:26802ms step_avg:71.66ms
+step:375/4150 train_time:26924ms step_avg:71.80ms
+step:376/4150 train_time:27046ms step_avg:71.93ms
+step:377/4150 train_time:27167ms step_avg:72.06ms
+step:378/4150 train_time:27287ms step_avg:72.19ms
+step:379/4150 train_time:27409ms step_avg:72.32ms
+step:380/4150 train_time:27532ms step_avg:72.45ms
+step:381/4150 train_time:27653ms step_avg:72.58ms
+step:382/4150 train_time:27775ms step_avg:72.71ms
+step:383/4150 train_time:27898ms step_avg:72.84ms
+step:384/4150 train_time:28018ms step_avg:72.96ms
+step:385/4150 train_time:28141ms step_avg:73.09ms
+step:386/4150 train_time:28262ms step_avg:73.22ms
+step:387/4150 train_time:28385ms step_avg:73.35ms
+step:388/4150 train_time:28504ms step_avg:73.46ms
+step:389/4150 train_time:28627ms step_avg:73.59ms
+step:390/4150 train_time:28747ms step_avg:73.71ms
+step:391/4150 train_time:28870ms step_avg:73.84ms
+step:392/4150 train_time:28991ms step_avg:73.96ms
+step:393/4150 train_time:29113ms step_avg:74.08ms
+step:394/4150 train_time:29234ms step_avg:74.20ms
+step:395/4150 train_time:29356ms step_avg:74.32ms
+step:396/4150 train_time:29477ms step_avg:74.44ms
+step:397/4150 train_time:29599ms step_avg:74.56ms
+step:398/4150 train_time:29719ms step_avg:74.67ms
+step:399/4150 train_time:29841ms step_avg:74.79ms
+step:400/4150 train_time:29960ms step_avg:74.90ms
+step:401/4150 train_time:30082ms step_avg:75.02ms
+step:402/4150 train_time:30201ms step_avg:75.13ms
+step:403/4150 train_time:30324ms step_avg:75.25ms
+step:404/4150 train_time:30445ms step_avg:75.36ms
+step:405/4150 train_time:30567ms step_avg:75.48ms
+step:406/4150 train_time:30687ms step_avg:75.58ms
+step:407/4150 train_time:30808ms step_avg:75.70ms
+step:408/4150 train_time:30929ms step_avg:75.81ms
+step:409/4150 train_time:31051ms step_avg:75.92ms
+step:410/4150 train_time:31172ms step_avg:76.03ms
+step:411/4150 train_time:31292ms step_avg:76.14ms
+step:412/4150 train_time:31412ms step_avg:76.24ms
+step:413/4150 train_time:31535ms step_avg:76.35ms
+step:414/4150 train_time:31657ms step_avg:76.47ms
+step:415/4150 train_time:31781ms step_avg:76.58ms
+step:416/4150 train_time:31901ms step_avg:76.69ms
+step:417/4150 train_time:32023ms step_avg:76.79ms
+step:418/4150 train_time:32144ms step_avg:76.90ms
+step:419/4150 train_time:32266ms step_avg:77.01ms
+step:420/4150 train_time:32386ms step_avg:77.11ms
+step:421/4150 train_time:32508ms step_avg:77.22ms
+step:422/4150 train_time:32628ms step_avg:77.32ms
+step:423/4150 train_time:32751ms step_avg:77.43ms
+step:424/4150 train_time:32872ms step_avg:77.53ms
+step:425/4150 train_time:32994ms step_avg:77.63ms
+step:426/4150 train_time:33116ms step_avg:77.74ms
+step:427/4150 train_time:33238ms step_avg:77.84ms
+step:428/4150 train_time:33357ms step_avg:77.94ms
+step:429/4150 train_time:33479ms step_avg:78.04ms
+step:430/4150 train_time:33600ms step_avg:78.14ms
+step:431/4150 train_time:33723ms step_avg:78.24ms
+step:432/4150 train_time:33844ms step_avg:78.34ms
+step:433/4150 train_time:33965ms step_avg:78.44ms
+step:434/4150 train_time:34086ms step_avg:78.54ms
+step:435/4150 train_time:34208ms step_avg:78.64ms
+step:436/4150 train_time:34328ms step_avg:78.73ms
+step:437/4150 train_time:34451ms step_avg:78.84ms
+step:438/4150 train_time:34573ms step_avg:78.93ms
+step:439/4150 train_time:34696ms step_avg:79.03ms
+step:440/4150 train_time:34816ms step_avg:79.13ms
+step:441/4150 train_time:34937ms step_avg:79.22ms
+step:442/4150 train_time:35057ms step_avg:79.31ms
+step:443/4150 train_time:35180ms step_avg:79.41ms
+step:444/4150 train_time:35300ms step_avg:79.50ms
+step:445/4150 train_time:35422ms step_avg:79.60ms
+step:446/4150 train_time:35542ms step_avg:79.69ms
+step:447/4150 train_time:35664ms step_avg:79.79ms
+step:448/4150 train_time:35786ms step_avg:79.88ms
+step:449/4150 train_time:35908ms step_avg:79.97ms
+step:450/4150 train_time:36028ms step_avg:80.06ms
+step:451/4150 train_time:36150ms step_avg:80.16ms
+step:452/4150 train_time:36270ms step_avg:80.24ms
+step:453/4150 train_time:36393ms step_avg:80.34ms
+step:454/4150 train_time:36513ms step_avg:80.43ms
+step:455/4150 train_time:36636ms step_avg:80.52ms
+step:456/4150 train_time:36758ms step_avg:80.61ms
+step:457/4150 train_time:36881ms step_avg:80.70ms
+step:458/4150 train_time:37001ms step_avg:80.79ms
+step:459/4150 train_time:37122ms step_avg:80.88ms
+step:460/4150 train_time:37242ms step_avg:80.96ms
+step:461/4150 train_time:37365ms step_avg:81.05ms
+step:462/4150 train_time:37485ms step_avg:81.14ms
+step:463/4150 train_time:37607ms step_avg:81.22ms
+step:464/4150 train_time:37727ms step_avg:81.31ms
+step:465/4150 train_time:37850ms step_avg:81.40ms
+step:466/4150 train_time:37971ms step_avg:81.48ms
+step:467/4150 train_time:38093ms step_avg:81.57ms
+step:468/4150 train_time:38214ms step_avg:81.65ms
+step:469/4150 train_time:38336ms step_avg:81.74ms
+step:470/4150 train_time:38457ms step_avg:81.82ms
+step:471/4150 train_time:38581ms step_avg:81.91ms
+step:472/4150 train_time:38701ms step_avg:81.99ms
+step:473/4150 train_time:38822ms step_avg:82.08ms
+step:474/4150 train_time:38942ms step_avg:82.16ms
+step:475/4150 train_time:39063ms step_avg:82.24ms
+step:476/4150 train_time:39184ms step_avg:82.32ms
+step:477/4150 train_time:39306ms step_avg:82.40ms
+step:478/4150 train_time:39427ms step_avg:82.48ms
+step:479/4150 train_time:39550ms step_avg:82.57ms
+step:480/4150 train_time:39670ms step_avg:82.65ms
+step:481/4150 train_time:39792ms step_avg:82.73ms
+step:482/4150 train_time:39911ms step_avg:82.80ms
+step:483/4150 train_time:40034ms step_avg:82.89ms
+step:484/4150 train_time:40155ms step_avg:82.96ms
+step:485/4150 train_time:40277ms step_avg:83.04ms
+step:486/4150 train_time:40397ms step_avg:83.12ms
+step:487/4150 train_time:40520ms step_avg:83.20ms
+step:488/4150 train_time:40640ms step_avg:83.28ms
+step:489/4150 train_time:40762ms step_avg:83.36ms
+step:490/4150 train_time:40882ms step_avg:83.43ms
+step:491/4150 train_time:41004ms step_avg:83.51ms
+step:492/4150 train_time:41126ms step_avg:83.59ms
+step:493/4150 train_time:41249ms step_avg:83.67ms
+step:494/4150 train_time:41370ms step_avg:83.74ms
+step:495/4150 train_time:41492ms step_avg:83.82ms
+step:496/4150 train_time:41612ms step_avg:83.89ms
+step:497/4150 train_time:41733ms step_avg:83.97ms
+step:498/4150 train_time:41855ms step_avg:84.05ms
+step:499/4150 train_time:41979ms step_avg:84.13ms
+step:500/4150 train_time:42100ms step_avg:84.20ms
+step:500/4150 val_loss:3.9089 train_time:42213ms step_avg:84.43ms
+step:501/4150 train_time:42234ms step_avg:84.30ms
+step:502/4150 train_time:42345ms step_avg:84.35ms
+step:503/4150 train_time:42470ms step_avg:84.43ms
+step:504/4150 train_time:42595ms step_avg:84.51ms
+step:505/4150 train_time:42718ms step_avg:84.59ms
+step:506/4150 train_time:42837ms step_avg:84.66ms
+step:507/4150 train_time:42957ms step_avg:84.73ms
+step:508/4150 train_time:43077ms step_avg:84.80ms
+step:509/4150 train_time:43198ms step_avg:84.87ms
+step:510/4150 train_time:43317ms step_avg:84.93ms
+step:511/4150 train_time:43440ms step_avg:85.01ms
+step:512/4150 train_time:43561ms step_avg:85.08ms
+step:513/4150 train_time:43684ms step_avg:85.15ms
+step:514/4150 train_time:43804ms step_avg:85.22ms
+step:515/4150 train_time:43927ms step_avg:85.29ms
+step:516/4150 train_time:44046ms step_avg:85.36ms
+step:517/4150 train_time:44168ms step_avg:85.43ms
+step:518/4150 train_time:44289ms step_avg:85.50ms
+step:519/4150 train_time:44413ms step_avg:85.57ms
+step:520/4150 train_time:44535ms step_avg:85.64ms
+step:521/4150 train_time:44658ms step_avg:85.72ms
+step:522/4150 train_time:44778ms step_avg:85.78ms
+step:523/4150 train_time:44899ms step_avg:85.85ms
+step:524/4150 train_time:45020ms step_avg:85.92ms
+step:525/4150 train_time:45142ms step_avg:85.98ms
+step:526/4150 train_time:45261ms step_avg:86.05ms
+step:527/4150 train_time:45384ms step_avg:86.12ms
+step:528/4150 train_time:45505ms step_avg:86.18ms
+step:529/4150 train_time:45628ms step_avg:86.25ms
+step:530/4150 train_time:45749ms step_avg:86.32ms
+step:531/4150 train_time:45872ms step_avg:86.39ms
+step:532/4150 train_time:45993ms step_avg:86.45ms
+step:533/4150 train_time:46117ms step_avg:86.52ms
+step:534/4150 train_time:46236ms step_avg:86.58ms
+step:535/4150 train_time:46357ms step_avg:86.65ms
+step:536/4150 train_time:46478ms step_avg:86.71ms
+step:537/4150 train_time:46600ms step_avg:86.78ms
+step:538/4150 train_time:46721ms step_avg:86.84ms
+step:539/4150 train_time:46843ms step_avg:86.91ms
+step:540/4150 train_time:46963ms step_avg:86.97ms
+step:541/4150 train_time:47086ms step_avg:87.03ms
+step:542/4150 train_time:47205ms step_avg:87.09ms
+step:543/4150 train_time:47326ms step_avg:87.16ms
+step:544/4150 train_time:47446ms step_avg:87.22ms
+step:545/4150 train_time:47568ms step_avg:87.28ms
+step:546/4150 train_time:47690ms step_avg:87.34ms
+step:547/4150 train_time:47812ms step_avg:87.41ms
+step:548/4150 train_time:47933ms step_avg:87.47ms
+step:549/4150 train_time:48056ms step_avg:87.53ms
+step:550/4150 train_time:48176ms step_avg:87.59ms
+step:551/4150 train_time:48298ms step_avg:87.65ms
+step:552/4150 train_time:48418ms step_avg:87.71ms
+step:553/4150 train_time:48539ms step_avg:87.77ms
+step:554/4150 train_time:48659ms step_avg:87.83ms
+step:555/4150 train_time:48782ms step_avg:87.90ms
+step:556/4150 train_time:48903ms step_avg:87.96ms
+step:557/4150 train_time:49025ms step_avg:88.02ms
+step:558/4150 train_time:49145ms step_avg:88.07ms
+step:559/4150 train_time:49266ms step_avg:88.13ms
+step:560/4150 train_time:49388ms step_avg:88.19ms
+step:561/4150 train_time:49511ms step_avg:88.25ms
+step:562/4150 train_time:49632ms step_avg:88.31ms
+step:563/4150 train_time:49754ms step_avg:88.37ms
+step:564/4150 train_time:49876ms step_avg:88.43ms
+step:565/4150 train_time:49997ms step_avg:88.49ms
+step:566/4150 train_time:50117ms step_avg:88.55ms
+step:567/4150 train_time:50239ms step_avg:88.60ms
+step:568/4150 train_time:50360ms step_avg:88.66ms
+step:569/4150 train_time:50483ms step_avg:88.72ms
+step:570/4150 train_time:50602ms step_avg:88.78ms
+step:571/4150 train_time:50724ms step_avg:88.83ms
+step:572/4150 train_time:50844ms step_avg:88.89ms
+step:573/4150 train_time:50967ms step_avg:88.95ms
+step:574/4150 train_time:51087ms step_avg:89.00ms
+step:575/4150 train_time:51209ms step_avg:89.06ms
+step:576/4150 train_time:51329ms step_avg:89.11ms
+step:577/4150 train_time:51452ms step_avg:89.17ms
+step:578/4150 train_time:51573ms step_avg:89.23ms
+step:579/4150 train_time:51695ms step_avg:89.28ms
+step:580/4150 train_time:51816ms step_avg:89.34ms
+step:581/4150 train_time:51938ms step_avg:89.39ms
+step:582/4150 train_time:52059ms step_avg:89.45ms
+step:583/4150 train_time:52180ms step_avg:89.50ms
+step:584/4150 train_time:52301ms step_avg:89.56ms
+step:585/4150 train_time:52424ms step_avg:89.61ms
+step:586/4150 train_time:52544ms step_avg:89.67ms
+step:587/4150 train_time:52667ms step_avg:89.72ms
+step:588/4150 train_time:52787ms step_avg:89.77ms
+step:589/4150 train_time:52909ms step_avg:89.83ms
+step:590/4150 train_time:53030ms step_avg:89.88ms
+step:591/4150 train_time:53153ms step_avg:89.94ms
+step:592/4150 train_time:53274ms step_avg:89.99ms
+step:593/4150 train_time:53397ms step_avg:90.05ms
+step:594/4150 train_time:53517ms step_avg:90.10ms
+step:595/4150 train_time:53639ms step_avg:90.15ms
+step:596/4150 train_time:53759ms step_avg:90.20ms
+step:597/4150 train_time:53881ms step_avg:90.25ms
+step:598/4150 train_time:54002ms step_avg:90.30ms
+step:599/4150 train_time:54124ms step_avg:90.36ms
+step:600/4150 train_time:54243ms step_avg:90.41ms
+step:601/4150 train_time:54365ms step_avg:90.46ms
+step:602/4150 train_time:54486ms step_avg:90.51ms
+step:603/4150 train_time:54607ms step_avg:90.56ms
+step:604/4150 train_time:54728ms step_avg:90.61ms
+step:605/4150 train_time:54849ms step_avg:90.66ms
+step:606/4150 train_time:54970ms step_avg:90.71ms
+step:607/4150 train_time:55095ms step_avg:90.77ms
+step:608/4150 train_time:55216ms step_avg:90.82ms
+step:609/4150 train_time:55338ms step_avg:90.87ms
+step:610/4150 train_time:55458ms step_avg:90.92ms
+step:611/4150 train_time:55579ms step_avg:90.96ms
+step:612/4150 train_time:55699ms step_avg:91.01ms
+step:613/4150 train_time:55821ms step_avg:91.06ms
+step:614/4150 train_time:55941ms step_avg:91.11ms
+step:615/4150 train_time:56063ms step_avg:91.16ms
+step:616/4150 train_time:56185ms step_avg:91.21ms
+step:617/4150 train_time:56307ms step_avg:91.26ms
+step:618/4150 train_time:56428ms step_avg:91.31ms
+step:619/4150 train_time:56548ms step_avg:91.35ms
+step:620/4150 train_time:56668ms step_avg:91.40ms
+step:621/4150 train_time:56790ms step_avg:91.45ms
+step:622/4150 train_time:56910ms step_avg:91.50ms
+step:623/4150 train_time:57032ms step_avg:91.54ms
+step:624/4150 train_time:57153ms step_avg:91.59ms
+step:625/4150 train_time:57276ms step_avg:91.64ms
+step:626/4150 train_time:57396ms step_avg:91.69ms
+step:627/4150 train_time:57519ms step_avg:91.74ms
+step:628/4150 train_time:57638ms step_avg:91.78ms
+step:629/4150 train_time:57762ms step_avg:91.83ms
+step:630/4150 train_time:57883ms step_avg:91.88ms
+step:631/4150 train_time:58005ms step_avg:91.92ms
+step:632/4150 train_time:58125ms step_avg:91.97ms
+step:633/4150 train_time:58247ms step_avg:92.02ms
+step:634/4150 train_time:58369ms step_avg:92.06ms
+step:635/4150 train_time:58491ms step_avg:92.11ms
+step:636/4150 train_time:58613ms step_avg:92.16ms
+step:637/4150 train_time:58735ms step_avg:92.21ms
+step:638/4150 train_time:58856ms step_avg:92.25ms
+step:639/4150 train_time:58979ms step_avg:92.30ms
+step:640/4150 train_time:59100ms step_avg:92.34ms
+step:641/4150 train_time:59222ms step_avg:92.39ms
+step:642/4150 train_time:59343ms step_avg:92.43ms
+step:643/4150 train_time:59466ms step_avg:92.48ms
+step:644/4150 train_time:59586ms step_avg:92.52ms
+step:645/4150 train_time:59709ms step_avg:92.57ms
+step:646/4150 train_time:59830ms step_avg:92.62ms
+step:647/4150 train_time:59952ms step_avg:92.66ms
+step:648/4150 train_time:60073ms step_avg:92.71ms
+step:649/4150 train_time:60195ms step_avg:92.75ms
+step:650/4150 train_time:60315ms step_avg:92.79ms
+step:651/4150 train_time:60437ms step_avg:92.84ms
+step:652/4150 train_time:60558ms step_avg:92.88ms
+step:653/4150 train_time:60680ms step_avg:92.93ms
+step:654/4150 train_time:60802ms step_avg:92.97ms
+step:655/4150 train_time:60923ms step_avg:93.01ms
+step:656/4150 train_time:61043ms step_avg:93.05ms
+step:657/4150 train_time:61165ms step_avg:93.10ms
+step:658/4150 train_time:61285ms step_avg:93.14ms
+step:659/4150 train_time:61406ms step_avg:93.18ms
+step:660/4150 train_time:61526ms step_avg:93.22ms
+step:661/4150 train_time:61648ms step_avg:93.27ms
+step:662/4150 train_time:61768ms step_avg:93.31ms
+step:663/4150 train_time:61890ms step_avg:93.35ms
+step:664/4150 train_time:62013ms step_avg:93.39ms
+step:665/4150 train_time:62135ms step_avg:93.44ms
+step:666/4150 train_time:62254ms step_avg:93.47ms
+step:667/4150 train_time:62374ms step_avg:93.51ms
+step:668/4150 train_time:62494ms step_avg:93.55ms
+step:669/4150 train_time:62618ms step_avg:93.60ms
+step:670/4150 train_time:62739ms step_avg:93.64ms
+step:671/4150 train_time:62861ms step_avg:93.68ms
+step:672/4150 train_time:62981ms step_avg:93.72ms
+step:673/4150 train_time:63104ms step_avg:93.76ms
+step:674/4150 train_time:63225ms step_avg:93.81ms
+step:675/4150 train_time:63347ms step_avg:93.85ms
+step:676/4150 train_time:63467ms step_avg:93.89ms
+step:677/4150 train_time:63591ms step_avg:93.93ms
+step:678/4150 train_time:63714ms step_avg:93.97ms
+step:679/4150 train_time:63835ms step_avg:94.01ms
+step:680/4150 train_time:63955ms step_avg:94.05ms
+step:681/4150 train_time:64078ms step_avg:94.09ms
+step:682/4150 train_time:64198ms step_avg:94.13ms
+step:683/4150 train_time:64319ms step_avg:94.17ms
+step:684/4150 train_time:64439ms step_avg:94.21ms
+step:685/4150 train_time:64560ms step_avg:94.25ms
+step:686/4150 train_time:64681ms step_avg:94.29ms
+step:687/4150 train_time:64804ms step_avg:94.33ms
+step:688/4150 train_time:64923ms step_avg:94.37ms
+step:689/4150 train_time:65050ms step_avg:94.41ms
+step:690/4150 train_time:65230ms step_avg:94.54ms
+step:691/4150 train_time:65407ms step_avg:94.66ms
+step:692/4150 train_time:65587ms step_avg:94.78ms
+step:693/4150 train_time:65766ms step_avg:94.90ms
+step:694/4150 train_time:65947ms step_avg:95.02ms
+step:695/4150 train_time:66124ms step_avg:95.14ms
+step:696/4150 train_time:66302ms step_avg:95.26ms
+step:697/4150 train_time:66483ms step_avg:95.38ms
+step:698/4150 train_time:66663ms step_avg:95.51ms
+step:699/4150 train_time:66842ms step_avg:95.62ms
+step:700/4150 train_time:67021ms step_avg:95.74ms
+step:701/4150 train_time:67199ms step_avg:95.86ms
+step:702/4150 train_time:67379ms step_avg:95.98ms
+step:703/4150 train_time:67556ms step_avg:96.10ms
+step:704/4150 train_time:67737ms step_avg:96.22ms
+step:705/4150 train_time:67914ms step_avg:96.33ms
+step:706/4150 train_time:68093ms step_avg:96.45ms
+step:707/4150 train_time:68274ms step_avg:96.57ms
+step:708/4150 train_time:68453ms step_avg:96.68ms
+step:709/4150 train_time:68631ms step_avg:96.80ms
+step:710/4150 train_time:68811ms step_avg:96.92ms
+step:711/4150 train_time:68991ms step_avg:97.03ms
+step:712/4150 train_time:69171ms step_avg:97.15ms
+step:713/4150 train_time:69350ms step_avg:97.27ms
+step:714/4150 train_time:69529ms step_avg:97.38ms
+step:715/4150 train_time:69707ms step_avg:97.49ms
+step:716/4150 train_time:69888ms step_avg:97.61ms
+step:717/4150 train_time:70068ms step_avg:97.72ms
+step:718/4150 train_time:70248ms step_avg:97.84ms
+step:719/4150 train_time:70426ms step_avg:97.95ms
+step:720/4150 train_time:70608ms step_avg:98.07ms
+step:721/4150 train_time:70786ms step_avg:98.18ms
+step:722/4150 train_time:70967ms step_avg:98.29ms
+step:723/4150 train_time:71146ms step_avg:98.40ms
+step:724/4150 train_time:71328ms step_avg:98.52ms
+step:725/4150 train_time:71505ms step_avg:98.63ms
+step:726/4150 train_time:71684ms step_avg:98.74ms
+step:727/4150 train_time:71863ms step_avg:98.85ms
+step:728/4150 train_time:72045ms step_avg:98.96ms
+step:729/4150 train_time:72225ms step_avg:99.07ms
+step:730/4150 train_time:72405ms step_avg:99.19ms
+step:731/4150 train_time:72583ms step_avg:99.29ms
+step:732/4150 train_time:72762ms step_avg:99.40ms
+step:733/4150 train_time:72942ms step_avg:99.51ms
+step:734/4150 train_time:73121ms step_avg:99.62ms
+step:735/4150 train_time:73299ms step_avg:99.73ms
+step:736/4150 train_time:73479ms step_avg:99.84ms
+step:737/4150 train_time:73659ms step_avg:99.94ms
+step:738/4150 train_time:73840ms step_avg:100.05ms
+step:739/4150 train_time:74021ms step_avg:100.16ms
+step:740/4150 train_time:74199ms step_avg:100.27ms
+step:741/4150 train_time:74377ms step_avg:100.37ms
+step:742/4150 train_time:74557ms step_avg:100.48ms
+step:743/4150 train_time:74736ms step_avg:100.59ms
+step:744/4150 train_time:74921ms step_avg:100.70ms
+step:745/4150 train_time:75100ms step_avg:100.81ms
+step:746/4150 train_time:75279ms step_avg:100.91ms
+step:747/4150 train_time:75457ms step_avg:101.01ms
+step:748/4150 train_time:75637ms step_avg:101.12ms
+step:749/4150 train_time:75816ms step_avg:101.22ms
+step:750/4150 train_time:75999ms step_avg:101.33ms
+step:750/4150 val_loss:3.5520 train_time:76165ms step_avg:101.55ms
+step:751/4150 train_time:76188ms step_avg:101.45ms
+step:752/4150 train_time:76364ms step_avg:101.55ms
+step:753/4150 train_time:76547ms step_avg:101.66ms
+step:754/4150 train_time:76726ms step_avg:101.76ms
+step:755/4150 train_time:76902ms step_avg:101.86ms
+step:756/4150 train_time:77080ms step_avg:101.96ms
+step:757/4150 train_time:77258ms step_avg:102.06ms
+step:758/4150 train_time:77440ms step_avg:102.16ms
+step:759/4150 train_time:77620ms step_avg:102.27ms
+step:760/4150 train_time:77801ms step_avg:102.37ms
+step:761/4150 train_time:77977ms step_avg:102.47ms
+step:762/4150 train_time:78156ms step_avg:102.57ms
+step:763/4150 train_time:78335ms step_avg:102.67ms
+step:764/4150 train_time:78516ms step_avg:102.77ms
+step:765/4150 train_time:78699ms step_avg:102.87ms
+step:766/4150 train_time:78880ms step_avg:102.98ms
+step:767/4150 train_time:79058ms step_avg:103.07ms
+step:768/4150 train_time:79235ms step_avg:103.17ms
+step:769/4150 train_time:79413ms step_avg:103.27ms
+step:770/4150 train_time:79596ms step_avg:103.37ms
+step:771/4150 train_time:79775ms step_avg:103.47ms
+step:772/4150 train_time:79955ms step_avg:103.57ms
+step:773/4150 train_time:80133ms step_avg:103.66ms
+step:774/4150 train_time:80310ms step_avg:103.76ms
+step:775/4150 train_time:80488ms step_avg:103.86ms
+step:776/4150 train_time:80670ms step_avg:103.96ms
+step:777/4150 train_time:80849ms step_avg:104.05ms
+step:778/4150 train_time:81029ms step_avg:104.15ms
+step:779/4150 train_time:81207ms step_avg:104.25ms
+step:780/4150 train_time:81385ms step_avg:104.34ms
+step:781/4150 train_time:81565ms step_avg:104.44ms
+step:782/4150 train_time:81744ms step_avg:104.53ms
+step:783/4150 train_time:81922ms step_avg:104.63ms
+step:784/4150 train_time:82102ms step_avg:104.72ms
+step:785/4150 train_time:82282ms step_avg:104.82ms
+step:786/4150 train_time:82461ms step_avg:104.91ms
+step:787/4150 train_time:82641ms step_avg:105.01ms
+step:788/4150 train_time:82821ms step_avg:105.10ms
+step:789/4150 train_time:82999ms step_avg:105.20ms
+step:790/4150 train_time:83177ms step_avg:105.29ms
+step:791/4150 train_time:83359ms step_avg:105.38ms
+step:792/4150 train_time:83540ms step_avg:105.48ms
+step:793/4150 train_time:83718ms step_avg:105.57ms
+step:794/4150 train_time:83898ms step_avg:105.66ms
+step:795/4150 train_time:84078ms step_avg:105.76ms
+step:796/4150 train_time:84257ms step_avg:105.85ms
+step:797/4150 train_time:84435ms step_avg:105.94ms
+step:798/4150 train_time:84616ms step_avg:106.04ms
+step:799/4150 train_time:84794ms step_avg:106.13ms
+step:800/4150 train_time:84973ms step_avg:106.22ms
+step:801/4150 train_time:85151ms step_avg:106.31ms
+step:802/4150 train_time:85333ms step_avg:106.40ms
+step:803/4150 train_time:85512ms step_avg:106.49ms
+step:804/4150 train_time:85693ms step_avg:106.58ms
+step:805/4150 train_time:85872ms step_avg:106.67ms
+step:806/4150 train_time:86053ms step_avg:106.77ms
+step:807/4150 train_time:86232ms step_avg:106.86ms
+step:808/4150 train_time:86414ms step_avg:106.95ms
+step:809/4150 train_time:86592ms step_avg:107.04ms
+step:810/4150 train_time:86773ms step_avg:107.13ms
+step:811/4150 train_time:86952ms step_avg:107.22ms
+step:812/4150 train_time:87132ms step_avg:107.31ms
+step:813/4150 train_time:87310ms step_avg:107.39ms
+step:814/4150 train_time:87490ms step_avg:107.48ms
+step:815/4150 train_time:87670ms step_avg:107.57ms
+step:816/4150 train_time:87849ms step_avg:107.66ms
+step:817/4150 train_time:88028ms step_avg:107.75ms
+step:818/4150 train_time:88205ms step_avg:107.83ms
+step:819/4150 train_time:88384ms step_avg:107.92ms
+step:820/4150 train_time:88565ms step_avg:108.01ms
+step:821/4150 train_time:88745ms step_avg:108.09ms
+step:822/4150 train_time:88924ms step_avg:108.18ms
+step:823/4150 train_time:89102ms step_avg:108.27ms
+step:824/4150 train_time:89281ms step_avg:108.35ms
+step:825/4150 train_time:89460ms step_avg:108.44ms
+step:826/4150 train_time:89641ms step_avg:108.52ms
+step:827/4150 train_time:89820ms step_avg:108.61ms
+step:828/4150 train_time:89999ms step_avg:108.69ms
+step:829/4150 train_time:90179ms step_avg:108.78ms
+step:830/4150 train_time:90358ms step_avg:108.86ms
+step:831/4150 train_time:90535ms step_avg:108.95ms
+step:832/4150 train_time:90715ms step_avg:109.03ms
+step:833/4150 train_time:90894ms step_avg:109.12ms
+step:834/4150 train_time:91074ms step_avg:109.20ms
+step:835/4150 train_time:91253ms step_avg:109.28ms
+step:836/4150 train_time:91432ms step_avg:109.37ms
+step:837/4150 train_time:91611ms step_avg:109.45ms
+step:838/4150 train_time:91792ms step_avg:109.54ms
+step:839/4150 train_time:91970ms step_avg:109.62ms
+step:840/4150 train_time:92151ms step_avg:109.70ms
+step:841/4150 train_time:92330ms step_avg:109.79ms
+step:842/4150 train_time:92511ms step_avg:109.87ms
+step:843/4150 train_time:92691ms step_avg:109.95ms
+step:844/4150 train_time:92873ms step_avg:110.04ms
+step:845/4150 train_time:93049ms step_avg:110.12ms
+step:846/4150 train_time:93230ms step_avg:110.20ms
+step:847/4150 train_time:93408ms step_avg:110.28ms
+step:848/4150 train_time:93589ms step_avg:110.36ms
+step:849/4150 train_time:93768ms step_avg:110.45ms
+step:850/4150 train_time:93950ms step_avg:110.53ms
+step:851/4150 train_time:94128ms step_avg:110.61ms
+step:852/4150 train_time:94308ms step_avg:110.69ms
+step:853/4150 train_time:94484ms step_avg:110.77ms
+step:854/4150 train_time:94664ms step_avg:110.85ms
+step:855/4150 train_time:94842ms step_avg:110.93ms
+step:856/4150 train_time:95021ms step_avg:111.01ms
+step:857/4150 train_time:95199ms step_avg:111.08ms
+step:858/4150 train_time:95379ms step_avg:111.16ms
+step:859/4150 train_time:95557ms step_avg:111.24ms
+step:860/4150 train_time:95738ms step_avg:111.32ms
+step:861/4150 train_time:95916ms step_avg:111.40ms
+step:862/4150 train_time:96096ms step_avg:111.48ms
+step:863/4150 train_time:96274ms step_avg:111.56ms
+step:864/4150 train_time:96452ms step_avg:111.63ms
+step:865/4150 train_time:96631ms step_avg:111.71ms
+step:866/4150 train_time:96813ms step_avg:111.79ms
+step:867/4150 train_time:96992ms step_avg:111.87ms
+step:868/4150 train_time:97173ms step_avg:111.95ms
+step:869/4150 train_time:97352ms step_avg:112.03ms
+step:870/4150 train_time:97532ms step_avg:112.11ms
+step:871/4150 train_time:97711ms step_avg:112.18ms
+step:872/4150 train_time:97892ms step_avg:112.26ms
+step:873/4150 train_time:98073ms step_avg:112.34ms
+step:874/4150 train_time:98253ms step_avg:112.42ms
+step:875/4150 train_time:98429ms step_avg:112.49ms
+step:876/4150 train_time:98608ms step_avg:112.57ms
+step:877/4150 train_time:98789ms step_avg:112.64ms
+step:878/4150 train_time:98968ms step_avg:112.72ms
+step:879/4150 train_time:99145ms step_avg:112.79ms
+step:880/4150 train_time:99325ms step_avg:112.87ms
+step:881/4150 train_time:99503ms step_avg:112.94ms
+step:882/4150 train_time:99682ms step_avg:113.02ms
+step:883/4150 train_time:99861ms step_avg:113.09ms
+step:884/4150 train_time:100041ms step_avg:113.17ms
+step:885/4150 train_time:100219ms step_avg:113.24ms
+step:886/4150 train_time:100399ms step_avg:113.32ms
+step:887/4150 train_time:100578ms step_avg:113.39ms
+step:888/4150 train_time:100758ms step_avg:113.47ms
+step:889/4150 train_time:100935ms step_avg:113.54ms
+step:890/4150 train_time:101117ms step_avg:113.61ms
+step:891/4150 train_time:101298ms step_avg:113.69ms
+step:892/4150 train_time:101478ms step_avg:113.76ms
+step:893/4150 train_time:101657ms step_avg:113.84ms
+step:894/4150 train_time:101837ms step_avg:113.91ms
+step:895/4150 train_time:102014ms step_avg:113.98ms
+step:896/4150 train_time:102197ms step_avg:114.06ms
+step:897/4150 train_time:102375ms step_avg:114.13ms
+step:898/4150 train_time:102555ms step_avg:114.20ms
+step:899/4150 train_time:102733ms step_avg:114.27ms
+step:900/4150 train_time:102912ms step_avg:114.35ms
+step:901/4150 train_time:103090ms step_avg:114.42ms
+step:902/4150 train_time:103272ms step_avg:114.49ms
+step:903/4150 train_time:103451ms step_avg:114.56ms
+step:904/4150 train_time:103630ms step_avg:114.64ms
+step:905/4150 train_time:103809ms step_avg:114.71ms
+step:906/4150 train_time:103989ms step_avg:114.78ms
+step:907/4150 train_time:104169ms step_avg:114.85ms
+step:908/4150 train_time:104349ms step_avg:114.92ms
+step:909/4150 train_time:104527ms step_avg:114.99ms
+step:910/4150 train_time:104706ms step_avg:115.06ms
+step:911/4150 train_time:104885ms step_avg:115.13ms
+step:912/4150 train_time:105065ms step_avg:115.20ms
+step:913/4150 train_time:105243ms step_avg:115.27ms
+step:914/4150 train_time:105424ms step_avg:115.34ms
+step:915/4150 train_time:105601ms step_avg:115.41ms
+step:916/4150 train_time:105780ms step_avg:115.48ms
+step:917/4150 train_time:105959ms step_avg:115.55ms
+step:918/4150 train_time:106138ms step_avg:115.62ms
+step:919/4150 train_time:106317ms step_avg:115.69ms
+step:920/4150 train_time:106497ms step_avg:115.76ms
+step:921/4150 train_time:106678ms step_avg:115.83ms
+step:922/4150 train_time:106858ms step_avg:115.90ms
+step:923/4150 train_time:107037ms step_avg:115.97ms
+step:924/4150 train_time:107218ms step_avg:116.04ms
+step:925/4150 train_time:107397ms step_avg:116.11ms
+step:926/4150 train_time:107577ms step_avg:116.17ms
+step:927/4150 train_time:107756ms step_avg:116.24ms
+step:928/4150 train_time:107936ms step_avg:116.31ms
+step:929/4150 train_time:108115ms step_avg:116.38ms
+step:930/4150 train_time:108297ms step_avg:116.45ms
+step:931/4150 train_time:108477ms step_avg:116.52ms
+step:932/4150 train_time:108657ms step_avg:116.58ms
+step:933/4150 train_time:108835ms step_avg:116.65ms
+step:934/4150 train_time:109015ms step_avg:116.72ms
+step:935/4150 train_time:109194ms step_avg:116.79ms
+step:936/4150 train_time:109377ms step_avg:116.86ms
+step:937/4150 train_time:109555ms step_avg:116.92ms
+step:938/4150 train_time:109736ms step_avg:116.99ms
+step:939/4150 train_time:109913ms step_avg:117.05ms
+step:940/4150 train_time:110093ms step_avg:117.12ms
+step:941/4150 train_time:110272ms step_avg:117.19ms
+step:942/4150 train_time:110451ms step_avg:117.25ms
+step:943/4150 train_time:110631ms step_avg:117.32ms
+step:944/4150 train_time:110811ms step_avg:117.38ms
+step:945/4150 train_time:110989ms step_avg:117.45ms
+step:946/4150 train_time:111169ms step_avg:117.51ms
+step:947/4150 train_time:111348ms step_avg:117.58ms
+step:948/4150 train_time:111529ms step_avg:117.65ms
+step:949/4150 train_time:111708ms step_avg:117.71ms
+step:950/4150 train_time:111888ms step_avg:117.78ms
+step:951/4150 train_time:112065ms step_avg:117.84ms
+step:952/4150 train_time:112245ms step_avg:117.90ms
+step:953/4150 train_time:112424ms step_avg:117.97ms
+step:954/4150 train_time:112604ms step_avg:118.03ms
+step:955/4150 train_time:112783ms step_avg:118.10ms
+step:956/4150 train_time:112961ms step_avg:118.16ms
+step:957/4150 train_time:113138ms step_avg:118.22ms
+step:958/4150 train_time:113317ms step_avg:118.28ms
+step:959/4150 train_time:113495ms step_avg:118.35ms
+step:960/4150 train_time:113677ms step_avg:118.41ms
+step:961/4150 train_time:113856ms step_avg:118.48ms
+step:962/4150 train_time:114035ms step_avg:118.54ms
+step:963/4150 train_time:114215ms step_avg:118.60ms
+step:964/4150 train_time:114396ms step_avg:118.67ms
+step:965/4150 train_time:114576ms step_avg:118.73ms
+step:966/4150 train_time:114757ms step_avg:118.80ms
+step:967/4150 train_time:114936ms step_avg:118.86ms
+step:968/4150 train_time:115115ms step_avg:118.92ms
+step:969/4150 train_time:115294ms step_avg:118.98ms
+step:970/4150 train_time:115476ms step_avg:119.05ms
+step:971/4150 train_time:115654ms step_avg:119.11ms
+step:972/4150 train_time:115834ms step_avg:119.17ms
+step:973/4150 train_time:116012ms step_avg:119.23ms
+step:974/4150 train_time:116193ms step_avg:119.30ms
+step:975/4150 train_time:116371ms step_avg:119.36ms
+step:976/4150 train_time:116552ms step_avg:119.42ms
+step:977/4150 train_time:116731ms step_avg:119.48ms
+step:978/4150 train_time:116911ms step_avg:119.54ms
+step:979/4150 train_time:117092ms step_avg:119.60ms
+step:980/4150 train_time:117272ms step_avg:119.67ms
+step:981/4150 train_time:117453ms step_avg:119.73ms
+step:982/4150 train_time:117632ms step_avg:119.79ms
+step:983/4150 train_time:117810ms step_avg:119.85ms
+step:984/4150 train_time:117990ms step_avg:119.91ms
+step:985/4150 train_time:118171ms step_avg:119.97ms
+step:986/4150 train_time:118348ms step_avg:120.03ms
+step:987/4150 train_time:118526ms step_avg:120.09ms
+step:988/4150 train_time:118705ms step_avg:120.15ms
+step:989/4150 train_time:118882ms step_avg:120.20ms
+step:990/4150 train_time:119062ms step_avg:120.26ms
+step:991/4150 train_time:119241ms step_avg:120.32ms
+step:992/4150 train_time:119422ms step_avg:120.39ms
+step:993/4150 train_time:119603ms step_avg:120.45ms
+step:994/4150 train_time:119784ms step_avg:120.51ms
+step:995/4150 train_time:119960ms step_avg:120.56ms
+step:996/4150 train_time:120140ms step_avg:120.62ms
+step:997/4150 train_time:120317ms step_avg:120.68ms
+step:998/4150 train_time:120495ms step_avg:120.74ms
+step:999/4150 train_time:120674ms step_avg:120.79ms
+step:1000/4150 train_time:120854ms step_avg:120.85ms
+step:1000/4150 val_loss:3.4409 train_time:121019ms step_avg:121.02ms
+step:1001/4150 train_time:121041ms step_avg:120.92ms
+step:1002/4150 train_time:121215ms step_avg:120.97ms
+step:1003/4150 train_time:121396ms step_avg:121.03ms
+step:1004/4150 train_time:121576ms step_avg:121.09ms
+step:1005/4150 train_time:121754ms step_avg:121.15ms
+step:1006/4150 train_time:121932ms step_avg:121.21ms
+step:1007/4150 train_time:122113ms step_avg:121.26ms
+step:1008/4150 train_time:122294ms step_avg:121.32ms
+step:1009/4150 train_time:122475ms step_avg:121.38ms
+step:1010/4150 train_time:122655ms step_avg:121.44ms
+step:1011/4150 train_time:122835ms step_avg:121.50ms
+step:1012/4150 train_time:123015ms step_avg:121.56ms
+step:1013/4150 train_time:123195ms step_avg:121.61ms
+step:1014/4150 train_time:123378ms step_avg:121.67ms
+step:1015/4150 train_time:123556ms step_avg:121.73ms
+step:1016/4150 train_time:123735ms step_avg:121.79ms
+step:1017/4150 train_time:123915ms step_avg:121.84ms
+step:1018/4150 train_time:124097ms step_avg:121.90ms
+step:1019/4150 train_time:124276ms step_avg:121.96ms
+step:1020/4150 train_time:124455ms step_avg:122.01ms
+step:1021/4150 train_time:124632ms step_avg:122.07ms
+step:1022/4150 train_time:124810ms step_avg:122.12ms
+step:1023/4150 train_time:124991ms step_avg:122.18ms
+step:1024/4150 train_time:125171ms step_avg:122.24ms
+step:1025/4150 train_time:125349ms step_avg:122.29ms
+step:1026/4150 train_time:125527ms step_avg:122.35ms
+step:1027/4150 train_time:125704ms step_avg:122.40ms
+step:1028/4150 train_time:125885ms step_avg:122.46ms
+step:1029/4150 train_time:126064ms step_avg:122.51ms
+step:1030/4150 train_time:126244ms step_avg:122.57ms
+step:1031/4150 train_time:126424ms step_avg:122.62ms
+step:1032/4150 train_time:126603ms step_avg:122.68ms
+step:1033/4150 train_time:126785ms step_avg:122.73ms
+step:1034/4150 train_time:127019ms step_avg:122.84ms
+step:1035/4150 train_time:127257ms step_avg:122.95ms
+step:1036/4150 train_time:127493ms step_avg:123.06ms
+step:1037/4150 train_time:127726ms step_avg:123.17ms
+step:1038/4150 train_time:127958ms step_avg:123.27ms
+step:1039/4150 train_time:128190ms step_avg:123.38ms
+step:1040/4150 train_time:128425ms step_avg:123.49ms
+step:1041/4150 train_time:128658ms step_avg:123.59ms
+step:1042/4150 train_time:128891ms step_avg:123.70ms
+step:1043/4150 train_time:129122ms step_avg:123.80ms
+step:1044/4150 train_time:129361ms step_avg:123.91ms
+step:1045/4150 train_time:129591ms step_avg:124.01ms
+step:1046/4150 train_time:129825ms step_avg:124.12ms
+step:1047/4150 train_time:130059ms step_avg:124.22ms
+step:1048/4150 train_time:130294ms step_avg:124.33ms
+step:1049/4150 train_time:130527ms step_avg:124.43ms
+step:1050/4150 train_time:130762ms step_avg:124.54ms
+step:1051/4150 train_time:130997ms step_avg:124.64ms
+step:1052/4150 train_time:131234ms step_avg:124.75ms
+step:1053/4150 train_time:131466ms step_avg:124.85ms
+step:1054/4150 train_time:131700ms step_avg:124.95ms
+step:1055/4150 train_time:131930ms step_avg:125.05ms
+step:1056/4150 train_time:132165ms step_avg:125.16ms
+step:1057/4150 train_time:132395ms step_avg:125.26ms
+step:1058/4150 train_time:132629ms step_avg:125.36ms
+step:1059/4150 train_time:132860ms step_avg:125.46ms
+step:1060/4150 train_time:133093ms step_avg:125.56ms
+step:1061/4150 train_time:133325ms step_avg:125.66ms
+step:1062/4150 train_time:133562ms step_avg:125.76ms
+step:1063/4150 train_time:133794ms step_avg:125.86ms
+step:1064/4150 train_time:134029ms step_avg:125.97ms
+step:1065/4150 train_time:134262ms step_avg:126.07ms
+step:1066/4150 train_time:134497ms step_avg:126.17ms
+step:1067/4150 train_time:134730ms step_avg:126.27ms
+step:1068/4150 train_time:134964ms step_avg:126.37ms
+step:1069/4150 train_time:135196ms step_avg:126.47ms
+step:1070/4150 train_time:135435ms step_avg:126.57ms
+step:1071/4150 train_time:135666ms step_avg:126.67ms
+step:1072/4150 train_time:135901ms step_avg:126.77ms
+step:1073/4150 train_time:136135ms step_avg:126.87ms
+step:1074/4150 train_time:136368ms step_avg:126.97ms
+step:1075/4150 train_time:136603ms step_avg:127.07ms
+step:1076/4150 train_time:136838ms step_avg:127.17ms
+step:1077/4150 train_time:137070ms step_avg:127.27ms
+step:1078/4150 train_time:137305ms step_avg:127.37ms
+step:1079/4150 train_time:137539ms step_avg:127.47ms
+step:1080/4150 train_time:137775ms step_avg:127.57ms
+step:1081/4150 train_time:138006ms step_avg:127.67ms
+step:1082/4150 train_time:138240ms step_avg:127.76ms
+step:1083/4150 train_time:138473ms step_avg:127.86ms
+step:1084/4150 train_time:138708ms step_avg:127.96ms
+step:1085/4150 train_time:138938ms step_avg:128.05ms
+step:1086/4150 train_time:139174ms step_avg:128.15ms
+step:1087/4150 train_time:139405ms step_avg:128.25ms
+step:1088/4150 train_time:139640ms step_avg:128.35ms
+step:1089/4150 train_time:139871ms step_avg:128.44ms
+step:1090/4150 train_time:140104ms step_avg:128.54ms
+step:1091/4150 train_time:140334ms step_avg:128.63ms
+step:1092/4150 train_time:140569ms step_avg:128.73ms
+step:1093/4150 train_time:140802ms step_avg:128.82ms
+step:1094/4150 train_time:141035ms step_avg:128.92ms
+step:1095/4150 train_time:141266ms step_avg:129.01ms
+step:1096/4150 train_time:141499ms step_avg:129.10ms
+step:1097/4150 train_time:141731ms step_avg:129.20ms
+step:1098/4150 train_time:141964ms step_avg:129.29ms
+step:1099/4150 train_time:142195ms step_avg:129.39ms
+step:1100/4150 train_time:142428ms step_avg:129.48ms
+step:1101/4150 train_time:142658ms step_avg:129.57ms
+step:1102/4150 train_time:142893ms step_avg:129.67ms
+step:1103/4150 train_time:143126ms step_avg:129.76ms
+step:1104/4150 train_time:143359ms step_avg:129.85ms
+step:1105/4150 train_time:143590ms step_avg:129.95ms
+step:1106/4150 train_time:143825ms step_avg:130.04ms
+step:1107/4150 train_time:144059ms step_avg:130.13ms
+step:1108/4150 train_time:144294ms step_avg:130.23ms
+step:1109/4150 train_time:144525ms step_avg:130.32ms
+step:1110/4150 train_time:144761ms step_avg:130.42ms
+step:1111/4150 train_time:144995ms step_avg:130.51ms
+step:1112/4150 train_time:145229ms step_avg:130.60ms
+step:1113/4150 train_time:145459ms step_avg:130.69ms
+step:1114/4150 train_time:145694ms step_avg:130.78ms
+step:1115/4150 train_time:145927ms step_avg:130.88ms
+step:1116/4150 train_time:146162ms step_avg:130.97ms
+step:1117/4150 train_time:146393ms step_avg:131.06ms
+step:1118/4150 train_time:146627ms step_avg:131.15ms
+step:1119/4150 train_time:146863ms step_avg:131.25ms
+step:1120/4150 train_time:147097ms step_avg:131.34ms
+step:1121/4150 train_time:147328ms step_avg:131.43ms
+step:1122/4150 train_time:147562ms step_avg:131.52ms
+step:1123/4150 train_time:147794ms step_avg:131.61ms
+step:1124/4150 train_time:148034ms step_avg:131.70ms
+step:1125/4150 train_time:148264ms step_avg:131.79ms
+step:1126/4150 train_time:148498ms step_avg:131.88ms
+step:1127/4150 train_time:148729ms step_avg:131.97ms
+step:1128/4150 train_time:148965ms step_avg:132.06ms
+step:1129/4150 train_time:149199ms step_avg:132.15ms
+step:1130/4150 train_time:149436ms step_avg:132.24ms
+step:1131/4150 train_time:149665ms step_avg:132.33ms
+step:1132/4150 train_time:149900ms step_avg:132.42ms
+step:1133/4150 train_time:150131ms step_avg:132.51ms
+step:1134/4150 train_time:150366ms step_avg:132.60ms
+step:1135/4150 train_time:150597ms step_avg:132.68ms
+step:1136/4150 train_time:150833ms step_avg:132.78ms
+step:1137/4150 train_time:151064ms step_avg:132.86ms
+step:1138/4150 train_time:151298ms step_avg:132.95ms
+step:1139/4150 train_time:151528ms step_avg:133.04ms
+step:1140/4150 train_time:151764ms step_avg:133.13ms
+step:1141/4150 train_time:151998ms step_avg:133.21ms
+step:1142/4150 train_time:152235ms step_avg:133.31ms
+step:1143/4150 train_time:152467ms step_avg:133.39ms
+step:1144/4150 train_time:152702ms step_avg:133.48ms
+step:1145/4150 train_time:152935ms step_avg:133.57ms
+step:1146/4150 train_time:153169ms step_avg:133.66ms
+step:1147/4150 train_time:153399ms step_avg:133.74ms
+step:1148/4150 train_time:153636ms step_avg:133.83ms
+step:1149/4150 train_time:153866ms step_avg:133.91ms
+step:1150/4150 train_time:154102ms step_avg:134.00ms
+step:1151/4150 train_time:154334ms step_avg:134.09ms
+step:1152/4150 train_time:154567ms step_avg:134.17ms
+step:1153/4150 train_time:154800ms step_avg:134.26ms
+step:1154/4150 train_time:155037ms step_avg:134.35ms
+step:1155/4150 train_time:155268ms step_avg:134.43ms
+step:1156/4150 train_time:155502ms step_avg:134.52ms
+step:1157/4150 train_time:155734ms step_avg:134.60ms
+step:1158/4150 train_time:155967ms step_avg:134.69ms
+step:1159/4150 train_time:156198ms step_avg:134.77ms
+step:1160/4150 train_time:156434ms step_avg:134.86ms
+step:1161/4150 train_time:156664ms step_avg:134.94ms
+step:1162/4150 train_time:156901ms step_avg:135.03ms
+step:1163/4150 train_time:157132ms step_avg:135.11ms
+step:1164/4150 train_time:157366ms step_avg:135.19ms
+step:1165/4150 train_time:157599ms step_avg:135.28ms
+step:1166/4150 train_time:157834ms step_avg:135.36ms
+step:1167/4150 train_time:158065ms step_avg:135.45ms
+step:1168/4150 train_time:158297ms step_avg:135.53ms
+step:1169/4150 train_time:158528ms step_avg:135.61ms
+step:1170/4150 train_time:158762ms step_avg:135.69ms
+step:1171/4150 train_time:158994ms step_avg:135.78ms
+step:1172/4150 train_time:159228ms step_avg:135.86ms
+step:1173/4150 train_time:159461ms step_avg:135.94ms
+step:1174/4150 train_time:159698ms step_avg:136.03ms
+step:1175/4150 train_time:159928ms step_avg:136.11ms
+step:1176/4150 train_time:160163ms step_avg:136.19ms
+step:1177/4150 train_time:160395ms step_avg:136.27ms
+step:1178/4150 train_time:160629ms step_avg:136.36ms
+step:1179/4150 train_time:160859ms step_avg:136.44ms
+step:1180/4150 train_time:161097ms step_avg:136.52ms
+step:1181/4150 train_time:161329ms step_avg:136.60ms
+step:1182/4150 train_time:161565ms step_avg:136.69ms
+step:1183/4150 train_time:161796ms step_avg:136.77ms
+step:1184/4150 train_time:162029ms step_avg:136.85ms
+step:1185/4150 train_time:162260ms step_avg:136.93ms
+step:1186/4150 train_time:162498ms step_avg:137.01ms
+step:1187/4150 train_time:162728ms step_avg:137.09ms
+step:1188/4150 train_time:162962ms step_avg:137.17ms
+step:1189/4150 train_time:163195ms step_avg:137.25ms
+step:1190/4150 train_time:163431ms step_avg:137.34ms
+step:1191/4150 train_time:163661ms step_avg:137.41ms
+step:1192/4150 train_time:163897ms step_avg:137.50ms
+step:1193/4150 train_time:164128ms step_avg:137.58ms
+step:1194/4150 train_time:164364ms step_avg:137.66ms
+step:1195/4150 train_time:164596ms step_avg:137.74ms
+step:1196/4150 train_time:164832ms step_avg:137.82ms
+step:1197/4150 train_time:165062ms step_avg:137.90ms
+step:1198/4150 train_time:165297ms step_avg:137.98ms
+step:1199/4150 train_time:165529ms step_avg:138.06ms
+step:1200/4150 train_time:165764ms step_avg:138.14ms
+step:1201/4150 train_time:165996ms step_avg:138.21ms
+step:1202/4150 train_time:166231ms step_avg:138.30ms
+step:1203/4150 train_time:166461ms step_avg:138.37ms
+step:1204/4150 train_time:166698ms step_avg:138.45ms
+step:1205/4150 train_time:166932ms step_avg:138.53ms
+step:1206/4150 train_time:167168ms step_avg:138.61ms
+step:1207/4150 train_time:167398ms step_avg:138.69ms
+step:1208/4150 train_time:167634ms step_avg:138.77ms
+step:1209/4150 train_time:167867ms step_avg:138.85ms
+step:1210/4150 train_time:168101ms step_avg:138.93ms
+step:1211/4150 train_time:168334ms step_avg:139.00ms
+step:1212/4150 train_time:168568ms step_avg:139.08ms
+step:1213/4150 train_time:168802ms step_avg:139.16ms
+step:1214/4150 train_time:169035ms step_avg:139.24ms
+step:1215/4150 train_time:169265ms step_avg:139.31ms
+step:1216/4150 train_time:169498ms step_avg:139.39ms
+step:1217/4150 train_time:169731ms step_avg:139.47ms
+step:1218/4150 train_time:169963ms step_avg:139.54ms
+step:1219/4150 train_time:170196ms step_avg:139.62ms
+step:1220/4150 train_time:170433ms step_avg:139.70ms
+step:1221/4150 train_time:170664ms step_avg:139.77ms
+step:1222/4150 train_time:170897ms step_avg:139.85ms
+step:1223/4150 train_time:171127ms step_avg:139.92ms
+step:1224/4150 train_time:171364ms step_avg:140.00ms
+step:1225/4150 train_time:171595ms step_avg:140.08ms
+step:1226/4150 train_time:171829ms step_avg:140.15ms
+step:1227/4150 train_time:172059ms step_avg:140.23ms
+step:1228/4150 train_time:172295ms step_avg:140.31ms
+step:1229/4150 train_time:172526ms step_avg:140.38ms
+step:1230/4150 train_time:172761ms step_avg:140.46ms
+step:1231/4150 train_time:172992ms step_avg:140.53ms
+step:1232/4150 train_time:173227ms step_avg:140.61ms
+step:1233/4150 train_time:173459ms step_avg:140.68ms
+step:1234/4150 train_time:173696ms step_avg:140.76ms
+step:1235/4150 train_time:173927ms step_avg:140.83ms
+step:1236/4150 train_time:174164ms step_avg:140.91ms
+step:1237/4150 train_time:174395ms step_avg:140.98ms
+step:1238/4150 train_time:174631ms step_avg:141.06ms
+step:1239/4150 train_time:174863ms step_avg:141.13ms
+step:1240/4150 train_time:175097ms step_avg:141.21ms
+step:1241/4150 train_time:175329ms step_avg:141.28ms
+step:1242/4150 train_time:175563ms step_avg:141.36ms
+step:1243/4150 train_time:175795ms step_avg:141.43ms
+step:1244/4150 train_time:176030ms step_avg:141.50ms
+step:1245/4150 train_time:176260ms step_avg:141.57ms
+step:1246/4150 train_time:176497ms step_avg:141.65ms
+step:1247/4150 train_time:176728ms step_avg:141.72ms
+step:1248/4150 train_time:176962ms step_avg:141.80ms
+step:1249/4150 train_time:177193ms step_avg:141.87ms
+step:1250/4150 train_time:177428ms step_avg:141.94ms
+step:1250/4150 val_loss:3.3543 train_time:177642ms step_avg:142.11ms
+step:1251/4150 train_time:177665ms step_avg:142.02ms
+step:1252/4150 train_time:177900ms step_avg:142.09ms
+step:1253/4150 train_time:178132ms step_avg:142.16ms
+step:1254/4150 train_time:178364ms step_avg:142.24ms
+step:1255/4150 train_time:178594ms step_avg:142.31ms
+step:1256/4150 train_time:178828ms step_avg:142.38ms
+step:1257/4150 train_time:179063ms step_avg:142.45ms
+step:1258/4150 train_time:179295ms step_avg:142.52ms
+step:1259/4150 train_time:179526ms step_avg:142.59ms
+step:1260/4150 train_time:179760ms step_avg:142.67ms
+step:1261/4150 train_time:179994ms step_avg:142.74ms
+step:1262/4150 train_time:180230ms step_avg:142.81ms
+step:1263/4150 train_time:180460ms step_avg:142.88ms
+step:1264/4150 train_time:180696ms step_avg:142.96ms
+step:1265/4150 train_time:180929ms step_avg:143.03ms
+step:1266/4150 train_time:181164ms step_avg:143.10ms
+step:1267/4150 train_time:181394ms step_avg:143.17ms
+step:1268/4150 train_time:181627ms step_avg:143.24ms
+step:1269/4150 train_time:181859ms step_avg:143.31ms
+step:1270/4150 train_time:182095ms step_avg:143.38ms
+step:1271/4150 train_time:182330ms step_avg:143.45ms
+step:1272/4150 train_time:182564ms step_avg:143.53ms
+step:1273/4150 train_time:182794ms step_avg:143.59ms
+step:1274/4150 train_time:183030ms step_avg:143.67ms
+step:1275/4150 train_time:183264ms step_avg:143.74ms
+step:1276/4150 train_time:183498ms step_avg:143.81ms
+step:1277/4150 train_time:183728ms step_avg:143.88ms
+step:1278/4150 train_time:183965ms step_avg:143.95ms
+step:1279/4150 train_time:184197ms step_avg:144.02ms
+step:1280/4150 train_time:184433ms step_avg:144.09ms
+step:1281/4150 train_time:184662ms step_avg:144.15ms
+step:1282/4150 train_time:184898ms step_avg:144.23ms
+step:1283/4150 train_time:185131ms step_avg:144.30ms
+step:1284/4150 train_time:185366ms step_avg:144.37ms
+step:1285/4150 train_time:185598ms step_avg:144.43ms
+step:1286/4150 train_time:185833ms step_avg:144.50ms
+step:1287/4150 train_time:186066ms step_avg:144.57ms
+step:1288/4150 train_time:186301ms step_avg:144.64ms
+step:1289/4150 train_time:186532ms step_avg:144.71ms
+step:1290/4150 train_time:186764ms step_avg:144.78ms
+step:1291/4150 train_time:186995ms step_avg:144.85ms
+step:1292/4150 train_time:187229ms step_avg:144.91ms
+step:1293/4150 train_time:187460ms step_avg:144.98ms
+step:1294/4150 train_time:187694ms step_avg:145.05ms
+step:1295/4150 train_time:187928ms step_avg:145.12ms
+step:1296/4150 train_time:188164ms step_avg:145.19ms
+step:1297/4150 train_time:188395ms step_avg:145.25ms
+step:1298/4150 train_time:188628ms step_avg:145.32ms
+step:1299/4150 train_time:188861ms step_avg:145.39ms
+step:1300/4150 train_time:189096ms step_avg:145.46ms
+step:1301/4150 train_time:189331ms step_avg:145.53ms
+step:1302/4150 train_time:189566ms step_avg:145.60ms
+step:1303/4150 train_time:189796ms step_avg:145.66ms
+step:1304/4150 train_time:190030ms step_avg:145.73ms
+step:1305/4150 train_time:190265ms step_avg:145.80ms
+step:1306/4150 train_time:190500ms step_avg:145.87ms
+step:1307/4150 train_time:190730ms step_avg:145.93ms
+step:1308/4150 train_time:190966ms step_avg:146.00ms
+step:1309/4150 train_time:191197ms step_avg:146.06ms
+step:1310/4150 train_time:191433ms step_avg:146.13ms
+step:1311/4150 train_time:191666ms step_avg:146.20ms
+step:1312/4150 train_time:191901ms step_avg:146.27ms
+step:1313/4150 train_time:192131ms step_avg:146.33ms
+step:1314/4150 train_time:192365ms step_avg:146.40ms
+step:1315/4150 train_time:192597ms step_avg:146.46ms
+step:1316/4150 train_time:192831ms step_avg:146.53ms
+step:1317/4150 train_time:193064ms step_avg:146.59ms
+step:1318/4150 train_time:193298ms step_avg:146.66ms
+step:1319/4150 train_time:193527ms step_avg:146.72ms
+step:1320/4150 train_time:193765ms step_avg:146.79ms
+step:1321/4150 train_time:193998ms step_avg:146.86ms
+step:1322/4150 train_time:194231ms step_avg:146.92ms
+step:1323/4150 train_time:194462ms step_avg:146.99ms
+step:1324/4150 train_time:194699ms step_avg:147.05ms
+step:1325/4150 train_time:194931ms step_avg:147.12ms
+step:1326/4150 train_time:195166ms step_avg:147.18ms
+step:1327/4150 train_time:195400ms step_avg:147.25ms
+step:1328/4150 train_time:195634ms step_avg:147.31ms
+step:1329/4150 train_time:195866ms step_avg:147.38ms
+step:1330/4150 train_time:196101ms step_avg:147.44ms
+step:1331/4150 train_time:196330ms step_avg:147.51ms
+step:1332/4150 train_time:196564ms step_avg:147.57ms
+step:1333/4150 train_time:196797ms step_avg:147.63ms
+step:1334/4150 train_time:197032ms step_avg:147.70ms
+step:1335/4150 train_time:197266ms step_avg:147.76ms
+step:1336/4150 train_time:197502ms step_avg:147.83ms
+step:1337/4150 train_time:197734ms step_avg:147.89ms
+step:1338/4150 train_time:197968ms step_avg:147.96ms
+step:1339/4150 train_time:198199ms step_avg:148.02ms
+step:1340/4150 train_time:198435ms step_avg:148.09ms
+step:1341/4150 train_time:198667ms step_avg:148.15ms
+step:1342/4150 train_time:198901ms step_avg:148.21ms
+step:1343/4150 train_time:199132ms step_avg:148.27ms
+step:1344/4150 train_time:199366ms step_avg:148.34ms
+step:1345/4150 train_time:199597ms step_avg:148.40ms
+step:1346/4150 train_time:199833ms step_avg:148.46ms
+step:1347/4150 train_time:200065ms step_avg:148.53ms
+step:1348/4150 train_time:200300ms step_avg:148.59ms
+step:1349/4150 train_time:200529ms step_avg:148.65ms
+step:1350/4150 train_time:200766ms step_avg:148.72ms
+step:1351/4150 train_time:200997ms step_avg:148.78ms
+step:1352/4150 train_time:201231ms step_avg:148.84ms
+step:1353/4150 train_time:201464ms step_avg:148.90ms
+step:1354/4150 train_time:201701ms step_avg:148.97ms
+step:1355/4150 train_time:201932ms step_avg:149.03ms
+step:1356/4150 train_time:202167ms step_avg:149.09ms
+step:1357/4150 train_time:202402ms step_avg:149.15ms
+step:1358/4150 train_time:202636ms step_avg:149.22ms
+step:1359/4150 train_time:202870ms step_avg:149.28ms
+step:1360/4150 train_time:203103ms step_avg:149.34ms
+step:1361/4150 train_time:203334ms step_avg:149.40ms
+step:1362/4150 train_time:203570ms step_avg:149.46ms
+step:1363/4150 train_time:203801ms step_avg:149.52ms
+step:1364/4150 train_time:204035ms step_avg:149.59ms
+step:1365/4150 train_time:204267ms step_avg:149.65ms
+step:1366/4150 train_time:204501ms step_avg:149.71ms
+step:1367/4150 train_time:204733ms step_avg:149.77ms
+step:1368/4150 train_time:204966ms step_avg:149.83ms
+step:1369/4150 train_time:205198ms step_avg:149.89ms
+step:1370/4150 train_time:205432ms step_avg:149.95ms
+step:1371/4150 train_time:205667ms step_avg:150.01ms
+step:1372/4150 train_time:205905ms step_avg:150.08ms
+step:1373/4150 train_time:206135ms step_avg:150.13ms
+step:1374/4150 train_time:206367ms step_avg:150.19ms
+step:1375/4150 train_time:206598ms step_avg:150.25ms
+step:1376/4150 train_time:206833ms step_avg:150.31ms
+step:1377/4150 train_time:207066ms step_avg:150.38ms
+step:1378/4150 train_time:207302ms step_avg:150.44ms
+step:1379/4150 train_time:207536ms step_avg:150.50ms
+step:1380/4150 train_time:207768ms step_avg:150.56ms
+step:1381/4150 train_time:208002ms step_avg:150.62ms
+step:1382/4150 train_time:208239ms step_avg:150.68ms
+step:1383/4150 train_time:208469ms step_avg:150.74ms
+step:1384/4150 train_time:208707ms step_avg:150.80ms
+step:1385/4150 train_time:208939ms step_avg:150.86ms
+step:1386/4150 train_time:209175ms step_avg:150.92ms
+step:1387/4150 train_time:209405ms step_avg:150.98ms
+step:1388/4150 train_time:209639ms step_avg:151.04ms
+step:1389/4150 train_time:209869ms step_avg:151.09ms
+step:1390/4150 train_time:210108ms step_avg:151.16ms
+step:1391/4150 train_time:210339ms step_avg:151.21ms
+step:1392/4150 train_time:210572ms step_avg:151.27ms
+step:1393/4150 train_time:210803ms step_avg:151.33ms
+step:1394/4150 train_time:211041ms step_avg:151.39ms
+step:1395/4150 train_time:211275ms step_avg:151.45ms
+step:1396/4150 train_time:211508ms step_avg:151.51ms
+step:1397/4150 train_time:211741ms step_avg:151.57ms
+step:1398/4150 train_time:211975ms step_avg:151.63ms
+step:1399/4150 train_time:212208ms step_avg:151.69ms
+step:1400/4150 train_time:212443ms step_avg:151.74ms
+step:1401/4150 train_time:212675ms step_avg:151.80ms
+step:1402/4150 train_time:212911ms step_avg:151.86ms
+step:1403/4150 train_time:213142ms step_avg:151.92ms
+step:1404/4150 train_time:213379ms step_avg:151.98ms
+step:1405/4150 train_time:213610ms step_avg:152.04ms
+step:1406/4150 train_time:213847ms step_avg:152.10ms
+step:1407/4150 train_time:214078ms step_avg:152.15ms
+step:1408/4150 train_time:214315ms step_avg:152.21ms
+step:1409/4150 train_time:214549ms step_avg:152.27ms
+step:1410/4150 train_time:214784ms step_avg:152.33ms
+step:1411/4150 train_time:215014ms step_avg:152.38ms
+step:1412/4150 train_time:215249ms step_avg:152.44ms
+step:1413/4150 train_time:215483ms step_avg:152.50ms
+step:1414/4150 train_time:215717ms step_avg:152.56ms
+step:1415/4150 train_time:215948ms step_avg:152.61ms
+step:1416/4150 train_time:216182ms step_avg:152.67ms
+step:1417/4150 train_time:216414ms step_avg:152.73ms
+step:1418/4150 train_time:216651ms step_avg:152.79ms
+step:1419/4150 train_time:216885ms step_avg:152.84ms
+step:1420/4150 train_time:217119ms step_avg:152.90ms
+step:1421/4150 train_time:217351ms step_avg:152.96ms
+step:1422/4150 train_time:217587ms step_avg:153.01ms
+step:1423/4150 train_time:217818ms step_avg:153.07ms
+step:1424/4150 train_time:218055ms step_avg:153.13ms
+step:1425/4150 train_time:218288ms step_avg:153.18ms
+step:1426/4150 train_time:218526ms step_avg:153.24ms
+step:1427/4150 train_time:218758ms step_avg:153.30ms
+step:1428/4150 train_time:218993ms step_avg:153.36ms
+step:1429/4150 train_time:219228ms step_avg:153.41ms
+step:1430/4150 train_time:219464ms step_avg:153.47ms
+step:1431/4150 train_time:219696ms step_avg:153.53ms
+step:1432/4150 train_time:219932ms step_avg:153.58ms
+step:1433/4150 train_time:220164ms step_avg:153.64ms
+step:1434/4150 train_time:220400ms step_avg:153.70ms
+step:1435/4150 train_time:220633ms step_avg:153.75ms
+step:1436/4150 train_time:220865ms step_avg:153.81ms
+step:1437/4150 train_time:221098ms step_avg:153.86ms
+step:1438/4150 train_time:221333ms step_avg:153.92ms
+step:1439/4150 train_time:221567ms step_avg:153.97ms
+step:1440/4150 train_time:221804ms step_avg:154.03ms
+step:1441/4150 train_time:222035ms step_avg:154.08ms
+step:1442/4150 train_time:222268ms step_avg:154.14ms
+step:1443/4150 train_time:222499ms step_avg:154.19ms
+step:1444/4150 train_time:222737ms step_avg:154.25ms
+step:1445/4150 train_time:222969ms step_avg:154.30ms
+step:1446/4150 train_time:223203ms step_avg:154.36ms
+step:1447/4150 train_time:223435ms step_avg:154.41ms
+step:1448/4150 train_time:223671ms step_avg:154.47ms
+step:1449/4150 train_time:223903ms step_avg:154.52ms
+step:1450/4150 train_time:224138ms step_avg:154.58ms
+step:1451/4150 train_time:224368ms step_avg:154.63ms
+step:1452/4150 train_time:224605ms step_avg:154.69ms
+step:1453/4150 train_time:224838ms step_avg:154.74ms
+step:1454/4150 train_time:225075ms step_avg:154.80ms
+step:1455/4150 train_time:225310ms step_avg:154.85ms
+step:1456/4150 train_time:225547ms step_avg:154.91ms
+step:1457/4150 train_time:225781ms step_avg:154.96ms
+step:1458/4150 train_time:226014ms step_avg:155.02ms
+step:1459/4150 train_time:226248ms step_avg:155.07ms
+step:1460/4150 train_time:226483ms step_avg:155.13ms
+step:1461/4150 train_time:226717ms step_avg:155.18ms
+step:1462/4150 train_time:226953ms step_avg:155.23ms
+step:1463/4150 train_time:227184ms step_avg:155.29ms
+step:1464/4150 train_time:227421ms step_avg:155.34ms
+step:1465/4150 train_time:227651ms step_avg:155.39ms
+step:1466/4150 train_time:227887ms step_avg:155.45ms
+step:1467/4150 train_time:228118ms step_avg:155.50ms
+step:1468/4150 train_time:228353ms step_avg:155.55ms
+step:1469/4150 train_time:228584ms step_avg:155.61ms
+step:1470/4150 train_time:228819ms step_avg:155.66ms
+step:1471/4150 train_time:229050ms step_avg:155.71ms
+step:1472/4150 train_time:229288ms step_avg:155.77ms
+step:1473/4150 train_time:229519ms step_avg:155.82ms
+step:1474/4150 train_time:229755ms step_avg:155.87ms
+step:1475/4150 train_time:229986ms step_avg:155.92ms
+step:1476/4150 train_time:230224ms step_avg:155.98ms
+step:1477/4150 train_time:230456ms step_avg:156.03ms
+step:1478/4150 train_time:230693ms step_avg:156.08ms
+step:1479/4150 train_time:230928ms step_avg:156.14ms
+step:1480/4150 train_time:231162ms step_avg:156.19ms
+step:1481/4150 train_time:231397ms step_avg:156.24ms
+step:1482/4150 train_time:231634ms step_avg:156.30ms
+step:1483/4150 train_time:231869ms step_avg:156.35ms
+step:1484/4150 train_time:232108ms step_avg:156.41ms
+step:1485/4150 train_time:232342ms step_avg:156.46ms
+step:1486/4150 train_time:232577ms step_avg:156.51ms
+step:1487/4150 train_time:232808ms step_avg:156.56ms
+step:1488/4150 train_time:233042ms step_avg:156.61ms
+step:1489/4150 train_time:233273ms step_avg:156.66ms
+step:1490/4150 train_time:233507ms step_avg:156.72ms
+step:1491/4150 train_time:233739ms step_avg:156.77ms
+step:1492/4150 train_time:233975ms step_avg:156.82ms
+step:1493/4150 train_time:234206ms step_avg:156.87ms
+step:1494/4150 train_time:234443ms step_avg:156.92ms
+step:1495/4150 train_time:234675ms step_avg:156.97ms
+step:1496/4150 train_time:234911ms step_avg:157.03ms
+step:1497/4150 train_time:235146ms step_avg:157.08ms
+step:1498/4150 train_time:235379ms step_avg:157.13ms
+step:1499/4150 train_time:235612ms step_avg:157.18ms
+step:1500/4150 train_time:235847ms step_avg:157.23ms
+step:1500/4150 val_loss:3.3498 train_time:236060ms step_avg:157.37ms
+step:1501/4150 train_time:236083ms step_avg:157.28ms
+step:1502/4150 train_time:236323ms step_avg:157.34ms
+step:1503/4150 train_time:236561ms step_avg:157.39ms
+step:1504/4150 train_time:236793ms step_avg:157.44ms
+step:1505/4150 train_time:237022ms step_avg:157.49ms
+step:1506/4150 train_time:237257ms step_avg:157.54ms
+step:1507/4150 train_time:237493ms step_avg:157.59ms
+step:1508/4150 train_time:237727ms step_avg:157.64ms
+step:1509/4150 train_time:237955ms step_avg:157.69ms
+step:1510/4150 train_time:238189ms step_avg:157.74ms
+step:1511/4150 train_time:238424ms step_avg:157.79ms
+step:1512/4150 train_time:238660ms step_avg:157.84ms
+step:1513/4150 train_time:238892ms step_avg:157.89ms
+step:1514/4150 train_time:239126ms step_avg:157.94ms
+step:1515/4150 train_time:239361ms step_avg:157.99ms
+step:1516/4150 train_time:239598ms step_avg:158.05ms
+step:1517/4150 train_time:239830ms step_avg:158.10ms
+step:1518/4150 train_time:240064ms step_avg:158.15ms
+step:1519/4150 train_time:240296ms step_avg:158.19ms
+step:1520/4150 train_time:240532ms step_avg:158.24ms
+step:1521/4150 train_time:240763ms step_avg:158.29ms
+step:1522/4150 train_time:240997ms step_avg:158.34ms
+step:1523/4150 train_time:241229ms step_avg:158.39ms
+step:1524/4150 train_time:241464ms step_avg:158.44ms
+step:1525/4150 train_time:241696ms step_avg:158.49ms
+step:1526/4150 train_time:241932ms step_avg:158.54ms
+step:1527/4150 train_time:242163ms step_avg:158.59ms
+step:1528/4150 train_time:242397ms step_avg:158.64ms
+step:1529/4150 train_time:242630ms step_avg:158.69ms
+step:1530/4150 train_time:242865ms step_avg:158.74ms
+step:1531/4150 train_time:243094ms step_avg:158.78ms
+step:1532/4150 train_time:243331ms step_avg:158.83ms
+step:1533/4150 train_time:243562ms step_avg:158.88ms
+step:1534/4150 train_time:243799ms step_avg:158.93ms
+step:1535/4150 train_time:244031ms step_avg:158.98ms
+step:1536/4150 train_time:244265ms step_avg:159.03ms
+step:1537/4150 train_time:244499ms step_avg:159.08ms
+step:1538/4150 train_time:244735ms step_avg:159.13ms
+step:1539/4150 train_time:244968ms step_avg:159.17ms
+step:1540/4150 train_time:245202ms step_avg:159.22ms
+step:1541/4150 train_time:245435ms step_avg:159.27ms
+step:1542/4150 train_time:245670ms step_avg:159.32ms
+step:1543/4150 train_time:245901ms step_avg:159.37ms
+step:1544/4150 train_time:246138ms step_avg:159.42ms
+step:1545/4150 train_time:246369ms step_avg:159.46ms
+step:1546/4150 train_time:246604ms step_avg:159.51ms
+step:1547/4150 train_time:246838ms step_avg:159.56ms
+step:1548/4150 train_time:247076ms step_avg:159.61ms
+step:1549/4150 train_time:247308ms step_avg:159.66ms
+step:1550/4150 train_time:247545ms step_avg:159.71ms
+step:1551/4150 train_time:247776ms step_avg:159.75ms
+step:1552/4150 train_time:248012ms step_avg:159.80ms
+step:1553/4150 train_time:248244ms step_avg:159.85ms
+step:1554/4150 train_time:248479ms step_avg:159.90ms
+step:1555/4150 train_time:248713ms step_avg:159.94ms
+step:1556/4150 train_time:248947ms step_avg:159.99ms
+step:1557/4150 train_time:249180ms step_avg:160.04ms
+step:1558/4150 train_time:249416ms step_avg:160.09ms
+step:1559/4150 train_time:249651ms step_avg:160.14ms
+step:1560/4150 train_time:249885ms step_avg:160.18ms
+step:1561/4150 train_time:250119ms step_avg:160.23ms
+step:1562/4150 train_time:250352ms step_avg:160.28ms
+step:1563/4150 train_time:250585ms step_avg:160.32ms
+step:1564/4150 train_time:250822ms step_avg:160.37ms
+step:1565/4150 train_time:251057ms step_avg:160.42ms
+step:1566/4150 train_time:251292ms step_avg:160.47ms
+step:1567/4150 train_time:251524ms step_avg:160.51ms
+step:1568/4150 train_time:251759ms step_avg:160.56ms
+step:1569/4150 train_time:251991ms step_avg:160.61ms
+step:1570/4150 train_time:252226ms step_avg:160.65ms
+step:1571/4150 train_time:252459ms step_avg:160.70ms
+step:1572/4150 train_time:252694ms step_avg:160.75ms
+step:1573/4150 train_time:252925ms step_avg:160.79ms
+step:1574/4150 train_time:253159ms step_avg:160.84ms
+step:1575/4150 train_time:253393ms step_avg:160.88ms
+step:1576/4150 train_time:253629ms step_avg:160.93ms
+step:1577/4150 train_time:253861ms step_avg:160.98ms
+step:1578/4150 train_time:254096ms step_avg:161.02ms
+step:1579/4150 train_time:254329ms step_avg:161.07ms
+step:1580/4150 train_time:254564ms step_avg:161.12ms
+step:1581/4150 train_time:254800ms step_avg:161.16ms
+step:1582/4150 train_time:255037ms step_avg:161.21ms
+step:1583/4150 train_time:255270ms step_avg:161.26ms
+step:1584/4150 train_time:255504ms step_avg:161.30ms
+step:1585/4150 train_time:255739ms step_avg:161.35ms
+step:1586/4150 train_time:255976ms step_avg:161.40ms
+step:1587/4150 train_time:256205ms step_avg:161.44ms
+step:1588/4150 train_time:256440ms step_avg:161.49ms
+step:1589/4150 train_time:256673ms step_avg:161.53ms
+step:1590/4150 train_time:256909ms step_avg:161.58ms
+step:1591/4150 train_time:257139ms step_avg:161.62ms
+step:1592/4150 train_time:257373ms step_avg:161.67ms
+step:1593/4150 train_time:257605ms step_avg:161.71ms
+step:1594/4150 train_time:257839ms step_avg:161.76ms
+step:1595/4150 train_time:258072ms step_avg:161.80ms
+step:1596/4150 train_time:258307ms step_avg:161.85ms
+step:1597/4150 train_time:258540ms step_avg:161.89ms
+step:1598/4150 train_time:258777ms step_avg:161.94ms
+step:1599/4150 train_time:259007ms step_avg:161.98ms
+step:1600/4150 train_time:259241ms step_avg:162.03ms
+step:1601/4150 train_time:259473ms step_avg:162.07ms
+step:1602/4150 train_time:259710ms step_avg:162.12ms
+step:1603/4150 train_time:259942ms step_avg:162.16ms
+step:1604/4150 train_time:260175ms step_avg:162.20ms
+step:1605/4150 train_time:260405ms step_avg:162.25ms
+step:1606/4150 train_time:260641ms step_avg:162.29ms
+step:1607/4150 train_time:260875ms step_avg:162.34ms
+step:1608/4150 train_time:261110ms step_avg:162.38ms
+step:1609/4150 train_time:261341ms step_avg:162.42ms
+step:1610/4150 train_time:261576ms step_avg:162.47ms
+step:1611/4150 train_time:261809ms step_avg:162.51ms
+step:1612/4150 train_time:262044ms step_avg:162.56ms
+step:1613/4150 train_time:262276ms step_avg:162.60ms
+step:1614/4150 train_time:262514ms step_avg:162.65ms
+step:1615/4150 train_time:262746ms step_avg:162.69ms
+step:1616/4150 train_time:262980ms step_avg:162.74ms
+step:1617/4150 train_time:263211ms step_avg:162.78ms
+step:1618/4150 train_time:263445ms step_avg:162.82ms
+step:1619/4150 train_time:263675ms step_avg:162.86ms
+step:1620/4150 train_time:263909ms step_avg:162.91ms
+step:1621/4150 train_time:264140ms step_avg:162.95ms
+step:1622/4150 train_time:264376ms step_avg:162.99ms
+step:1623/4150 train_time:264609ms step_avg:163.04ms
+step:1624/4150 train_time:264845ms step_avg:163.08ms
+step:1625/4150 train_time:265076ms step_avg:163.12ms
+step:1626/4150 train_time:265312ms step_avg:163.17ms
+step:1627/4150 train_time:265544ms step_avg:163.21ms
+step:1628/4150 train_time:265779ms step_avg:163.25ms
+step:1629/4150 train_time:266012ms step_avg:163.30ms
+step:1630/4150 train_time:266248ms step_avg:163.34ms
+step:1631/4150 train_time:266479ms step_avg:163.38ms
+step:1632/4150 train_time:266716ms step_avg:163.43ms
+step:1633/4150 train_time:266949ms step_avg:163.47ms
+step:1634/4150 train_time:267184ms step_avg:163.52ms
+step:1635/4150 train_time:267417ms step_avg:163.56ms
+step:1636/4150 train_time:267653ms step_avg:163.60ms
+step:1637/4150 train_time:267887ms step_avg:163.65ms
+step:1638/4150 train_time:268122ms step_avg:163.69ms
+step:1639/4150 train_time:268357ms step_avg:163.73ms
+step:1640/4150 train_time:268595ms step_avg:163.78ms
+step:1641/4150 train_time:268831ms step_avg:163.82ms
+step:1642/4150 train_time:269065ms step_avg:163.86ms
+step:1643/4150 train_time:269296ms step_avg:163.91ms
+step:1644/4150 train_time:269532ms step_avg:163.95ms
+step:1645/4150 train_time:269763ms step_avg:163.99ms
+step:1646/4150 train_time:269998ms step_avg:164.03ms
+step:1647/4150 train_time:270228ms step_avg:164.07ms
+step:1648/4150 train_time:270463ms step_avg:164.12ms
+step:1649/4150 train_time:270693ms step_avg:164.16ms
+step:1650/4150 train_time:270930ms step_avg:164.20ms
+step:1651/4150 train_time:271161ms step_avg:164.24ms
+step:1652/4150 train_time:271396ms step_avg:164.28ms
+step:1653/4150 train_time:271627ms step_avg:164.32ms
+step:1654/4150 train_time:271861ms step_avg:164.37ms
+step:1655/4150 train_time:272094ms step_avg:164.41ms
+step:1656/4150 train_time:272332ms step_avg:164.45ms
+step:1657/4150 train_time:272565ms step_avg:164.49ms
+step:1658/4150 train_time:272799ms step_avg:164.53ms
+step:1659/4150 train_time:273033ms step_avg:164.58ms
+step:1660/4150 train_time:273268ms step_avg:164.62ms
+step:1661/4150 train_time:273503ms step_avg:164.66ms
+step:1662/4150 train_time:273737ms step_avg:164.70ms
+step:1663/4150 train_time:273969ms step_avg:164.74ms
+step:1664/4150 train_time:274205ms step_avg:164.79ms
+step:1665/4150 train_time:274438ms step_avg:164.83ms
+step:1666/4150 train_time:274673ms step_avg:164.87ms
+step:1667/4150 train_time:274905ms step_avg:164.91ms
+step:1668/4150 train_time:275138ms step_avg:164.95ms
+step:1669/4150 train_time:275369ms step_avg:164.99ms
+step:1670/4150 train_time:275603ms step_avg:165.03ms
+step:1671/4150 train_time:275836ms step_avg:165.07ms
+step:1672/4150 train_time:276071ms step_avg:165.11ms
+step:1673/4150 train_time:276304ms step_avg:165.15ms
+step:1674/4150 train_time:276540ms step_avg:165.20ms
+step:1675/4150 train_time:276771ms step_avg:165.24ms
+step:1676/4150 train_time:277007ms step_avg:165.28ms
+step:1677/4150 train_time:277240ms step_avg:165.32ms
+step:1678/4150 train_time:277476ms step_avg:165.36ms
+step:1679/4150 train_time:277707ms step_avg:165.40ms
+step:1680/4150 train_time:277943ms step_avg:165.44ms
+step:1681/4150 train_time:278178ms step_avg:165.48ms
+step:1682/4150 train_time:278416ms step_avg:165.53ms
+step:1683/4150 train_time:278648ms step_avg:165.57ms
+step:1684/4150 train_time:278882ms step_avg:165.61ms
+step:1685/4150 train_time:279118ms step_avg:165.65ms
+step:1686/4150 train_time:279353ms step_avg:165.69ms
+step:1687/4150 train_time:279586ms step_avg:165.73ms
+step:1688/4150 train_time:279818ms step_avg:165.77ms
+step:1689/4150 train_time:280049ms step_avg:165.81ms
+step:1690/4150 train_time:280284ms step_avg:165.85ms
+step:1691/4150 train_time:280518ms step_avg:165.89ms
+step:1692/4150 train_time:280752ms step_avg:165.93ms
+step:1693/4150 train_time:280984ms step_avg:165.97ms
+step:1694/4150 train_time:281220ms step_avg:166.01ms
+step:1695/4150 train_time:281451ms step_avg:166.05ms
+step:1696/4150 train_time:281686ms step_avg:166.09ms
+step:1697/4150 train_time:281918ms step_avg:166.13ms
+step:1698/4150 train_time:282156ms step_avg:166.17ms
+step:1699/4150 train_time:282389ms step_avg:166.21ms
+step:1700/4150 train_time:282625ms step_avg:166.25ms
+step:1701/4150 train_time:282856ms step_avg:166.29ms
+step:1702/4150 train_time:283093ms step_avg:166.33ms
+step:1703/4150 train_time:283327ms step_avg:166.37ms
+step:1704/4150 train_time:283562ms step_avg:166.41ms
+step:1705/4150 train_time:283794ms step_avg:166.45ms
+step:1706/4150 train_time:284031ms step_avg:166.49ms
+step:1707/4150 train_time:284262ms step_avg:166.53ms
+step:1708/4150 train_time:284497ms step_avg:166.57ms
+step:1709/4150 train_time:284728ms step_avg:166.60ms
+step:1710/4150 train_time:284962ms step_avg:166.64ms
+step:1711/4150 train_time:285193ms step_avg:166.68ms
+step:1712/4150 train_time:285427ms step_avg:166.72ms
+step:1713/4150 train_time:285663ms step_avg:166.76ms
+step:1714/4150 train_time:285899ms step_avg:166.80ms
+step:1715/4150 train_time:286131ms step_avg:166.84ms
+step:1716/4150 train_time:286364ms step_avg:166.88ms
+step:1717/4150 train_time:286596ms step_avg:166.92ms
+step:1718/4150 train_time:286835ms step_avg:166.96ms
+step:1719/4150 train_time:287067ms step_avg:167.00ms
+step:1720/4150 train_time:287303ms step_avg:167.04ms
+step:1721/4150 train_time:287538ms step_avg:167.08ms
+step:1722/4150 train_time:287775ms step_avg:167.12ms
+step:1723/4150 train_time:288007ms step_avg:167.15ms
+step:1724/4150 train_time:288244ms step_avg:167.19ms
+step:1725/4150 train_time:288482ms step_avg:167.24ms
+step:1726/4150 train_time:288716ms step_avg:167.27ms
+step:1727/4150 train_time:288947ms step_avg:167.31ms
+step:1728/4150 train_time:289186ms step_avg:167.35ms
+step:1729/4150 train_time:289420ms step_avg:167.39ms
+step:1730/4150 train_time:289658ms step_avg:167.43ms
+step:1731/4150 train_time:289889ms step_avg:167.47ms
+step:1732/4150 train_time:290123ms step_avg:167.51ms
+step:1733/4150 train_time:290356ms step_avg:167.55ms
+step:1734/4150 train_time:290593ms step_avg:167.59ms
+step:1735/4150 train_time:290823ms step_avg:167.62ms
+step:1736/4150 train_time:291058ms step_avg:167.66ms
+step:1737/4150 train_time:291290ms step_avg:167.70ms
+step:1738/4150 train_time:291528ms step_avg:167.74ms
+step:1739/4150 train_time:291761ms step_avg:167.77ms
+step:1740/4150 train_time:291994ms step_avg:167.81ms
+step:1741/4150 train_time:292226ms step_avg:167.85ms
+step:1742/4150 train_time:292465ms step_avg:167.89ms
+step:1743/4150 train_time:292698ms step_avg:167.93ms
+step:1744/4150 train_time:292932ms step_avg:167.97ms
+step:1745/4150 train_time:293162ms step_avg:168.00ms
+step:1746/4150 train_time:293401ms step_avg:168.04ms
+step:1747/4150 train_time:293636ms step_avg:168.08ms
+step:1748/4150 train_time:293873ms step_avg:168.12ms
+step:1749/4150 train_time:294104ms step_avg:168.16ms
+step:1750/4150 train_time:294345ms step_avg:168.20ms
+step:1750/4150 val_loss:3.2301 train_time:294559ms step_avg:168.32ms
+step:1751/4150 train_time:294582ms step_avg:168.24ms
+step:1752/4150 train_time:294820ms step_avg:168.28ms
+step:1753/4150 train_time:295053ms step_avg:168.31ms
+step:1754/4150 train_time:295284ms step_avg:168.35ms
+step:1755/4150 train_time:295515ms step_avg:168.38ms
+step:1756/4150 train_time:295752ms step_avg:168.42ms
+step:1757/4150 train_time:295990ms step_avg:168.46ms
+step:1758/4150 train_time:296225ms step_avg:168.50ms
+step:1759/4150 train_time:296456ms step_avg:168.54ms
+step:1760/4150 train_time:296693ms step_avg:168.58ms
+step:1761/4150 train_time:296926ms step_avg:168.61ms
+step:1762/4150 train_time:297162ms step_avg:168.65ms
+step:1763/4150 train_time:297392ms step_avg:168.68ms
+step:1764/4150 train_time:297628ms step_avg:168.72ms
+step:1765/4150 train_time:297862ms step_avg:168.76ms
+step:1766/4150 train_time:298100ms step_avg:168.80ms
+step:1767/4150 train_time:298332ms step_avg:168.84ms
+step:1768/4150 train_time:298567ms step_avg:168.87ms
+step:1769/4150 train_time:298803ms step_avg:168.91ms
+step:1770/4150 train_time:299042ms step_avg:168.95ms
+step:1771/4150 train_time:299274ms step_avg:168.99ms
+step:1772/4150 train_time:299508ms step_avg:169.02ms
+step:1773/4150 train_time:299743ms step_avg:169.06ms
+step:1774/4150 train_time:299981ms step_avg:169.10ms
+step:1775/4150 train_time:300213ms step_avg:169.13ms
+step:1776/4150 train_time:300447ms step_avg:169.17ms
+step:1777/4150 train_time:300681ms step_avg:169.21ms
+step:1778/4150 train_time:300917ms step_avg:169.24ms
+step:1779/4150 train_time:301148ms step_avg:169.28ms
+step:1780/4150 train_time:301385ms step_avg:169.32ms
+step:1781/4150 train_time:301617ms step_avg:169.35ms
+step:1782/4150 train_time:301853ms step_avg:169.39ms
+step:1783/4150 train_time:302086ms step_avg:169.43ms
+step:1784/4150 train_time:302321ms step_avg:169.46ms
+step:1785/4150 train_time:302554ms step_avg:169.50ms
+step:1786/4150 train_time:302789ms step_avg:169.53ms
+step:1787/4150 train_time:303021ms step_avg:169.57ms
+step:1788/4150 train_time:303259ms step_avg:169.61ms
+step:1789/4150 train_time:303493ms step_avg:169.64ms
+step:1790/4150 train_time:303729ms step_avg:169.68ms
+step:1791/4150 train_time:303964ms step_avg:169.72ms
+step:1792/4150 train_time:304200ms step_avg:169.75ms
+step:1793/4150 train_time:304431ms step_avg:169.79ms
+step:1794/4150 train_time:304668ms step_avg:169.83ms
+step:1795/4150 train_time:304902ms step_avg:169.86ms
+step:1796/4150 train_time:305142ms step_avg:169.90ms
+step:1797/4150 train_time:305374ms step_avg:169.94ms
+step:1798/4150 train_time:305610ms step_avg:169.97ms
+step:1799/4150 train_time:305845ms step_avg:170.01ms
+step:1800/4150 train_time:306086ms step_avg:170.05ms
+step:1801/4150 train_time:306321ms step_avg:170.08ms
+step:1802/4150 train_time:306558ms step_avg:170.12ms
+step:1803/4150 train_time:306790ms step_avg:170.16ms
+step:1804/4150 train_time:307024ms step_avg:170.19ms
+step:1805/4150 train_time:307257ms step_avg:170.23ms
+step:1806/4150 train_time:307491ms step_avg:170.26ms
+step:1807/4150 train_time:307725ms step_avg:170.30ms
+step:1808/4150 train_time:307964ms step_avg:170.33ms
+step:1809/4150 train_time:308198ms step_avg:170.37ms
+step:1810/4150 train_time:308434ms step_avg:170.41ms
+step:1811/4150 train_time:308667ms step_avg:170.44ms
+step:1812/4150 train_time:308903ms step_avg:170.48ms
+step:1813/4150 train_time:309137ms step_avg:170.51ms
+step:1814/4150 train_time:309371ms step_avg:170.55ms
+step:1815/4150 train_time:309605ms step_avg:170.58ms
+step:1816/4150 train_time:309840ms step_avg:170.62ms
+step:1817/4150 train_time:310075ms step_avg:170.65ms
+step:1818/4150 train_time:310310ms step_avg:170.69ms
+step:1819/4150 train_time:310542ms step_avg:170.72ms
+step:1820/4150 train_time:310779ms step_avg:170.76ms
+step:1821/4150 train_time:311010ms step_avg:170.79ms
+step:1822/4150 train_time:311247ms step_avg:170.83ms
+step:1823/4150 train_time:311483ms step_avg:170.86ms
+step:1824/4150 train_time:311721ms step_avg:170.90ms
+step:1825/4150 train_time:311954ms step_avg:170.93ms
+step:1826/4150 train_time:312189ms step_avg:170.97ms
+step:1827/4150 train_time:312424ms step_avg:171.00ms
+step:1828/4150 train_time:312662ms step_avg:171.04ms
+step:1829/4150 train_time:312893ms step_avg:171.07ms
+step:1830/4150 train_time:313128ms step_avg:171.11ms
+step:1831/4150 train_time:313363ms step_avg:171.14ms
+step:1832/4150 train_time:313600ms step_avg:171.18ms
+step:1833/4150 train_time:313832ms step_avg:171.21ms
+step:1834/4150 train_time:314071ms step_avg:171.25ms
+step:1835/4150 train_time:314305ms step_avg:171.28ms
+step:1836/4150 train_time:314541ms step_avg:171.32ms
+step:1837/4150 train_time:314771ms step_avg:171.35ms
+step:1838/4150 train_time:315007ms step_avg:171.39ms
+step:1839/4150 train_time:315241ms step_avg:171.42ms
+step:1840/4150 train_time:315477ms step_avg:171.46ms
+step:1841/4150 train_time:315710ms step_avg:171.49ms
+step:1842/4150 train_time:315946ms step_avg:171.52ms
+step:1843/4150 train_time:316180ms step_avg:171.56ms
+step:1844/4150 train_time:316416ms step_avg:171.59ms
+step:1845/4150 train_time:316648ms step_avg:171.62ms
+step:1846/4150 train_time:316884ms step_avg:171.66ms
+step:1847/4150 train_time:317120ms step_avg:171.69ms
+step:1848/4150 train_time:317358ms step_avg:171.73ms
+step:1849/4150 train_time:317593ms step_avg:171.76ms
+step:1850/4150 train_time:317827ms step_avg:171.80ms
+step:1851/4150 train_time:318060ms step_avg:171.83ms
+step:1852/4150 train_time:318298ms step_avg:171.87ms
+step:1853/4150 train_time:318531ms step_avg:171.90ms
+step:1854/4150 train_time:318766ms step_avg:171.93ms
+step:1855/4150 train_time:318999ms step_avg:171.97ms
+step:1856/4150 train_time:319237ms step_avg:172.00ms
+step:1857/4150 train_time:319471ms step_avg:172.04ms
+step:1858/4150 train_time:319705ms step_avg:172.07ms
+step:1859/4150 train_time:319936ms step_avg:172.10ms
+step:1860/4150 train_time:320172ms step_avg:172.14ms
+step:1861/4150 train_time:320405ms step_avg:172.17ms
+step:1862/4150 train_time:320640ms step_avg:172.20ms
+step:1863/4150 train_time:320872ms step_avg:172.23ms
+step:1864/4150 train_time:321111ms step_avg:172.27ms
+step:1865/4150 train_time:321346ms step_avg:172.30ms
+step:1866/4150 train_time:321583ms step_avg:172.34ms
+step:1867/4150 train_time:321817ms step_avg:172.37ms
+step:1868/4150 train_time:322051ms step_avg:172.40ms
+step:1869/4150 train_time:322284ms step_avg:172.44ms
+step:1870/4150 train_time:322521ms step_avg:172.47ms
+step:1871/4150 train_time:322753ms step_avg:172.50ms
+step:1872/4150 train_time:322989ms step_avg:172.54ms
+step:1873/4150 train_time:323224ms step_avg:172.57ms
+step:1874/4150 train_time:323458ms step_avg:172.60ms
+step:1875/4150 train_time:323691ms step_avg:172.63ms
+step:1876/4150 train_time:323925ms step_avg:172.67ms
+step:1877/4150 train_time:324161ms step_avg:172.70ms
+step:1878/4150 train_time:324399ms step_avg:172.74ms
+step:1879/4150 train_time:324631ms step_avg:172.77ms
+step:1880/4150 train_time:324867ms step_avg:172.80ms
+step:1881/4150 train_time:325100ms step_avg:172.83ms
+step:1882/4150 train_time:325337ms step_avg:172.87ms
+step:1883/4150 train_time:325572ms step_avg:172.90ms
+step:1884/4150 train_time:325810ms step_avg:172.94ms
+step:1885/4150 train_time:326044ms step_avg:172.97ms
+step:1886/4150 train_time:326280ms step_avg:173.00ms
+step:1887/4150 train_time:326515ms step_avg:173.03ms
+step:1888/4150 train_time:326751ms step_avg:173.07ms
+step:1889/4150 train_time:326984ms step_avg:173.10ms
+step:1890/4150 train_time:327219ms step_avg:173.13ms
+step:1891/4150 train_time:327456ms step_avg:173.17ms
+step:1892/4150 train_time:327691ms step_avg:173.20ms
+step:1893/4150 train_time:327924ms step_avg:173.23ms
+step:1894/4150 train_time:328163ms step_avg:173.26ms
+step:1895/4150 train_time:328395ms step_avg:173.30ms
+step:1896/4150 train_time:328630ms step_avg:173.33ms
+step:1897/4150 train_time:328865ms step_avg:173.36ms
+step:1898/4150 train_time:329101ms step_avg:173.39ms
+step:1899/4150 train_time:329333ms step_avg:173.42ms
+step:1900/4150 train_time:329569ms step_avg:173.46ms
+step:1901/4150 train_time:329802ms step_avg:173.49ms
+step:1902/4150 train_time:330041ms step_avg:173.52ms
+step:1903/4150 train_time:330273ms step_avg:173.55ms
+step:1904/4150 train_time:330507ms step_avg:173.59ms
+step:1905/4150 train_time:330740ms step_avg:173.62ms
+step:1906/4150 train_time:330978ms step_avg:173.65ms
+step:1907/4150 train_time:331208ms step_avg:173.68ms
+step:1908/4150 train_time:331444ms step_avg:173.71ms
+step:1909/4150 train_time:331676ms step_avg:173.74ms
+step:1910/4150 train_time:331911ms step_avg:173.78ms
+step:1911/4150 train_time:332143ms step_avg:173.81ms
+step:1912/4150 train_time:332380ms step_avg:173.84ms
+step:1913/4150 train_time:332612ms step_avg:173.87ms
+step:1914/4150 train_time:332849ms step_avg:173.90ms
+step:1915/4150 train_time:333082ms step_avg:173.93ms
+step:1916/4150 train_time:333318ms step_avg:173.97ms
+step:1917/4150 train_time:333551ms step_avg:174.00ms
+step:1918/4150 train_time:333788ms step_avg:174.03ms
+step:1919/4150 train_time:334023ms step_avg:174.06ms
+step:1920/4150 train_time:334260ms step_avg:174.09ms
+step:1921/4150 train_time:334491ms step_avg:174.12ms
+step:1922/4150 train_time:334727ms step_avg:174.16ms
+step:1923/4150 train_time:334960ms step_avg:174.19ms
+step:1924/4150 train_time:335198ms step_avg:174.22ms
+step:1925/4150 train_time:335429ms step_avg:174.25ms
+step:1926/4150 train_time:335665ms step_avg:174.28ms
+step:1927/4150 train_time:335897ms step_avg:174.31ms
+step:1928/4150 train_time:336133ms step_avg:174.34ms
+step:1929/4150 train_time:336365ms step_avg:174.37ms
+step:1930/4150 train_time:336602ms step_avg:174.41ms
+step:1931/4150 train_time:336837ms step_avg:174.44ms
+step:1932/4150 train_time:337073ms step_avg:174.47ms
+step:1933/4150 train_time:337303ms step_avg:174.50ms
+step:1934/4150 train_time:337539ms step_avg:174.53ms
+step:1935/4150 train_time:337771ms step_avg:174.56ms
+step:1936/4150 train_time:338007ms step_avg:174.59ms
+step:1937/4150 train_time:338240ms step_avg:174.62ms
+step:1938/4150 train_time:338476ms step_avg:174.65ms
+step:1939/4150 train_time:338708ms step_avg:174.68ms
+step:1940/4150 train_time:338945ms step_avg:174.71ms
+step:1941/4150 train_time:339177ms step_avg:174.74ms
+step:1942/4150 train_time:339416ms step_avg:174.78ms
+step:1943/4150 train_time:339647ms step_avg:174.81ms
+step:1944/4150 train_time:339883ms step_avg:174.84ms
+step:1945/4150 train_time:340114ms step_avg:174.87ms
+step:1946/4150 train_time:340349ms step_avg:174.90ms
+step:1947/4150 train_time:340580ms step_avg:174.93ms
+step:1948/4150 train_time:340816ms step_avg:174.96ms
+step:1949/4150 train_time:341050ms step_avg:174.99ms
+step:1950/4150 train_time:341284ms step_avg:175.02ms
+step:1951/4150 train_time:341519ms step_avg:175.05ms
+step:1952/4150 train_time:341757ms step_avg:175.08ms
+step:1953/4150 train_time:341990ms step_avg:175.11ms
+step:1954/4150 train_time:342226ms step_avg:175.14ms
+step:1955/4150 train_time:342458ms step_avg:175.17ms
+step:1956/4150 train_time:342693ms step_avg:175.20ms
+step:1957/4150 train_time:342927ms step_avg:175.23ms
+step:1958/4150 train_time:343162ms step_avg:175.26ms
+step:1959/4150 train_time:343393ms step_avg:175.29ms
+step:1960/4150 train_time:343631ms step_avg:175.32ms
+step:1961/4150 train_time:343865ms step_avg:175.35ms
+step:1962/4150 train_time:344104ms step_avg:175.38ms
+step:1963/4150 train_time:344338ms step_avg:175.41ms
+step:1964/4150 train_time:344575ms step_avg:175.45ms
+step:1965/4150 train_time:344806ms step_avg:175.47ms
+step:1966/4150 train_time:345044ms step_avg:175.51ms
+step:1967/4150 train_time:345277ms step_avg:175.53ms
+step:1968/4150 train_time:345512ms step_avg:175.57ms
+step:1969/4150 train_time:345744ms step_avg:175.59ms
+step:1970/4150 train_time:345983ms step_avg:175.63ms
+step:1971/4150 train_time:346216ms step_avg:175.65ms
+step:1972/4150 train_time:346452ms step_avg:175.69ms
+step:1973/4150 train_time:346685ms step_avg:175.71ms
+step:1974/4150 train_time:346922ms step_avg:175.75ms
+step:1975/4150 train_time:347155ms step_avg:175.77ms
+step:1976/4150 train_time:347389ms step_avg:175.80ms
+step:1977/4150 train_time:347621ms step_avg:175.83ms
+step:1978/4150 train_time:347858ms step_avg:175.86ms
+step:1979/4150 train_time:348092ms step_avg:175.89ms
+step:1980/4150 train_time:348328ms step_avg:175.92ms
+step:1981/4150 train_time:348564ms step_avg:175.95ms
+step:1982/4150 train_time:348798ms step_avg:175.98ms
+step:1983/4150 train_time:349031ms step_avg:176.01ms
+step:1984/4150 train_time:349265ms step_avg:176.04ms
+step:1985/4150 train_time:349498ms step_avg:176.07ms
+step:1986/4150 train_time:349732ms step_avg:176.10ms
+step:1987/4150 train_time:349964ms step_avg:176.13ms
+step:1988/4150 train_time:350202ms step_avg:176.16ms
+step:1989/4150 train_time:350435ms step_avg:176.19ms
+step:1990/4150 train_time:350670ms step_avg:176.22ms
+step:1991/4150 train_time:350902ms step_avg:176.24ms
+step:1992/4150 train_time:351140ms step_avg:176.27ms
+step:1993/4150 train_time:351374ms step_avg:176.30ms
+step:1994/4150 train_time:351608ms step_avg:176.33ms
+step:1995/4150 train_time:351842ms step_avg:176.36ms
+step:1996/4150 train_time:352077ms step_avg:176.39ms
+step:1997/4150 train_time:352310ms step_avg:176.42ms
+step:1998/4150 train_time:352546ms step_avg:176.45ms
+step:1999/4150 train_time:352779ms step_avg:176.48ms
+step:2000/4150 train_time:353012ms step_avg:176.51ms
+step:2000/4150 val_loss:3.1841 train_time:353226ms step_avg:176.61ms
+step:2001/4150 train_time:353249ms step_avg:176.54ms
+step:2002/4150 train_time:353491ms step_avg:176.57ms
+step:2003/4150 train_time:353725ms step_avg:176.60ms
+step:2004/4150 train_time:353958ms step_avg:176.63ms
+step:2005/4150 train_time:354187ms step_avg:176.65ms
+step:2006/4150 train_time:354426ms step_avg:176.68ms
+step:2007/4150 train_time:354658ms step_avg:176.71ms
+step:2008/4150 train_time:354892ms step_avg:176.74ms
+step:2009/4150 train_time:355124ms step_avg:176.77ms
+step:2010/4150 train_time:355361ms step_avg:176.80ms
+step:2011/4150 train_time:355596ms step_avg:176.83ms
+step:2012/4150 train_time:355829ms step_avg:176.85ms
+step:2013/4150 train_time:356059ms step_avg:176.88ms
+step:2014/4150 train_time:356296ms step_avg:176.91ms
+step:2015/4150 train_time:356530ms step_avg:176.94ms
+step:2016/4150 train_time:356768ms step_avg:176.97ms
+step:2017/4150 train_time:356999ms step_avg:176.99ms
+step:2018/4150 train_time:357235ms step_avg:177.02ms
+step:2019/4150 train_time:357468ms step_avg:177.05ms
+step:2020/4150 train_time:357706ms step_avg:177.08ms
+step:2021/4150 train_time:357937ms step_avg:177.11ms
+step:2022/4150 train_time:358172ms step_avg:177.14ms
+step:2023/4150 train_time:358406ms step_avg:177.17ms
+step:2024/4150 train_time:358644ms step_avg:177.20ms
+step:2025/4150 train_time:358877ms step_avg:177.22ms
+step:2026/4150 train_time:359113ms step_avg:177.25ms
+step:2027/4150 train_time:359346ms step_avg:177.28ms
+step:2028/4150 train_time:359585ms step_avg:177.31ms
+step:2029/4150 train_time:359819ms step_avg:177.34ms
+step:2030/4150 train_time:360054ms step_avg:177.37ms
+step:2031/4150 train_time:360288ms step_avg:177.39ms
+step:2032/4150 train_time:360527ms step_avg:177.42ms
+step:2033/4150 train_time:360760ms step_avg:177.45ms
+step:2034/4150 train_time:360996ms step_avg:177.48ms
+step:2035/4150 train_time:361231ms step_avg:177.51ms
+step:2036/4150 train_time:361466ms step_avg:177.54ms
+step:2037/4150 train_time:361700ms step_avg:177.56ms
+step:2038/4150 train_time:361936ms step_avg:177.59ms
+step:2039/4150 train_time:362170ms step_avg:177.62ms
+step:2040/4150 train_time:362408ms step_avg:177.65ms
+step:2041/4150 train_time:362641ms step_avg:177.68ms
+step:2042/4150 train_time:362875ms step_avg:177.71ms
+step:2043/4150 train_time:363104ms step_avg:177.73ms
+step:2044/4150 train_time:363340ms step_avg:177.76ms
+step:2045/4150 train_time:363575ms step_avg:177.79ms
+step:2046/4150 train_time:363811ms step_avg:177.82ms
+step:2047/4150 train_time:364042ms step_avg:177.84ms
+step:2048/4150 train_time:364278ms step_avg:177.87ms
+step:2049/4150 train_time:364512ms step_avg:177.90ms
+step:2050/4150 train_time:364747ms step_avg:177.93ms
+step:2051/4150 train_time:364982ms step_avg:177.95ms
+step:2052/4150 train_time:365219ms step_avg:177.98ms
+step:2053/4150 train_time:365455ms step_avg:178.01ms
+step:2054/4150 train_time:365691ms step_avg:178.04ms
+step:2055/4150 train_time:365922ms step_avg:178.06ms
+step:2056/4150 train_time:366158ms step_avg:178.09ms
+step:2057/4150 train_time:366390ms step_avg:178.12ms
+step:2058/4150 train_time:366629ms step_avg:178.15ms
+step:2059/4150 train_time:366862ms step_avg:178.18ms
+step:2060/4150 train_time:367098ms step_avg:178.20ms
+step:2061/4150 train_time:367331ms step_avg:178.23ms
+step:2062/4150 train_time:367567ms step_avg:178.26ms
+step:2063/4150 train_time:367800ms step_avg:178.28ms
+step:2064/4150 train_time:368034ms step_avg:178.31ms
+step:2065/4150 train_time:368267ms step_avg:178.34ms
+step:2066/4150 train_time:368506ms step_avg:178.37ms
+step:2067/4150 train_time:368738ms step_avg:178.39ms
+step:2068/4150 train_time:368973ms step_avg:178.42ms
+step:2069/4150 train_time:369207ms step_avg:178.45ms
+step:2070/4150 train_time:369445ms step_avg:178.48ms
+step:2071/4150 train_time:369677ms step_avg:178.50ms
+step:2072/4150 train_time:369915ms step_avg:178.53ms
+step:2073/4150 train_time:370151ms step_avg:178.56ms
+step:2074/4150 train_time:370391ms step_avg:178.59ms
+step:2075/4150 train_time:370624ms step_avg:178.61ms
+step:2076/4150 train_time:370859ms step_avg:178.64ms
+step:2077/4150 train_time:371096ms step_avg:178.67ms
+step:2078/4150 train_time:371331ms step_avg:178.70ms
+step:2079/4150 train_time:371567ms step_avg:178.72ms
+step:2080/4150 train_time:371803ms step_avg:178.75ms
+step:2081/4150 train_time:372037ms step_avg:178.78ms
+step:2082/4150 train_time:372272ms step_avg:178.80ms
+step:2083/4150 train_time:372503ms step_avg:178.83ms
+step:2084/4150 train_time:372741ms step_avg:178.86ms
+step:2085/4150 train_time:372976ms step_avg:178.89ms
+step:2086/4150 train_time:373211ms step_avg:178.91ms
+step:2087/4150 train_time:373444ms step_avg:178.94ms
+step:2088/4150 train_time:373680ms step_avg:178.97ms
+step:2089/4150 train_time:373912ms step_avg:178.99ms
+step:2090/4150 train_time:374148ms step_avg:179.02ms
+step:2091/4150 train_time:374381ms step_avg:179.04ms
+step:2092/4150 train_time:374619ms step_avg:179.07ms
+step:2093/4150 train_time:374852ms step_avg:179.10ms
+step:2094/4150 train_time:375091ms step_avg:179.13ms
+step:2095/4150 train_time:375326ms step_avg:179.15ms
+step:2096/4150 train_time:375563ms step_avg:179.18ms
+step:2097/4150 train_time:375796ms step_avg:179.21ms
+step:2098/4150 train_time:376031ms step_avg:179.23ms
+step:2099/4150 train_time:376266ms step_avg:179.26ms
+step:2100/4150 train_time:376504ms step_avg:179.29ms
+step:2101/4150 train_time:376737ms step_avg:179.31ms
+step:2102/4150 train_time:376972ms step_avg:179.34ms
+step:2103/4150 train_time:377205ms step_avg:179.37ms
+step:2104/4150 train_time:377442ms step_avg:179.39ms
+step:2105/4150 train_time:377677ms step_avg:179.42ms
+step:2106/4150 train_time:377914ms step_avg:179.45ms
+step:2107/4150 train_time:378149ms step_avg:179.47ms
+step:2108/4150 train_time:378388ms step_avg:179.50ms
+step:2109/4150 train_time:378622ms step_avg:179.53ms
+step:2110/4150 train_time:378859ms step_avg:179.55ms
+step:2111/4150 train_time:379092ms step_avg:179.58ms
+step:2112/4150 train_time:379332ms step_avg:179.61ms
+step:2113/4150 train_time:379565ms step_avg:179.63ms
+step:2114/4150 train_time:379800ms step_avg:179.66ms
+step:2115/4150 train_time:380032ms step_avg:179.68ms
+step:2116/4150 train_time:380270ms step_avg:179.71ms
+step:2117/4150 train_time:380504ms step_avg:179.74ms
+step:2118/4150 train_time:380742ms step_avg:179.76ms
+step:2119/4150 train_time:380974ms step_avg:179.79ms
+step:2120/4150 train_time:381209ms step_avg:179.82ms
+step:2121/4150 train_time:381442ms step_avg:179.84ms
+step:2122/4150 train_time:381679ms step_avg:179.87ms
+step:2123/4150 train_time:381910ms step_avg:179.89ms
+step:2124/4150 train_time:382148ms step_avg:179.92ms
+step:2125/4150 train_time:382384ms step_avg:179.95ms
+step:2126/4150 train_time:382619ms step_avg:179.97ms
+step:2127/4150 train_time:382854ms step_avg:180.00ms
+step:2128/4150 train_time:383089ms step_avg:180.02ms
+step:2129/4150 train_time:383323ms step_avg:180.05ms
+step:2130/4150 train_time:383560ms step_avg:180.08ms
+step:2131/4150 train_time:383793ms step_avg:180.10ms
+step:2132/4150 train_time:384030ms step_avg:180.13ms
+step:2133/4150 train_time:384264ms step_avg:180.15ms
+step:2134/4150 train_time:384501ms step_avg:180.18ms
+step:2135/4150 train_time:384737ms step_avg:180.20ms
+step:2136/4150 train_time:384974ms step_avg:180.23ms
+step:2137/4150 train_time:385209ms step_avg:180.26ms
+step:2138/4150 train_time:385449ms step_avg:180.28ms
+step:2139/4150 train_time:385681ms step_avg:180.31ms
+step:2140/4150 train_time:385916ms step_avg:180.33ms
+step:2141/4150 train_time:386153ms step_avg:180.36ms
+step:2142/4150 train_time:386391ms step_avg:180.39ms
+step:2143/4150 train_time:386624ms step_avg:180.41ms
+step:2144/4150 train_time:386859ms step_avg:180.44ms
+step:2145/4150 train_time:387093ms step_avg:180.46ms
+step:2146/4150 train_time:387330ms step_avg:180.49ms
+step:2147/4150 train_time:387563ms step_avg:180.51ms
+step:2148/4150 train_time:387799ms step_avg:180.54ms
+step:2149/4150 train_time:388033ms step_avg:180.56ms
+step:2150/4150 train_time:388271ms step_avg:180.59ms
+step:2151/4150 train_time:388507ms step_avg:180.62ms
+step:2152/4150 train_time:388742ms step_avg:180.64ms
+step:2153/4150 train_time:388977ms step_avg:180.67ms
+step:2154/4150 train_time:389213ms step_avg:180.69ms
+step:2155/4150 train_time:389449ms step_avg:180.72ms
+step:2156/4150 train_time:389684ms step_avg:180.74ms
+step:2157/4150 train_time:389918ms step_avg:180.77ms
+step:2158/4150 train_time:390157ms step_avg:180.80ms
+step:2159/4150 train_time:390393ms step_avg:180.82ms
+step:2160/4150 train_time:390632ms step_avg:180.85ms
+step:2161/4150 train_time:390866ms step_avg:180.87ms
+step:2162/4150 train_time:391103ms step_avg:180.90ms
+step:2163/4150 train_time:391337ms step_avg:180.92ms
+step:2164/4150 train_time:391574ms step_avg:180.95ms
+step:2165/4150 train_time:391808ms step_avg:180.97ms
+step:2166/4150 train_time:392043ms step_avg:181.00ms
+step:2167/4150 train_time:392278ms step_avg:181.02ms
+step:2168/4150 train_time:392513ms step_avg:181.05ms
+step:2169/4150 train_time:392750ms step_avg:181.07ms
+step:2170/4150 train_time:392990ms step_avg:181.10ms
+step:2171/4150 train_time:393225ms step_avg:181.13ms
+step:2172/4150 train_time:393463ms step_avg:181.15ms
+step:2173/4150 train_time:393696ms step_avg:181.18ms
+step:2174/4150 train_time:393937ms step_avg:181.20ms
+step:2175/4150 train_time:394172ms step_avg:181.23ms
+step:2176/4150 train_time:394409ms step_avg:181.25ms
+step:2177/4150 train_time:394642ms step_avg:181.28ms
+step:2178/4150 train_time:394877ms step_avg:181.30ms
+step:2179/4150 train_time:395110ms step_avg:181.33ms
+step:2180/4150 train_time:395349ms step_avg:181.35ms
+step:2181/4150 train_time:395582ms step_avg:181.38ms
+step:2182/4150 train_time:395820ms step_avg:181.40ms
+step:2183/4150 train_time:396052ms step_avg:181.43ms
+step:2184/4150 train_time:396292ms step_avg:181.45ms
+step:2185/4150 train_time:396523ms step_avg:181.48ms
+step:2186/4150 train_time:396763ms step_avg:181.50ms
+step:2187/4150 train_time:396996ms step_avg:181.53ms
+step:2188/4150 train_time:397231ms step_avg:181.55ms
+step:2189/4150 train_time:397465ms step_avg:181.57ms
+step:2190/4150 train_time:397699ms step_avg:181.60ms
+step:2191/4150 train_time:397935ms step_avg:181.62ms
+step:2192/4150 train_time:398172ms step_avg:181.65ms
+step:2193/4150 train_time:398406ms step_avg:181.67ms
+step:2194/4150 train_time:398645ms step_avg:181.70ms
+step:2195/4150 train_time:398879ms step_avg:181.72ms
+step:2196/4150 train_time:399116ms step_avg:181.75ms
+step:2197/4150 train_time:399349ms step_avg:181.77ms
+step:2198/4150 train_time:399589ms step_avg:181.80ms
+step:2199/4150 train_time:399820ms step_avg:181.82ms
+step:2200/4150 train_time:400054ms step_avg:181.84ms
+step:2201/4150 train_time:400289ms step_avg:181.87ms
+step:2202/4150 train_time:400526ms step_avg:181.89ms
+step:2203/4150 train_time:400759ms step_avg:181.92ms
+step:2204/4150 train_time:400994ms step_avg:181.94ms
+step:2205/4150 train_time:401228ms step_avg:181.96ms
+step:2206/4150 train_time:401467ms step_avg:181.99ms
+step:2207/4150 train_time:401700ms step_avg:182.01ms
+step:2208/4150 train_time:401936ms step_avg:182.04ms
+step:2209/4150 train_time:402167ms step_avg:182.06ms
+step:2210/4150 train_time:402405ms step_avg:182.08ms
+step:2211/4150 train_time:402639ms step_avg:182.11ms
+step:2212/4150 train_time:402876ms step_avg:182.13ms
+step:2213/4150 train_time:403110ms step_avg:182.16ms
+step:2214/4150 train_time:403347ms step_avg:182.18ms
+step:2215/4150 train_time:403579ms step_avg:182.20ms
+step:2216/4150 train_time:403815ms step_avg:182.23ms
+step:2217/4150 train_time:404048ms step_avg:182.25ms
+step:2218/4150 train_time:404285ms step_avg:182.27ms
+step:2219/4150 train_time:404519ms step_avg:182.30ms
+step:2220/4150 train_time:404758ms step_avg:182.32ms
+step:2221/4150 train_time:404994ms step_avg:182.35ms
+step:2222/4150 train_time:405230ms step_avg:182.37ms
+step:2223/4150 train_time:405464ms step_avg:182.39ms
+step:2224/4150 train_time:405701ms step_avg:182.42ms
+step:2225/4150 train_time:405933ms step_avg:182.44ms
+step:2226/4150 train_time:406170ms step_avg:182.47ms
+step:2227/4150 train_time:406402ms step_avg:182.49ms
+step:2228/4150 train_time:406639ms step_avg:182.51ms
+step:2229/4150 train_time:406872ms step_avg:182.54ms
+step:2230/4150 train_time:407109ms step_avg:182.56ms
+step:2231/4150 train_time:407341ms step_avg:182.58ms
+step:2232/4150 train_time:407576ms step_avg:182.61ms
+step:2233/4150 train_time:407810ms step_avg:182.63ms
+step:2234/4150 train_time:408046ms step_avg:182.65ms
+step:2235/4150 train_time:408280ms step_avg:182.68ms
+step:2236/4150 train_time:408517ms step_avg:182.70ms
+step:2237/4150 train_time:408753ms step_avg:182.72ms
+step:2238/4150 train_time:408988ms step_avg:182.75ms
+step:2239/4150 train_time:409222ms step_avg:182.77ms
+step:2240/4150 train_time:409455ms step_avg:182.79ms
+step:2241/4150 train_time:409688ms step_avg:182.81ms
+step:2242/4150 train_time:409924ms step_avg:182.84ms
+step:2243/4150 train_time:410157ms step_avg:182.86ms
+step:2244/4150 train_time:410392ms step_avg:182.88ms
+step:2245/4150 train_time:410626ms step_avg:182.91ms
+step:2246/4150 train_time:410862ms step_avg:182.93ms
+step:2247/4150 train_time:411096ms step_avg:182.95ms
+step:2248/4150 train_time:411331ms step_avg:182.98ms
+step:2249/4150 train_time:411566ms step_avg:183.00ms
+step:2250/4150 train_time:411802ms step_avg:183.02ms
+step:2250/4150 val_loss:3.1429 train_time:412016ms step_avg:183.12ms
+step:2251/4150 train_time:412040ms step_avg:183.05ms
+step:2252/4150 train_time:412277ms step_avg:183.07ms
+step:2253/4150 train_time:412514ms step_avg:183.10ms
+step:2254/4150 train_time:412748ms step_avg:183.12ms
+step:2255/4150 train_time:412981ms step_avg:183.14ms
+step:2256/4150 train_time:413217ms step_avg:183.16ms
+step:2257/4150 train_time:413457ms step_avg:183.19ms
+step:2258/4150 train_time:413694ms step_avg:183.21ms
+step:2259/4150 train_time:413929ms step_avg:183.24ms
+step:2260/4150 train_time:414165ms step_avg:183.26ms
+step:2261/4150 train_time:414399ms step_avg:183.28ms
+step:2262/4150 train_time:414639ms step_avg:183.31ms
+step:2263/4150 train_time:414871ms step_avg:183.33ms
+step:2264/4150 train_time:415107ms step_avg:183.35ms
+step:2265/4150 train_time:415342ms step_avg:183.37ms
+step:2266/4150 train_time:415579ms step_avg:183.40ms
+step:2267/4150 train_time:415812ms step_avg:183.42ms
+step:2268/4150 train_time:416047ms step_avg:183.44ms
+step:2269/4150 train_time:416282ms step_avg:183.46ms
+step:2270/4150 train_time:416518ms step_avg:183.49ms
+step:2271/4150 train_time:416750ms step_avg:183.51ms
+step:2272/4150 train_time:416986ms step_avg:183.53ms
+step:2273/4150 train_time:417218ms step_avg:183.55ms
+step:2274/4150 train_time:417456ms step_avg:183.58ms
+step:2275/4150 train_time:417692ms step_avg:183.60ms
+step:2276/4150 train_time:417932ms step_avg:183.63ms
+step:2277/4150 train_time:418166ms step_avg:183.65ms
+step:2278/4150 train_time:418399ms step_avg:183.67ms
+step:2279/4150 train_time:418633ms step_avg:183.69ms
+step:2280/4150 train_time:418868ms step_avg:183.71ms
+step:2281/4150 train_time:419100ms step_avg:183.74ms
+step:2282/4150 train_time:419336ms step_avg:183.76ms
+step:2283/4150 train_time:419572ms step_avg:183.78ms
+step:2284/4150 train_time:419808ms step_avg:183.80ms
+step:2285/4150 train_time:420041ms step_avg:183.83ms
+step:2286/4150 train_time:420275ms step_avg:183.85ms
+step:2287/4150 train_time:420507ms step_avg:183.87ms
+step:2288/4150 train_time:420744ms step_avg:183.89ms
+step:2289/4150 train_time:420975ms step_avg:183.91ms
+step:2290/4150 train_time:421213ms step_avg:183.94ms
+step:2291/4150 train_time:421446ms step_avg:183.96ms
+step:2292/4150 train_time:421683ms step_avg:183.98ms
+step:2293/4150 train_time:421916ms step_avg:184.00ms
+step:2294/4150 train_time:422154ms step_avg:184.03ms
+step:2295/4150 train_time:422392ms step_avg:184.05ms
+step:2296/4150 train_time:422628ms step_avg:184.07ms
+step:2297/4150 train_time:422860ms step_avg:184.09ms
+step:2298/4150 train_time:423096ms step_avg:184.11ms
+step:2299/4150 train_time:423330ms step_avg:184.14ms
+step:2300/4150 train_time:423567ms step_avg:184.16ms
+step:2301/4150 train_time:423801ms step_avg:184.18ms
+step:2302/4150 train_time:424036ms step_avg:184.20ms
+step:2303/4150 train_time:424270ms step_avg:184.22ms
+step:2304/4150 train_time:424509ms step_avg:184.25ms
+step:2305/4150 train_time:424744ms step_avg:184.27ms
+step:2306/4150 train_time:424977ms step_avg:184.29ms
+step:2307/4150 train_time:425211ms step_avg:184.31ms
+step:2308/4150 train_time:425448ms step_avg:184.34ms
+step:2309/4150 train_time:425686ms step_avg:184.36ms
+step:2310/4150 train_time:425923ms step_avg:184.38ms
+step:2311/4150 train_time:426155ms step_avg:184.40ms
+step:2312/4150 train_time:426393ms step_avg:184.43ms
+step:2313/4150 train_time:426626ms step_avg:184.45ms
+step:2314/4150 train_time:426865ms step_avg:184.47ms
+step:2315/4150 train_time:427097ms step_avg:184.49ms
+step:2316/4150 train_time:427335ms step_avg:184.51ms
+step:2317/4150 train_time:427569ms step_avg:184.54ms
+step:2318/4150 train_time:427805ms step_avg:184.56ms
+step:2319/4150 train_time:428039ms step_avg:184.58ms
+step:2320/4150 train_time:428275ms step_avg:184.60ms
+step:2321/4150 train_time:428511ms step_avg:184.62ms
+step:2322/4150 train_time:428752ms step_avg:184.65ms
+step:2323/4150 train_time:428987ms step_avg:184.67ms
+step:2324/4150 train_time:429224ms step_avg:184.69ms
+step:2325/4150 train_time:429456ms step_avg:184.71ms
+step:2326/4150 train_time:429695ms step_avg:184.74ms
+step:2327/4150 train_time:429929ms step_avg:184.76ms
+step:2328/4150 train_time:430164ms step_avg:184.78ms
+step:2329/4150 train_time:430396ms step_avg:184.80ms
+step:2330/4150 train_time:430636ms step_avg:184.82ms
+step:2331/4150 train_time:430870ms step_avg:184.84ms
+step:2332/4150 train_time:431106ms step_avg:184.87ms
+step:2333/4150 train_time:431337ms step_avg:184.89ms
+step:2334/4150 train_time:431572ms step_avg:184.91ms
+step:2335/4150 train_time:431806ms step_avg:184.93ms
+step:2336/4150 train_time:432042ms step_avg:184.95ms
+step:2337/4150 train_time:432272ms step_avg:184.97ms
+step:2338/4150 train_time:432507ms step_avg:184.99ms
+step:2339/4150 train_time:432741ms step_avg:185.01ms
+step:2340/4150 train_time:432978ms step_avg:185.03ms
+step:2341/4150 train_time:433213ms step_avg:185.05ms
+step:2342/4150 train_time:433448ms step_avg:185.08ms
+step:2343/4150 train_time:433681ms step_avg:185.10ms
+step:2344/4150 train_time:433918ms step_avg:185.12ms
+step:2345/4150 train_time:434150ms step_avg:185.14ms
+step:2346/4150 train_time:434388ms step_avg:185.16ms
+step:2347/4150 train_time:434620ms step_avg:185.18ms
+step:2348/4150 train_time:434858ms step_avg:185.20ms
+step:2349/4150 train_time:435091ms step_avg:185.22ms
+step:2350/4150 train_time:435329ms step_avg:185.25ms
+step:2351/4150 train_time:435562ms step_avg:185.27ms
+step:2352/4150 train_time:435799ms step_avg:185.29ms
+step:2353/4150 train_time:436034ms step_avg:185.31ms
+step:2354/4150 train_time:436275ms step_avg:185.33ms
+step:2355/4150 train_time:436507ms step_avg:185.35ms
+step:2356/4150 train_time:436743ms step_avg:185.37ms
+step:2357/4150 train_time:436977ms step_avg:185.40ms
+step:2358/4150 train_time:437213ms step_avg:185.42ms
+step:2359/4150 train_time:437445ms step_avg:185.44ms
+step:2360/4150 train_time:437680ms step_avg:185.46ms
+step:2361/4150 train_time:437914ms step_avg:185.48ms
+step:2362/4150 train_time:438153ms step_avg:185.50ms
+step:2363/4150 train_time:438390ms step_avg:185.52ms
+step:2364/4150 train_time:438626ms step_avg:185.54ms
+step:2365/4150 train_time:438862ms step_avg:185.57ms
+step:2366/4150 train_time:439096ms step_avg:185.59ms
+step:2367/4150 train_time:439331ms step_avg:185.61ms
+step:2368/4150 train_time:439569ms step_avg:185.63ms
+step:2369/4150 train_time:439802ms step_avg:185.65ms
+step:2370/4150 train_time:440038ms step_avg:185.67ms
+step:2371/4150 train_time:440276ms step_avg:185.69ms
+step:2372/4150 train_time:440512ms step_avg:185.71ms
+step:2373/4150 train_time:440745ms step_avg:185.73ms
+step:2374/4150 train_time:440985ms step_avg:185.76ms
+step:2375/4150 train_time:441217ms step_avg:185.78ms
+step:2376/4150 train_time:441453ms step_avg:185.80ms
+step:2377/4150 train_time:441685ms step_avg:185.82ms
+step:2378/4150 train_time:441924ms step_avg:185.84ms
+step:2379/4150 train_time:442157ms step_avg:185.86ms
+step:2380/4150 train_time:442392ms step_avg:185.88ms
+step:2381/4150 train_time:442625ms step_avg:185.90ms
+step:2382/4150 train_time:442865ms step_avg:185.92ms
+step:2383/4150 train_time:443097ms step_avg:185.94ms
+step:2384/4150 train_time:443332ms step_avg:185.96ms
+step:2385/4150 train_time:443564ms step_avg:185.98ms
+step:2386/4150 train_time:443799ms step_avg:186.00ms
+step:2387/4150 train_time:444034ms step_avg:186.02ms
+step:2388/4150 train_time:444273ms step_avg:186.04ms
+step:2389/4150 train_time:444504ms step_avg:186.06ms
+step:2390/4150 train_time:444741ms step_avg:186.08ms
+step:2391/4150 train_time:444974ms step_avg:186.10ms
+step:2392/4150 train_time:445208ms step_avg:186.12ms
+step:2393/4150 train_time:445442ms step_avg:186.14ms
+step:2394/4150 train_time:445678ms step_avg:186.16ms
+step:2395/4150 train_time:445913ms step_avg:186.18ms
+step:2396/4150 train_time:446150ms step_avg:186.21ms
+step:2397/4150 train_time:446382ms step_avg:186.23ms
+step:2398/4150 train_time:446620ms step_avg:186.25ms
+step:2399/4150 train_time:446853ms step_avg:186.27ms
+step:2400/4150 train_time:447088ms step_avg:186.29ms
+step:2401/4150 train_time:447321ms step_avg:186.31ms
+step:2402/4150 train_time:447559ms step_avg:186.33ms
+step:2403/4150 train_time:447792ms step_avg:186.35ms
+step:2404/4150 train_time:448032ms step_avg:186.37ms
+step:2405/4150 train_time:448266ms step_avg:186.39ms
+step:2406/4150 train_time:448500ms step_avg:186.41ms
+step:2407/4150 train_time:448733ms step_avg:186.43ms
+step:2408/4150 train_time:448969ms step_avg:186.45ms
+step:2409/4150 train_time:449202ms step_avg:186.47ms
+step:2410/4150 train_time:449440ms step_avg:186.49ms
+step:2411/4150 train_time:449679ms step_avg:186.51ms
+step:2412/4150 train_time:449917ms step_avg:186.53ms
+step:2413/4150 train_time:450149ms step_avg:186.55ms
+step:2414/4150 train_time:450385ms step_avg:186.57ms
+step:2415/4150 train_time:450620ms step_avg:186.59ms
+step:2416/4150 train_time:450859ms step_avg:186.61ms
+step:2417/4150 train_time:451097ms step_avg:186.64ms
+step:2418/4150 train_time:451334ms step_avg:186.66ms
+step:2419/4150 train_time:451567ms step_avg:186.68ms
+step:2420/4150 train_time:451803ms step_avg:186.70ms
+step:2421/4150 train_time:452037ms step_avg:186.71ms
+step:2422/4150 train_time:452276ms step_avg:186.74ms
+step:2423/4150 train_time:452507ms step_avg:186.75ms
+step:2424/4150 train_time:452745ms step_avg:186.78ms
+step:2425/4150 train_time:452978ms step_avg:186.79ms
+step:2426/4150 train_time:453212ms step_avg:186.81ms
+step:2427/4150 train_time:453446ms step_avg:186.83ms
+step:2428/4150 train_time:453683ms step_avg:186.85ms
+step:2429/4150 train_time:453918ms step_avg:186.87ms
+step:2430/4150 train_time:454156ms step_avg:186.90ms
+step:2431/4150 train_time:454393ms step_avg:186.92ms
+step:2432/4150 train_time:454630ms step_avg:186.94ms
+step:2433/4150 train_time:454863ms step_avg:186.96ms
+step:2434/4150 train_time:455098ms step_avg:186.98ms
+step:2435/4150 train_time:455334ms step_avg:187.00ms
+step:2436/4150 train_time:455569ms step_avg:187.02ms
+step:2437/4150 train_time:455803ms step_avg:187.03ms
+step:2438/4150 train_time:456041ms step_avg:187.06ms
+step:2439/4150 train_time:456276ms step_avg:187.08ms
+step:2440/4150 train_time:456515ms step_avg:187.10ms
+step:2441/4150 train_time:456747ms step_avg:187.11ms
+step:2442/4150 train_time:456985ms step_avg:187.14ms
+step:2443/4150 train_time:457217ms step_avg:187.15ms
+step:2444/4150 train_time:457455ms step_avg:187.17ms
+step:2445/4150 train_time:457689ms step_avg:187.19ms
+step:2446/4150 train_time:457925ms step_avg:187.21ms
+step:2447/4150 train_time:458158ms step_avg:187.23ms
+step:2448/4150 train_time:458395ms step_avg:187.25ms
+step:2449/4150 train_time:458630ms step_avg:187.27ms
+step:2450/4150 train_time:458869ms step_avg:187.29ms
+step:2451/4150 train_time:459104ms step_avg:187.31ms
+step:2452/4150 train_time:459340ms step_avg:187.33ms
+step:2453/4150 train_time:459574ms step_avg:187.35ms
+step:2454/4150 train_time:459815ms step_avg:187.37ms
+step:2455/4150 train_time:460048ms step_avg:187.39ms
+step:2456/4150 train_time:460286ms step_avg:187.41ms
+step:2457/4150 train_time:460519ms step_avg:187.43ms
+step:2458/4150 train_time:460753ms step_avg:187.45ms
+step:2459/4150 train_time:460988ms step_avg:187.47ms
+step:2460/4150 train_time:461225ms step_avg:187.49ms
+step:2461/4150 train_time:461459ms step_avg:187.51ms
+step:2462/4150 train_time:461698ms step_avg:187.53ms
+step:2463/4150 train_time:461938ms step_avg:187.55ms
+step:2464/4150 train_time:462174ms step_avg:187.57ms
+step:2465/4150 train_time:462408ms step_avg:187.59ms
+step:2466/4150 train_time:462649ms step_avg:187.61ms
+step:2467/4150 train_time:462882ms step_avg:187.63ms
+step:2468/4150 train_time:463118ms step_avg:187.65ms
+step:2469/4150 train_time:463357ms step_avg:187.67ms
+step:2470/4150 train_time:463593ms step_avg:187.69ms
+step:2471/4150 train_time:463830ms step_avg:187.71ms
+step:2472/4150 train_time:464065ms step_avg:187.73ms
+step:2473/4150 train_time:464296ms step_avg:187.75ms
+step:2474/4150 train_time:464531ms step_avg:187.77ms
+step:2475/4150 train_time:464767ms step_avg:187.78ms
+step:2476/4150 train_time:465004ms step_avg:187.80ms
+step:2477/4150 train_time:465236ms step_avg:187.82ms
+step:2478/4150 train_time:465475ms step_avg:187.84ms
+step:2479/4150 train_time:465707ms step_avg:187.86ms
+step:2480/4150 train_time:465943ms step_avg:187.88ms
+step:2481/4150 train_time:466174ms step_avg:187.90ms
+step:2482/4150 train_time:466409ms step_avg:187.92ms
+step:2483/4150 train_time:466643ms step_avg:187.93ms
+step:2484/4150 train_time:466879ms step_avg:187.95ms
+step:2485/4150 train_time:467113ms step_avg:187.97ms
+step:2486/4150 train_time:467351ms step_avg:187.99ms
+step:2487/4150 train_time:467585ms step_avg:188.01ms
+step:2488/4150 train_time:467827ms step_avg:188.03ms
+step:2489/4150 train_time:468058ms step_avg:188.05ms
+step:2490/4150 train_time:468293ms step_avg:188.07ms
+step:2491/4150 train_time:468527ms step_avg:188.09ms
+step:2492/4150 train_time:468763ms step_avg:188.11ms
+step:2493/4150 train_time:468998ms step_avg:188.13ms
+step:2494/4150 train_time:469234ms step_avg:188.15ms
+step:2495/4150 train_time:469469ms step_avg:188.16ms
+step:2496/4150 train_time:469706ms step_avg:188.18ms
+step:2497/4150 train_time:469938ms step_avg:188.20ms
+step:2498/4150 train_time:470175ms step_avg:188.22ms
+step:2499/4150 train_time:470407ms step_avg:188.24ms
+step:2500/4150 train_time:470645ms step_avg:188.26ms
+step:2500/4150 val_loss:3.1071 train_time:470860ms step_avg:188.34ms
+step:2501/4150 train_time:470884ms step_avg:188.28ms
+step:2502/4150 train_time:471124ms step_avg:188.30ms
+step:2503/4150 train_time:471363ms step_avg:188.32ms
+step:2504/4150 train_time:471594ms step_avg:188.34ms
+step:2505/4150 train_time:471827ms step_avg:188.35ms
+step:2506/4150 train_time:472063ms step_avg:188.37ms
+step:2507/4150 train_time:472301ms step_avg:188.39ms
+step:2508/4150 train_time:472536ms step_avg:188.41ms
+step:2509/4150 train_time:472769ms step_avg:188.43ms
+step:2510/4150 train_time:473007ms step_avg:188.45ms
+step:2511/4150 train_time:473243ms step_avg:188.47ms
+step:2512/4150 train_time:473478ms step_avg:188.49ms
+step:2513/4150 train_time:473710ms step_avg:188.50ms
+step:2514/4150 train_time:473945ms step_avg:188.52ms
+step:2515/4150 train_time:474182ms step_avg:188.54ms
+step:2516/4150 train_time:474421ms step_avg:188.56ms
+step:2517/4150 train_time:474651ms step_avg:188.58ms
+step:2518/4150 train_time:474891ms step_avg:188.60ms
+step:2519/4150 train_time:475129ms step_avg:188.62ms
+step:2520/4150 train_time:475368ms step_avg:188.64ms
+step:2521/4150 train_time:475600ms step_avg:188.66ms
+step:2522/4150 train_time:475834ms step_avg:188.67ms
+step:2523/4150 train_time:476071ms step_avg:188.69ms
+step:2524/4150 train_time:476308ms step_avg:188.71ms
+step:2525/4150 train_time:476544ms step_avg:188.73ms
+step:2526/4150 train_time:476780ms step_avg:188.75ms
+step:2527/4150 train_time:477015ms step_avg:188.77ms
+step:2528/4150 train_time:477252ms step_avg:188.79ms
+step:2529/4150 train_time:477487ms step_avg:188.80ms
+step:2530/4150 train_time:477723ms step_avg:188.82ms
+step:2531/4150 train_time:477955ms step_avg:188.84ms
+step:2532/4150 train_time:478193ms step_avg:188.86ms
+step:2533/4150 train_time:478429ms step_avg:188.88ms
+step:2534/4150 train_time:478668ms step_avg:188.90ms
+step:2535/4150 train_time:478901ms step_avg:188.92ms
+step:2536/4150 train_time:479137ms step_avg:188.93ms
+step:2537/4150 train_time:479373ms step_avg:188.95ms
+step:2538/4150 train_time:479611ms step_avg:188.97ms
+step:2539/4150 train_time:479845ms step_avg:188.99ms
+step:2540/4150 train_time:480081ms step_avg:189.01ms
+step:2541/4150 train_time:480315ms step_avg:189.03ms
+step:2542/4150 train_time:480552ms step_avg:189.04ms
+step:2543/4150 train_time:480786ms step_avg:189.06ms
+step:2544/4150 train_time:481022ms step_avg:189.08ms
+step:2545/4150 train_time:481254ms step_avg:189.10ms
+step:2546/4150 train_time:481495ms step_avg:189.12ms
+step:2547/4150 train_time:481730ms step_avg:189.14ms
+step:2548/4150 train_time:481968ms step_avg:189.16ms
+step:2549/4150 train_time:482202ms step_avg:189.17ms
+step:2550/4150 train_time:482438ms step_avg:189.19ms
+step:2551/4150 train_time:482673ms step_avg:189.21ms
+step:2552/4150 train_time:482911ms step_avg:189.23ms
+step:2553/4150 train_time:483145ms step_avg:189.25ms
+step:2554/4150 train_time:483384ms step_avg:189.27ms
+step:2555/4150 train_time:483616ms step_avg:189.28ms
+step:2556/4150 train_time:483853ms step_avg:189.30ms
+step:2557/4150 train_time:484090ms step_avg:189.32ms
+step:2558/4150 train_time:484326ms step_avg:189.34ms
+step:2559/4150 train_time:484562ms step_avg:189.36ms
+step:2560/4150 train_time:484798ms step_avg:189.37ms
+step:2561/4150 train_time:485034ms step_avg:189.39ms
+step:2562/4150 train_time:485269ms step_avg:189.41ms
+step:2563/4150 train_time:485504ms step_avg:189.43ms
+step:2564/4150 train_time:485741ms step_avg:189.45ms
+step:2565/4150 train_time:485977ms step_avg:189.46ms
+step:2566/4150 train_time:486214ms step_avg:189.48ms
+step:2567/4150 train_time:486452ms step_avg:189.50ms
+step:2568/4150 train_time:486690ms step_avg:189.52ms
+step:2569/4150 train_time:486922ms step_avg:189.54ms
+step:2570/4150 train_time:487161ms step_avg:189.56ms
+step:2571/4150 train_time:487395ms step_avg:189.57ms
+step:2572/4150 train_time:487631ms step_avg:189.59ms
+step:2573/4150 train_time:487864ms step_avg:189.61ms
+step:2574/4150 train_time:488101ms step_avg:189.63ms
+step:2575/4150 train_time:488337ms step_avg:189.65ms
+step:2576/4150 train_time:488575ms step_avg:189.66ms
+step:2577/4150 train_time:488809ms step_avg:189.68ms
+step:2578/4150 train_time:489047ms step_avg:189.70ms
+step:2579/4150 train_time:489280ms step_avg:189.72ms
+step:2580/4150 train_time:489514ms step_avg:189.73ms
+step:2581/4150 train_time:489750ms step_avg:189.75ms
+step:2582/4150 train_time:489991ms step_avg:189.77ms
+step:2583/4150 train_time:490221ms step_avg:189.79ms
+step:2584/4150 train_time:490457ms step_avg:189.81ms
+step:2585/4150 train_time:490691ms step_avg:189.82ms
+step:2586/4150 train_time:490930ms step_avg:189.84ms
+step:2587/4150 train_time:491162ms step_avg:189.86ms
+step:2588/4150 train_time:491397ms step_avg:189.88ms
+step:2589/4150 train_time:491632ms step_avg:189.89ms
+step:2590/4150 train_time:491873ms step_avg:189.91ms
+step:2591/4150 train_time:492108ms step_avg:189.93ms
+step:2592/4150 train_time:492345ms step_avg:189.95ms
+step:2593/4150 train_time:492579ms step_avg:189.96ms
+step:2594/4150 train_time:492813ms step_avg:189.98ms
+step:2595/4150 train_time:493050ms step_avg:190.00ms
+step:2596/4150 train_time:493291ms step_avg:190.02ms
+step:2597/4150 train_time:493525ms step_avg:190.04ms
+step:2598/4150 train_time:493762ms step_avg:190.05ms
+step:2599/4150 train_time:493994ms step_avg:190.07ms
+step:2600/4150 train_time:494233ms step_avg:190.09ms
+step:2601/4150 train_time:494467ms step_avg:190.11ms
+step:2602/4150 train_time:494703ms step_avg:190.12ms
+step:2603/4150 train_time:494937ms step_avg:190.14ms
+step:2604/4150 train_time:495172ms step_avg:190.16ms
+step:2605/4150 train_time:495407ms step_avg:190.18ms
+step:2606/4150 train_time:495645ms step_avg:190.19ms
+step:2607/4150 train_time:495879ms step_avg:190.21ms
+step:2608/4150 train_time:496114ms step_avg:190.23ms
+step:2609/4150 train_time:496349ms step_avg:190.25ms
+step:2610/4150 train_time:496585ms step_avg:190.26ms
+step:2611/4150 train_time:496818ms step_avg:190.28ms
+step:2612/4150 train_time:497058ms step_avg:190.30ms
+step:2613/4150 train_time:497294ms step_avg:190.32ms
+step:2614/4150 train_time:497531ms step_avg:190.33ms
+step:2615/4150 train_time:497768ms step_avg:190.35ms
+step:2616/4150 train_time:498004ms step_avg:190.37ms
+step:2617/4150 train_time:498237ms step_avg:190.38ms
+step:2618/4150 train_time:498475ms step_avg:190.40ms
+step:2619/4150 train_time:498711ms step_avg:190.42ms
+step:2620/4150 train_time:498950ms step_avg:190.44ms
+step:2621/4150 train_time:499182ms step_avg:190.45ms
+step:2622/4150 train_time:499421ms step_avg:190.47ms
+step:2623/4150 train_time:499654ms step_avg:190.49ms
+step:2624/4150 train_time:499898ms step_avg:190.51ms
+step:2625/4150 train_time:500135ms step_avg:190.53ms
+step:2626/4150 train_time:500373ms step_avg:190.55ms
+step:2627/4150 train_time:500608ms step_avg:190.56ms
+step:2628/4150 train_time:500846ms step_avg:190.58ms
+step:2629/4150 train_time:501079ms step_avg:190.60ms
+step:2630/4150 train_time:501314ms step_avg:190.61ms
+step:2631/4150 train_time:501547ms step_avg:190.63ms
+step:2632/4150 train_time:501786ms step_avg:190.65ms
+step:2633/4150 train_time:502018ms step_avg:190.66ms
+step:2634/4150 train_time:502255ms step_avg:190.68ms
+step:2635/4150 train_time:502489ms step_avg:190.70ms
+step:2636/4150 train_time:502728ms step_avg:190.72ms
+step:2637/4150 train_time:502961ms step_avg:190.73ms
+step:2638/4150 train_time:503200ms step_avg:190.75ms
+step:2639/4150 train_time:503435ms step_avg:190.77ms
+step:2640/4150 train_time:503675ms step_avg:190.79ms
+step:2641/4150 train_time:503909ms step_avg:190.80ms
+step:2642/4150 train_time:504149ms step_avg:190.82ms
+step:2643/4150 train_time:504385ms step_avg:190.84ms
+step:2644/4150 train_time:504622ms step_avg:190.86ms
+step:2645/4150 train_time:504856ms step_avg:190.87ms
+step:2646/4150 train_time:505093ms step_avg:190.89ms
+step:2647/4150 train_time:505328ms step_avg:190.91ms
+step:2648/4150 train_time:505568ms step_avg:190.92ms
+step:2649/4150 train_time:505801ms step_avg:190.94ms
+step:2650/4150 train_time:506039ms step_avg:190.96ms
+step:2651/4150 train_time:506274ms step_avg:190.97ms
+step:2652/4150 train_time:506513ms step_avg:190.99ms
+step:2653/4150 train_time:506749ms step_avg:191.01ms
+step:2654/4150 train_time:506986ms step_avg:191.03ms
+step:2655/4150 train_time:507219ms step_avg:191.04ms
+step:2656/4150 train_time:507455ms step_avg:191.06ms
+step:2657/4150 train_time:507691ms step_avg:191.08ms
+step:2658/4150 train_time:507928ms step_avg:191.09ms
+step:2659/4150 train_time:508162ms step_avg:191.11ms
+step:2660/4150 train_time:508398ms step_avg:191.13ms
+step:2661/4150 train_time:508633ms step_avg:191.14ms
+step:2662/4150 train_time:508874ms step_avg:191.16ms
+step:2663/4150 train_time:509108ms step_avg:191.18ms
+step:2664/4150 train_time:509345ms step_avg:191.20ms
+step:2665/4150 train_time:509576ms step_avg:191.21ms
+step:2666/4150 train_time:509812ms step_avg:191.23ms
+step:2667/4150 train_time:510049ms step_avg:191.24ms
+step:2668/4150 train_time:510287ms step_avg:191.26ms
+step:2669/4150 train_time:510521ms step_avg:191.28ms
+step:2670/4150 train_time:510758ms step_avg:191.29ms
+step:2671/4150 train_time:510991ms step_avg:191.31ms
+step:2672/4150 train_time:511229ms step_avg:191.33ms
+step:2673/4150 train_time:511464ms step_avg:191.34ms
+step:2674/4150 train_time:511698ms step_avg:191.36ms
+step:2675/4150 train_time:511931ms step_avg:191.38ms
+step:2676/4150 train_time:512171ms step_avg:191.39ms
+step:2677/4150 train_time:512404ms step_avg:191.41ms
+step:2678/4150 train_time:512638ms step_avg:191.43ms
+step:2679/4150 train_time:512870ms step_avg:191.44ms
+step:2680/4150 train_time:513110ms step_avg:191.46ms
+step:2681/4150 train_time:513343ms step_avg:191.47ms
+step:2682/4150 train_time:513580ms step_avg:191.49ms
+step:2683/4150 train_time:513811ms step_avg:191.51ms
+step:2684/4150 train_time:514050ms step_avg:191.52ms
+step:2685/4150 train_time:514282ms step_avg:191.54ms
+step:2686/4150 train_time:514518ms step_avg:191.56ms
+step:2687/4150 train_time:514756ms step_avg:191.57ms
+step:2688/4150 train_time:514993ms step_avg:191.59ms
+step:2689/4150 train_time:515230ms step_avg:191.61ms
+step:2690/4150 train_time:515470ms step_avg:191.62ms
+step:2691/4150 train_time:515702ms step_avg:191.64ms
+step:2692/4150 train_time:515939ms step_avg:191.66ms
+step:2693/4150 train_time:516174ms step_avg:191.67ms
+step:2694/4150 train_time:516414ms step_avg:191.69ms
+step:2695/4150 train_time:516650ms step_avg:191.71ms
+step:2696/4150 train_time:516886ms step_avg:191.72ms
+step:2697/4150 train_time:517121ms step_avg:191.74ms
+step:2698/4150 train_time:517359ms step_avg:191.76ms
+step:2699/4150 train_time:517594ms step_avg:191.77ms
+step:2700/4150 train_time:517829ms step_avg:191.79ms
+step:2701/4150 train_time:518059ms step_avg:191.80ms
+step:2702/4150 train_time:518299ms step_avg:191.82ms
+step:2703/4150 train_time:518536ms step_avg:191.84ms
+step:2704/4150 train_time:518775ms step_avg:191.85ms
+step:2705/4150 train_time:519008ms step_avg:191.87ms
+step:2706/4150 train_time:519247ms step_avg:191.89ms
+step:2707/4150 train_time:519482ms step_avg:191.90ms
+step:2708/4150 train_time:519718ms step_avg:191.92ms
+step:2709/4150 train_time:519954ms step_avg:191.94ms
+step:2710/4150 train_time:520191ms step_avg:191.95ms
+step:2711/4150 train_time:520422ms step_avg:191.97ms
+step:2712/4150 train_time:520661ms step_avg:191.98ms
+step:2713/4150 train_time:520893ms step_avg:192.00ms
+step:2714/4150 train_time:521128ms step_avg:192.01ms
+step:2715/4150 train_time:521363ms step_avg:192.03ms
+step:2716/4150 train_time:521603ms step_avg:192.05ms
+step:2717/4150 train_time:521835ms step_avg:192.06ms
+step:2718/4150 train_time:522071ms step_avg:192.08ms
+step:2719/4150 train_time:522306ms step_avg:192.09ms
+step:2720/4150 train_time:522543ms step_avg:192.11ms
+step:2721/4150 train_time:522778ms step_avg:192.13ms
+step:2722/4150 train_time:523013ms step_avg:192.14ms
+step:2723/4150 train_time:523247ms step_avg:192.16ms
+step:2724/4150 train_time:523488ms step_avg:192.18ms
+step:2725/4150 train_time:523720ms step_avg:192.19ms
+step:2726/4150 train_time:523957ms step_avg:192.21ms
+step:2727/4150 train_time:524194ms step_avg:192.22ms
+step:2728/4150 train_time:524429ms step_avg:192.24ms
+step:2729/4150 train_time:524665ms step_avg:192.26ms
+step:2730/4150 train_time:524901ms step_avg:192.27ms
+step:2731/4150 train_time:525134ms step_avg:192.29ms
+step:2732/4150 train_time:525372ms step_avg:192.30ms
+step:2733/4150 train_time:525608ms step_avg:192.32ms
+step:2734/4150 train_time:525845ms step_avg:192.34ms
+step:2735/4150 train_time:526076ms step_avg:192.35ms
+step:2736/4150 train_time:526312ms step_avg:192.37ms
+step:2737/4150 train_time:526546ms step_avg:192.38ms
+step:2738/4150 train_time:526782ms step_avg:192.40ms
+step:2739/4150 train_time:527017ms step_avg:192.41ms
+step:2740/4150 train_time:527254ms step_avg:192.43ms
+step:2741/4150 train_time:527489ms step_avg:192.44ms
+step:2742/4150 train_time:527726ms step_avg:192.46ms
+step:2743/4150 train_time:527960ms step_avg:192.48ms
+step:2744/4150 train_time:528197ms step_avg:192.49ms
+step:2745/4150 train_time:528430ms step_avg:192.51ms
+step:2746/4150 train_time:528668ms step_avg:192.52ms
+step:2747/4150 train_time:528900ms step_avg:192.54ms
+step:2748/4150 train_time:529137ms step_avg:192.55ms
+step:2749/4150 train_time:529375ms step_avg:192.57ms
+step:2750/4150 train_time:529614ms step_avg:192.59ms
+step:2750/4150 val_loss:3.0736 train_time:529832ms step_avg:192.67ms
+step:2751/4150 train_time:529859ms step_avg:192.61ms
+step:2752/4150 train_time:530096ms step_avg:192.62ms
+step:2753/4150 train_time:530330ms step_avg:192.64ms
+step:2754/4150 train_time:530562ms step_avg:192.65ms
+step:2755/4150 train_time:530795ms step_avg:192.67ms
+step:2756/4150 train_time:531033ms step_avg:192.68ms
+step:2757/4150 train_time:531268ms step_avg:192.70ms
+step:2758/4150 train_time:531505ms step_avg:192.71ms
+step:2759/4150 train_time:531738ms step_avg:192.73ms
+step:2760/4150 train_time:531976ms step_avg:192.74ms
+step:2761/4150 train_time:532213ms step_avg:192.76ms
+step:2762/4150 train_time:532450ms step_avg:192.78ms
+step:2763/4150 train_time:532684ms step_avg:192.79ms
+step:2764/4150 train_time:532920ms step_avg:192.81ms
+step:2765/4150 train_time:533156ms step_avg:192.82ms
+step:2766/4150 train_time:533392ms step_avg:192.84ms
+step:2767/4150 train_time:533627ms step_avg:192.85ms
+step:2768/4150 train_time:533865ms step_avg:192.87ms
+step:2769/4150 train_time:534101ms step_avg:192.89ms
+step:2770/4150 train_time:534338ms step_avg:192.90ms
+step:2771/4150 train_time:534571ms step_avg:192.92ms
+step:2772/4150 train_time:534808ms step_avg:192.93ms
+step:2773/4150 train_time:535042ms step_avg:192.95ms
+step:2774/4150 train_time:535279ms step_avg:192.96ms
+step:2775/4150 train_time:535513ms step_avg:192.98ms
+step:2776/4150 train_time:535752ms step_avg:192.99ms
+step:2777/4150 train_time:535989ms step_avg:193.01ms
+step:2778/4150 train_time:536227ms step_avg:193.03ms
+step:2779/4150 train_time:536463ms step_avg:193.04ms
+step:2780/4150 train_time:536701ms step_avg:193.06ms
+step:2781/4150 train_time:536934ms step_avg:193.07ms
+step:2782/4150 train_time:537171ms step_avg:193.09ms
+step:2783/4150 train_time:537404ms step_avg:193.10ms
+step:2784/4150 train_time:537646ms step_avg:193.12ms
+step:2785/4150 train_time:537878ms step_avg:193.13ms
+step:2786/4150 train_time:538115ms step_avg:193.15ms
+step:2787/4150 train_time:538350ms step_avg:193.16ms
+step:2788/4150 train_time:538592ms step_avg:193.18ms
+step:2789/4150 train_time:538827ms step_avg:193.20ms
+step:2790/4150 train_time:539065ms step_avg:193.21ms
+step:2791/4150 train_time:539302ms step_avg:193.23ms
+step:2792/4150 train_time:539538ms step_avg:193.24ms
+step:2793/4150 train_time:539772ms step_avg:193.26ms
+step:2794/4150 train_time:540008ms step_avg:193.27ms
+step:2795/4150 train_time:540244ms step_avg:193.29ms
+step:2796/4150 train_time:540481ms step_avg:193.31ms
+step:2797/4150 train_time:540714ms step_avg:193.32ms
+step:2798/4150 train_time:540950ms step_avg:193.33ms
+step:2799/4150 train_time:541189ms step_avg:193.35ms
+step:2800/4150 train_time:541430ms step_avg:193.37ms
+step:2801/4150 train_time:541664ms step_avg:193.38ms
+step:2802/4150 train_time:541900ms step_avg:193.40ms
+step:2803/4150 train_time:542133ms step_avg:193.41ms
+step:2804/4150 train_time:542368ms step_avg:193.43ms
+step:2805/4150 train_time:542603ms step_avg:193.44ms
+step:2806/4150 train_time:542839ms step_avg:193.46ms
+step:2807/4150 train_time:543074ms step_avg:193.47ms
+step:2808/4150 train_time:543310ms step_avg:193.49ms
+step:2809/4150 train_time:543546ms step_avg:193.50ms
+step:2810/4150 train_time:543788ms step_avg:193.52ms
+step:2811/4150 train_time:544021ms step_avg:193.53ms
+step:2812/4150 train_time:544258ms step_avg:193.55ms
+step:2813/4150 train_time:544491ms step_avg:193.56ms
+step:2814/4150 train_time:544730ms step_avg:193.58ms
+step:2815/4150 train_time:544967ms step_avg:193.59ms
+step:2816/4150 train_time:545207ms step_avg:193.61ms
+step:2817/4150 train_time:545443ms step_avg:193.63ms
+step:2818/4150 train_time:545682ms step_avg:193.64ms
+step:2819/4150 train_time:545914ms step_avg:193.66ms
+step:2820/4150 train_time:546151ms step_avg:193.67ms
+step:2821/4150 train_time:546387ms step_avg:193.69ms
+step:2822/4150 train_time:546627ms step_avg:193.70ms
+step:2823/4150 train_time:546858ms step_avg:193.72ms
+step:2824/4150 train_time:547096ms step_avg:193.73ms
+step:2825/4150 train_time:547334ms step_avg:193.75ms
+step:2826/4150 train_time:547569ms step_avg:193.76ms
+step:2827/4150 train_time:547802ms step_avg:193.77ms
+step:2828/4150 train_time:548040ms step_avg:193.79ms
+step:2829/4150 train_time:548274ms step_avg:193.80ms
+step:2830/4150 train_time:548511ms step_avg:193.82ms
+step:2831/4150 train_time:548749ms step_avg:193.84ms
+step:2832/4150 train_time:548991ms step_avg:193.85ms
+step:2833/4150 train_time:549224ms step_avg:193.87ms
+step:2834/4150 train_time:549461ms step_avg:193.88ms
+step:2835/4150 train_time:549695ms step_avg:193.90ms
+step:2836/4150 train_time:549934ms step_avg:193.91ms
+step:2837/4150 train_time:550166ms step_avg:193.93ms
+step:2838/4150 train_time:550408ms step_avg:193.94ms
+step:2839/4150 train_time:550644ms step_avg:193.96ms
+step:2840/4150 train_time:550882ms step_avg:193.97ms
+step:2841/4150 train_time:551115ms step_avg:193.99ms
+step:2842/4150 train_time:551350ms step_avg:194.00ms
+step:2843/4150 train_time:551586ms step_avg:194.02ms
+step:2844/4150 train_time:551825ms step_avg:194.03ms
+step:2845/4150 train_time:552060ms step_avg:194.05ms
+step:2846/4150 train_time:552296ms step_avg:194.06ms
+step:2847/4150 train_time:552532ms step_avg:194.08ms
+step:2848/4150 train_time:552768ms step_avg:194.09ms
+step:2849/4150 train_time:553001ms step_avg:194.10ms
+step:2850/4150 train_time:553240ms step_avg:194.12ms
+step:2851/4150 train_time:553471ms step_avg:194.13ms
+step:2852/4150 train_time:553706ms step_avg:194.15ms
+step:2853/4150 train_time:553942ms step_avg:194.16ms
+step:2854/4150 train_time:554180ms step_avg:194.18ms
+step:2855/4150 train_time:554414ms step_avg:194.19ms
+step:2856/4150 train_time:554651ms step_avg:194.21ms
+step:2857/4150 train_time:554888ms step_avg:194.22ms
+step:2858/4150 train_time:555125ms step_avg:194.24ms
+step:2859/4150 train_time:555360ms step_avg:194.25ms
+step:2860/4150 train_time:555598ms step_avg:194.27ms
+step:2861/4150 train_time:555833ms step_avg:194.28ms
+step:2862/4150 train_time:556070ms step_avg:194.29ms
+step:2863/4150 train_time:556306ms step_avg:194.31ms
+step:2864/4150 train_time:556544ms step_avg:194.32ms
+step:2865/4150 train_time:556778ms step_avg:194.34ms
+step:2866/4150 train_time:557015ms step_avg:194.35ms
+step:2867/4150 train_time:557247ms step_avg:194.37ms
+step:2868/4150 train_time:557484ms step_avg:194.38ms
+step:2869/4150 train_time:557718ms step_avg:194.39ms
+step:2870/4150 train_time:557956ms step_avg:194.41ms
+step:2871/4150 train_time:558191ms step_avg:194.42ms
+step:2872/4150 train_time:558428ms step_avg:194.44ms
+step:2873/4150 train_time:558663ms step_avg:194.45ms
+step:2874/4150 train_time:558900ms step_avg:194.47ms
+step:2875/4150 train_time:559138ms step_avg:194.48ms
+step:2876/4150 train_time:559373ms step_avg:194.50ms
+step:2877/4150 train_time:559607ms step_avg:194.51ms
+step:2878/4150 train_time:559847ms step_avg:194.53ms
+step:2879/4150 train_time:560082ms step_avg:194.54ms
+step:2880/4150 train_time:560321ms step_avg:194.56ms
+step:2881/4150 train_time:560555ms step_avg:194.57ms
+step:2882/4150 train_time:560791ms step_avg:194.58ms
+step:2883/4150 train_time:561026ms step_avg:194.60ms
+step:2884/4150 train_time:561265ms step_avg:194.61ms
+step:2885/4150 train_time:561498ms step_avg:194.63ms
+step:2886/4150 train_time:561734ms step_avg:194.64ms
+step:2887/4150 train_time:561969ms step_avg:194.66ms
+step:2888/4150 train_time:562208ms step_avg:194.67ms
+step:2889/4150 train_time:562442ms step_avg:194.68ms
+step:2890/4150 train_time:562681ms step_avg:194.70ms
+step:2891/4150 train_time:562914ms step_avg:194.71ms
+step:2892/4150 train_time:563152ms step_avg:194.73ms
+step:2893/4150 train_time:563384ms step_avg:194.74ms
+step:2894/4150 train_time:563620ms step_avg:194.75ms
+step:2895/4150 train_time:563854ms step_avg:194.77ms
+step:2896/4150 train_time:564091ms step_avg:194.78ms
+step:2897/4150 train_time:564329ms step_avg:194.80ms
+step:2898/4150 train_time:564565ms step_avg:194.81ms
+step:2899/4150 train_time:564800ms step_avg:194.83ms
+step:2900/4150 train_time:565036ms step_avg:194.84ms
+step:2901/4150 train_time:565270ms step_avg:194.85ms
+step:2902/4150 train_time:565508ms step_avg:194.87ms
+step:2903/4150 train_time:565740ms step_avg:194.88ms
+step:2904/4150 train_time:565978ms step_avg:194.90ms
+step:2905/4150 train_time:566209ms step_avg:194.91ms
+step:2906/4150 train_time:566446ms step_avg:194.92ms
+step:2907/4150 train_time:566680ms step_avg:194.94ms
+step:2908/4150 train_time:566919ms step_avg:194.95ms
+step:2909/4150 train_time:567155ms step_avg:194.97ms
+step:2910/4150 train_time:567391ms step_avg:194.98ms
+step:2911/4150 train_time:567626ms step_avg:194.99ms
+step:2912/4150 train_time:567863ms step_avg:195.01ms
+step:2913/4150 train_time:568096ms step_avg:195.02ms
+step:2914/4150 train_time:568332ms step_avg:195.03ms
+step:2915/4150 train_time:568568ms step_avg:195.05ms
+step:2916/4150 train_time:568804ms step_avg:195.06ms
+step:2917/4150 train_time:569036ms step_avg:195.08ms
+step:2918/4150 train_time:569278ms step_avg:195.09ms
+step:2919/4150 train_time:569514ms step_avg:195.11ms
+step:2920/4150 train_time:569749ms step_avg:195.12ms
+step:2921/4150 train_time:569987ms step_avg:195.13ms
+step:2922/4150 train_time:570224ms step_avg:195.15ms
+step:2923/4150 train_time:570460ms step_avg:195.16ms
+step:2924/4150 train_time:570698ms step_avg:195.18ms
+step:2925/4150 train_time:570932ms step_avg:195.19ms
+step:2926/4150 train_time:571166ms step_avg:195.20ms
+step:2927/4150 train_time:571399ms step_avg:195.22ms
+step:2928/4150 train_time:571636ms step_avg:195.23ms
+step:2929/4150 train_time:571874ms step_avg:195.25ms
+step:2930/4150 train_time:572112ms step_avg:195.26ms
+step:2931/4150 train_time:572348ms step_avg:195.27ms
+step:2932/4150 train_time:572587ms step_avg:195.29ms
+step:2933/4150 train_time:572820ms step_avg:195.30ms
+step:2934/4150 train_time:573059ms step_avg:195.32ms
+step:2935/4150 train_time:573294ms step_avg:195.33ms
+step:2936/4150 train_time:573534ms step_avg:195.35ms
+step:2937/4150 train_time:573769ms step_avg:195.36ms
+step:2938/4150 train_time:574003ms step_avg:195.37ms
+step:2939/4150 train_time:574239ms step_avg:195.39ms
+step:2940/4150 train_time:574477ms step_avg:195.40ms
+step:2941/4150 train_time:574714ms step_avg:195.41ms
+step:2942/4150 train_time:574952ms step_avg:195.43ms
+step:2943/4150 train_time:575189ms step_avg:195.44ms
+step:2944/4150 train_time:575426ms step_avg:195.46ms
+step:2945/4150 train_time:575661ms step_avg:195.47ms
+step:2946/4150 train_time:575899ms step_avg:195.49ms
+step:2947/4150 train_time:576134ms step_avg:195.50ms
+step:2948/4150 train_time:576369ms step_avg:195.51ms
+step:2949/4150 train_time:576603ms step_avg:195.52ms
+step:2950/4150 train_time:576841ms step_avg:195.54ms
+step:2951/4150 train_time:577074ms step_avg:195.55ms
+step:2952/4150 train_time:577312ms step_avg:195.57ms
+step:2953/4150 train_time:577549ms step_avg:195.58ms
+step:2954/4150 train_time:577790ms step_avg:195.60ms
+step:2955/4150 train_time:578028ms step_avg:195.61ms
+step:2956/4150 train_time:578265ms step_avg:195.62ms
+step:2957/4150 train_time:578498ms step_avg:195.64ms
+step:2958/4150 train_time:578735ms step_avg:195.65ms
+step:2959/4150 train_time:578972ms step_avg:195.66ms
+step:2960/4150 train_time:579211ms step_avg:195.68ms
+step:2961/4150 train_time:579448ms step_avg:195.69ms
+step:2962/4150 train_time:579686ms step_avg:195.71ms
+step:2963/4150 train_time:579920ms step_avg:195.72ms
+step:2964/4150 train_time:580158ms step_avg:195.73ms
+step:2965/4150 train_time:580393ms step_avg:195.75ms
+step:2966/4150 train_time:580630ms step_avg:195.76ms
+step:2967/4150 train_time:580868ms step_avg:195.78ms
+step:2968/4150 train_time:581106ms step_avg:195.79ms
+step:2969/4150 train_time:581343ms step_avg:195.80ms
+step:2970/4150 train_time:581584ms step_avg:195.82ms
+step:2971/4150 train_time:581817ms step_avg:195.83ms
+step:2972/4150 train_time:582054ms step_avg:195.85ms
+step:2973/4150 train_time:582288ms step_avg:195.86ms
+step:2974/4150 train_time:582526ms step_avg:195.87ms
+step:2975/4150 train_time:582761ms step_avg:195.89ms
+step:2976/4150 train_time:582998ms step_avg:195.90ms
+step:2977/4150 train_time:583233ms step_avg:195.91ms
+step:2978/4150 train_time:583467ms step_avg:195.93ms
+step:2979/4150 train_time:583699ms step_avg:195.94ms
+step:2980/4150 train_time:583938ms step_avg:195.95ms
+step:2981/4150 train_time:584171ms step_avg:195.96ms
+step:2982/4150 train_time:584410ms step_avg:195.98ms
+step:2983/4150 train_time:584643ms step_avg:195.99ms
+step:2984/4150 train_time:584885ms step_avg:196.01ms
+step:2985/4150 train_time:585120ms step_avg:196.02ms
+step:2986/4150 train_time:585359ms step_avg:196.03ms
+step:2987/4150 train_time:585594ms step_avg:196.05ms
+step:2988/4150 train_time:585831ms step_avg:196.06ms
+step:2989/4150 train_time:586066ms step_avg:196.07ms
+step:2990/4150 train_time:586305ms step_avg:196.09ms
+step:2991/4150 train_time:586540ms step_avg:196.10ms
+step:2992/4150 train_time:586779ms step_avg:196.12ms
+step:2993/4150 train_time:587010ms step_avg:196.13ms
+step:2994/4150 train_time:587248ms step_avg:196.14ms
+step:2995/4150 train_time:587481ms step_avg:196.15ms
+step:2996/4150 train_time:587718ms step_avg:196.17ms
+step:2997/4150 train_time:587954ms step_avg:196.18ms
+step:2998/4150 train_time:588190ms step_avg:196.19ms
+step:2999/4150 train_time:588426ms step_avg:196.21ms
+step:3000/4150 train_time:588667ms step_avg:196.22ms
+step:3000/4150 val_loss:3.0415 train_time:588883ms step_avg:196.29ms
+step:3001/4150 train_time:588907ms step_avg:196.24ms
+step:3002/4150 train_time:589149ms step_avg:196.25ms
+step:3003/4150 train_time:589386ms step_avg:196.27ms
+step:3004/4150 train_time:589619ms step_avg:196.28ms
+step:3005/4150 train_time:589851ms step_avg:196.29ms
+step:3006/4150 train_time:590088ms step_avg:196.30ms
+step:3007/4150 train_time:590327ms step_avg:196.32ms
+step:3008/4150 train_time:590567ms step_avg:196.33ms
+step:3009/4150 train_time:590799ms step_avg:196.34ms
+step:3010/4150 train_time:591037ms step_avg:196.36ms
+step:3011/4150 train_time:591275ms step_avg:196.37ms
+step:3012/4150 train_time:591515ms step_avg:196.39ms
+step:3013/4150 train_time:591748ms step_avg:196.40ms
+step:3014/4150 train_time:591986ms step_avg:196.41ms
+step:3015/4150 train_time:592223ms step_avg:196.43ms
+step:3016/4150 train_time:592458ms step_avg:196.44ms
+step:3017/4150 train_time:592693ms step_avg:196.45ms
+step:3018/4150 train_time:592928ms step_avg:196.46ms
+step:3019/4150 train_time:593164ms step_avg:196.48ms
+step:3020/4150 train_time:593403ms step_avg:196.49ms
+step:3021/4150 train_time:593639ms step_avg:196.50ms
+step:3022/4150 train_time:593874ms step_avg:196.52ms
+step:3023/4150 train_time:594111ms step_avg:196.53ms
+step:3024/4150 train_time:594349ms step_avg:196.54ms
+step:3025/4150 train_time:594581ms step_avg:196.56ms
+step:3026/4150 train_time:594816ms step_avg:196.57ms
+step:3027/4150 train_time:595052ms step_avg:196.58ms
+step:3028/4150 train_time:595288ms step_avg:196.59ms
+step:3029/4150 train_time:595520ms step_avg:196.61ms
+step:3030/4150 train_time:595760ms step_avg:196.62ms
+step:3031/4150 train_time:595995ms step_avg:196.63ms
+step:3032/4150 train_time:596232ms step_avg:196.65ms
+step:3033/4150 train_time:596466ms step_avg:196.66ms
+step:3034/4150 train_time:596704ms step_avg:196.67ms
+step:3035/4150 train_time:596942ms step_avg:196.69ms
+step:3036/4150 train_time:597178ms step_avg:196.70ms
+step:3037/4150 train_time:597413ms step_avg:196.71ms
+step:3038/4150 train_time:597649ms step_avg:196.72ms
+step:3039/4150 train_time:597882ms step_avg:196.74ms
+step:3040/4150 train_time:598121ms step_avg:196.75ms
+step:3041/4150 train_time:598360ms step_avg:196.76ms
+step:3042/4150 train_time:598595ms step_avg:196.78ms
+step:3043/4150 train_time:598830ms step_avg:196.79ms
+step:3044/4150 train_time:599066ms step_avg:196.80ms
+step:3045/4150 train_time:599303ms step_avg:196.82ms
+step:3046/4150 train_time:599540ms step_avg:196.83ms
+step:3047/4150 train_time:599777ms step_avg:196.84ms
+step:3048/4150 train_time:600015ms step_avg:196.86ms
+step:3049/4150 train_time:600249ms step_avg:196.87ms
+step:3050/4150 train_time:600488ms step_avg:196.88ms
+step:3051/4150 train_time:600723ms step_avg:196.89ms
+step:3052/4150 train_time:600962ms step_avg:196.91ms
+step:3053/4150 train_time:601195ms step_avg:196.92ms
+step:3054/4150 train_time:601433ms step_avg:196.93ms
+step:3055/4150 train_time:601667ms step_avg:196.94ms
+step:3056/4150 train_time:601905ms step_avg:196.96ms
+step:3057/4150 train_time:602141ms step_avg:196.97ms
+step:3058/4150 train_time:602376ms step_avg:196.98ms
+step:3059/4150 train_time:602613ms step_avg:197.00ms
+step:3060/4150 train_time:602851ms step_avg:197.01ms
+step:3061/4150 train_time:603085ms step_avg:197.02ms
+step:3062/4150 train_time:603324ms step_avg:197.04ms
+step:3063/4150 train_time:603560ms step_avg:197.05ms
+step:3064/4150 train_time:603800ms step_avg:197.06ms
+step:3065/4150 train_time:604034ms step_avg:197.07ms
+step:3066/4150 train_time:604272ms step_avg:197.09ms
+step:3067/4150 train_time:604506ms step_avg:197.10ms
+step:3068/4150 train_time:604743ms step_avg:197.11ms
+step:3069/4150 train_time:604974ms step_avg:197.12ms
+step:3070/4150 train_time:605211ms step_avg:197.14ms
+step:3071/4150 train_time:605446ms step_avg:197.15ms
+step:3072/4150 train_time:605684ms step_avg:197.16ms
+step:3073/4150 train_time:605917ms step_avg:197.17ms
+step:3074/4150 train_time:606154ms step_avg:197.19ms
+step:3075/4150 train_time:606391ms step_avg:197.20ms
+step:3076/4150 train_time:606628ms step_avg:197.21ms
+step:3077/4150 train_time:606862ms step_avg:197.23ms
+step:3078/4150 train_time:607103ms step_avg:197.24ms
+step:3079/4150 train_time:607338ms step_avg:197.25ms
+step:3080/4150 train_time:607575ms step_avg:197.26ms
+step:3081/4150 train_time:607809ms step_avg:197.28ms
+step:3082/4150 train_time:608047ms step_avg:197.29ms
+step:3083/4150 train_time:608280ms step_avg:197.30ms
+step:3084/4150 train_time:608519ms step_avg:197.31ms
+step:3085/4150 train_time:608755ms step_avg:197.33ms
+step:3086/4150 train_time:608994ms step_avg:197.34ms
+step:3087/4150 train_time:609227ms step_avg:197.35ms
+step:3088/4150 train_time:609464ms step_avg:197.37ms
+step:3089/4150 train_time:609696ms step_avg:197.38ms
+step:3090/4150 train_time:609934ms step_avg:197.39ms
+step:3091/4150 train_time:610167ms step_avg:197.40ms
+step:3092/4150 train_time:610404ms step_avg:197.41ms
+step:3093/4150 train_time:610640ms step_avg:197.43ms
+step:3094/4150 train_time:610878ms step_avg:197.44ms
+step:3095/4150 train_time:611112ms step_avg:197.45ms
+step:3096/4150 train_time:611348ms step_avg:197.46ms
+step:3097/4150 train_time:611585ms step_avg:197.48ms
+step:3098/4150 train_time:611822ms step_avg:197.49ms
+step:3099/4150 train_time:612057ms step_avg:197.50ms
+step:3100/4150 train_time:612291ms step_avg:197.51ms
+step:3101/4150 train_time:612527ms step_avg:197.53ms
+step:3102/4150 train_time:612762ms step_avg:197.54ms
+step:3103/4150 train_time:612998ms step_avg:197.55ms
+step:3104/4150 train_time:613236ms step_avg:197.56ms
+step:3105/4150 train_time:613470ms step_avg:197.57ms
+step:3106/4150 train_time:613708ms step_avg:197.59ms
+step:3107/4150 train_time:613944ms step_avg:197.60ms
+step:3108/4150 train_time:614185ms step_avg:197.61ms
+step:3109/4150 train_time:614421ms step_avg:197.63ms
+step:3110/4150 train_time:614659ms step_avg:197.64ms
+step:3111/4150 train_time:614896ms step_avg:197.65ms
+step:3112/4150 train_time:615134ms step_avg:197.67ms
+step:3113/4150 train_time:615369ms step_avg:197.68ms
+step:3114/4150 train_time:615605ms step_avg:197.69ms
+step:3115/4150 train_time:615843ms step_avg:197.70ms
+step:3116/4150 train_time:616081ms step_avg:197.72ms
+step:3117/4150 train_time:616315ms step_avg:197.73ms
+step:3118/4150 train_time:616553ms step_avg:197.74ms
+step:3119/4150 train_time:616787ms step_avg:197.75ms
+step:3120/4150 train_time:617030ms step_avg:197.77ms
+step:3121/4150 train_time:617267ms step_avg:197.78ms
+step:3122/4150 train_time:617502ms step_avg:197.79ms
+step:3123/4150 train_time:617737ms step_avg:197.80ms
+step:3124/4150 train_time:617974ms step_avg:197.82ms
+step:3125/4150 train_time:618209ms step_avg:197.83ms
+step:3126/4150 train_time:618446ms step_avg:197.84ms
+step:3127/4150 train_time:618681ms step_avg:197.85ms
+step:3128/4150 train_time:618919ms step_avg:197.86ms
+step:3129/4150 train_time:619152ms step_avg:197.88ms
+step:3130/4150 train_time:619391ms step_avg:197.89ms
+step:3131/4150 train_time:619624ms step_avg:197.90ms
+step:3132/4150 train_time:619858ms step_avg:197.91ms
+step:3133/4150 train_time:620095ms step_avg:197.92ms
+step:3134/4150 train_time:620334ms step_avg:197.94ms
+step:3135/4150 train_time:620570ms step_avg:197.95ms
+step:3136/4150 train_time:620808ms step_avg:197.96ms
+step:3137/4150 train_time:621045ms step_avg:197.97ms
+step:3138/4150 train_time:621284ms step_avg:197.99ms
+step:3139/4150 train_time:621518ms step_avg:198.00ms
+step:3140/4150 train_time:621759ms step_avg:198.01ms
+step:3141/4150 train_time:621991ms step_avg:198.02ms
+step:3142/4150 train_time:622230ms step_avg:198.04ms
+step:3143/4150 train_time:622461ms step_avg:198.05ms
+step:3144/4150 train_time:622702ms step_avg:198.06ms
+step:3145/4150 train_time:622941ms step_avg:198.07ms
+step:3146/4150 train_time:623179ms step_avg:198.09ms
+step:3147/4150 train_time:623412ms step_avg:198.10ms
+step:3148/4150 train_time:623649ms step_avg:198.11ms
+step:3149/4150 train_time:623883ms step_avg:198.12ms
+step:3150/4150 train_time:624124ms step_avg:198.13ms
+step:3151/4150 train_time:624360ms step_avg:198.15ms
+step:3152/4150 train_time:624596ms step_avg:198.16ms
+step:3153/4150 train_time:624831ms step_avg:198.17ms
+step:3154/4150 train_time:625068ms step_avg:198.18ms
+step:3155/4150 train_time:625304ms step_avg:198.19ms
+step:3156/4150 train_time:625542ms step_avg:198.21ms
+step:3157/4150 train_time:625778ms step_avg:198.22ms
+step:3158/4150 train_time:626018ms step_avg:198.23ms
+step:3159/4150 train_time:626254ms step_avg:198.24ms
+step:3160/4150 train_time:626498ms step_avg:198.26ms
+step:3161/4150 train_time:626732ms step_avg:198.27ms
+step:3162/4150 train_time:626968ms step_avg:198.28ms
+step:3163/4150 train_time:627203ms step_avg:198.29ms
+step:3164/4150 train_time:627443ms step_avg:198.31ms
+step:3165/4150 train_time:627677ms step_avg:198.32ms
+step:3166/4150 train_time:627911ms step_avg:198.33ms
+step:3167/4150 train_time:628145ms step_avg:198.34ms
+step:3168/4150 train_time:628384ms step_avg:198.35ms
+step:3169/4150 train_time:628618ms step_avg:198.36ms
+step:3170/4150 train_time:628855ms step_avg:198.38ms
+step:3171/4150 train_time:629088ms step_avg:198.39ms
+step:3172/4150 train_time:629325ms step_avg:198.40ms
+step:3173/4150 train_time:629562ms step_avg:198.41ms
+step:3174/4150 train_time:629801ms step_avg:198.43ms
+step:3175/4150 train_time:630036ms step_avg:198.44ms
+step:3176/4150 train_time:630276ms step_avg:198.45ms
+step:3177/4150 train_time:630509ms step_avg:198.46ms
+step:3178/4150 train_time:630745ms step_avg:198.47ms
+step:3179/4150 train_time:630982ms step_avg:198.48ms
+step:3180/4150 train_time:631221ms step_avg:198.50ms
+step:3181/4150 train_time:631455ms step_avg:198.51ms
+step:3182/4150 train_time:631692ms step_avg:198.52ms
+step:3183/4150 train_time:631928ms step_avg:198.53ms
+step:3184/4150 train_time:632165ms step_avg:198.54ms
+step:3185/4150 train_time:632399ms step_avg:198.56ms
+step:3186/4150 train_time:632635ms step_avg:198.57ms
+step:3187/4150 train_time:632869ms step_avg:198.58ms
+step:3188/4150 train_time:633106ms step_avg:198.59ms
+step:3189/4150 train_time:633341ms step_avg:198.60ms
+step:3190/4150 train_time:633577ms step_avg:198.61ms
+step:3191/4150 train_time:633811ms step_avg:198.62ms
+step:3192/4150 train_time:634048ms step_avg:198.64ms
+step:3193/4150 train_time:634284ms step_avg:198.65ms
+step:3194/4150 train_time:634518ms step_avg:198.66ms
+step:3195/4150 train_time:634754ms step_avg:198.67ms
+step:3196/4150 train_time:634989ms step_avg:198.68ms
+step:3197/4150 train_time:635223ms step_avg:198.69ms
+step:3198/4150 train_time:635459ms step_avg:198.71ms
+step:3199/4150 train_time:635694ms step_avg:198.72ms
+step:3200/4150 train_time:635930ms step_avg:198.73ms
+step:3201/4150 train_time:636165ms step_avg:198.74ms
+step:3202/4150 train_time:636404ms step_avg:198.75ms
+step:3203/4150 train_time:636637ms step_avg:198.76ms
+step:3204/4150 train_time:636877ms step_avg:198.78ms
+step:3205/4150 train_time:637111ms step_avg:198.79ms
+step:3206/4150 train_time:637352ms step_avg:198.80ms
+step:3207/4150 train_time:637585ms step_avg:198.81ms
+step:3208/4150 train_time:637823ms step_avg:198.82ms
+step:3209/4150 train_time:638060ms step_avg:198.83ms
+step:3210/4150 train_time:638296ms step_avg:198.85ms
+step:3211/4150 train_time:638532ms step_avg:198.86ms
+step:3212/4150 train_time:638771ms step_avg:198.87ms
+step:3213/4150 train_time:639004ms step_avg:198.88ms
+step:3214/4150 train_time:639241ms step_avg:198.89ms
+step:3215/4150 train_time:639477ms step_avg:198.90ms
+step:3216/4150 train_time:639712ms step_avg:198.92ms
+step:3217/4150 train_time:639950ms step_avg:198.93ms
+step:3218/4150 train_time:640184ms step_avg:198.94ms
+step:3219/4150 train_time:640420ms step_avg:198.95ms
+step:3220/4150 train_time:640657ms step_avg:198.96ms
+step:3221/4150 train_time:640890ms step_avg:198.97ms
+step:3222/4150 train_time:641125ms step_avg:198.98ms
+step:3223/4150 train_time:641360ms step_avg:198.99ms
+step:3224/4150 train_time:641599ms step_avg:199.01ms
+step:3225/4150 train_time:641833ms step_avg:199.02ms
+step:3226/4150 train_time:642072ms step_avg:199.03ms
+step:3227/4150 train_time:642307ms step_avg:199.04ms
+step:3228/4150 train_time:642544ms step_avg:199.05ms
+step:3229/4150 train_time:642779ms step_avg:199.06ms
+step:3230/4150 train_time:643015ms step_avg:199.08ms
+step:3231/4150 train_time:643251ms step_avg:199.09ms
+step:3232/4150 train_time:643486ms step_avg:199.10ms
+step:3233/4150 train_time:643722ms step_avg:199.11ms
+step:3234/4150 train_time:643959ms step_avg:199.12ms
+step:3235/4150 train_time:644192ms step_avg:199.13ms
+step:3236/4150 train_time:644429ms step_avg:199.14ms
+step:3237/4150 train_time:644662ms step_avg:199.15ms
+step:3238/4150 train_time:644900ms step_avg:199.17ms
+step:3239/4150 train_time:645137ms step_avg:199.18ms
+step:3240/4150 train_time:645376ms step_avg:199.19ms
+step:3241/4150 train_time:645610ms step_avg:199.20ms
+step:3242/4150 train_time:645850ms step_avg:199.21ms
+step:3243/4150 train_time:646083ms step_avg:199.22ms
+step:3244/4150 train_time:646320ms step_avg:199.24ms
+step:3245/4150 train_time:646558ms step_avg:199.25ms
+step:3246/4150 train_time:646795ms step_avg:199.26ms
+step:3247/4150 train_time:647031ms step_avg:199.27ms
+step:3248/4150 train_time:647269ms step_avg:199.28ms
+step:3249/4150 train_time:647505ms step_avg:199.29ms
+step:3250/4150 train_time:647740ms step_avg:199.30ms
+step:3250/4150 val_loss:3.0096 train_time:647955ms step_avg:199.37ms
+step:3251/4150 train_time:647978ms step_avg:199.32ms
+step:3252/4150 train_time:648218ms step_avg:199.33ms
+step:3253/4150 train_time:648455ms step_avg:199.34ms
+step:3254/4150 train_time:648690ms step_avg:199.35ms
+step:3255/4150 train_time:648922ms step_avg:199.36ms
+step:3256/4150 train_time:649161ms step_avg:199.37ms
+step:3257/4150 train_time:649401ms step_avg:199.39ms
+step:3258/4150 train_time:649638ms step_avg:199.40ms
+step:3259/4150 train_time:649869ms step_avg:199.41ms
+step:3260/4150 train_time:650106ms step_avg:199.42ms
+step:3261/4150 train_time:650342ms step_avg:199.43ms
+step:3262/4150 train_time:650579ms step_avg:199.44ms
+step:3263/4150 train_time:650814ms step_avg:199.45ms
+step:3264/4150 train_time:651053ms step_avg:199.46ms
+step:3265/4150 train_time:651288ms step_avg:199.48ms
+step:3266/4150 train_time:651533ms step_avg:199.49ms
+step:3267/4150 train_time:651767ms step_avg:199.50ms
+step:3268/4150 train_time:652004ms step_avg:199.51ms
+step:3269/4150 train_time:652236ms step_avg:199.52ms
+step:3270/4150 train_time:652474ms step_avg:199.53ms
+step:3271/4150 train_time:652711ms step_avg:199.54ms
+step:3272/4150 train_time:652950ms step_avg:199.56ms
+step:3273/4150 train_time:653185ms step_avg:199.57ms
+step:3274/4150 train_time:653422ms step_avg:199.58ms
+step:3275/4150 train_time:653655ms step_avg:199.59ms
+step:3276/4150 train_time:653898ms step_avg:199.60ms
+step:3277/4150 train_time:654135ms step_avg:199.61ms
+step:3278/4150 train_time:654370ms step_avg:199.62ms
+step:3279/4150 train_time:654607ms step_avg:199.64ms
+step:3280/4150 train_time:654845ms step_avg:199.65ms
+step:3281/4150 train_time:655079ms step_avg:199.66ms
+step:3282/4150 train_time:655316ms step_avg:199.67ms
+step:3283/4150 train_time:655550ms step_avg:199.68ms
+step:3284/4150 train_time:655789ms step_avg:199.69ms
+step:3285/4150 train_time:656023ms step_avg:199.70ms
+step:3286/4150 train_time:656261ms step_avg:199.71ms
+step:3287/4150 train_time:656494ms step_avg:199.72ms
+step:3288/4150 train_time:656732ms step_avg:199.74ms
+step:3289/4150 train_time:656968ms step_avg:199.75ms
+step:3290/4150 train_time:657206ms step_avg:199.76ms
+step:3291/4150 train_time:657444ms step_avg:199.77ms
+step:3292/4150 train_time:657680ms step_avg:199.78ms
+step:3293/4150 train_time:657914ms step_avg:199.79ms
+step:3294/4150 train_time:658154ms step_avg:199.80ms
+step:3295/4150 train_time:658392ms step_avg:199.82ms
+step:3296/4150 train_time:658629ms step_avg:199.83ms
+step:3297/4150 train_time:658865ms step_avg:199.84ms
+step:3298/4150 train_time:659103ms step_avg:199.85ms
+step:3299/4150 train_time:659338ms step_avg:199.86ms
+step:3300/4150 train_time:659575ms step_avg:199.87ms
+step:3301/4150 train_time:659809ms step_avg:199.88ms
+step:3302/4150 train_time:660046ms step_avg:199.89ms
+step:3303/4150 train_time:660279ms step_avg:199.90ms
+step:3304/4150 train_time:660517ms step_avg:199.91ms
+step:3305/4150 train_time:660750ms step_avg:199.92ms
+step:3306/4150 train_time:660987ms step_avg:199.94ms
+step:3307/4150 train_time:661221ms step_avg:199.95ms
+step:3308/4150 train_time:661460ms step_avg:199.96ms
+step:3309/4150 train_time:661695ms step_avg:199.97ms
+step:3310/4150 train_time:661931ms step_avg:199.98ms
+step:3311/4150 train_time:662166ms step_avg:199.99ms
+step:3312/4150 train_time:662403ms step_avg:200.00ms
+step:3313/4150 train_time:662640ms step_avg:200.01ms
+step:3314/4150 train_time:662877ms step_avg:200.02ms
+step:3315/4150 train_time:663117ms step_avg:200.04ms
+step:3316/4150 train_time:663354ms step_avg:200.05ms
+step:3317/4150 train_time:663591ms step_avg:200.06ms
+step:3318/4150 train_time:663829ms step_avg:200.07ms
+step:3319/4150 train_time:664068ms step_avg:200.08ms
+step:3320/4150 train_time:664308ms step_avg:200.09ms
+step:3321/4150 train_time:664541ms step_avg:200.10ms
+step:3322/4150 train_time:664778ms step_avg:200.11ms
+step:3323/4150 train_time:665012ms step_avg:200.12ms
+step:3324/4150 train_time:665251ms step_avg:200.14ms
+step:3325/4150 train_time:665485ms step_avg:200.15ms
+step:3326/4150 train_time:665723ms step_avg:200.16ms
+step:3327/4150 train_time:665958ms step_avg:200.17ms
+step:3328/4150 train_time:666196ms step_avg:200.18ms
+step:3329/4150 train_time:666434ms step_avg:200.19ms
+step:3330/4150 train_time:666672ms step_avg:200.20ms
+step:3331/4150 train_time:666908ms step_avg:200.21ms
+step:3332/4150 train_time:667148ms step_avg:200.22ms
+step:3333/4150 train_time:667386ms step_avg:200.24ms
+step:3334/4150 train_time:667622ms step_avg:200.25ms
+step:3335/4150 train_time:667857ms step_avg:200.26ms
+step:3336/4150 train_time:668096ms step_avg:200.27ms
+step:3337/4150 train_time:668329ms step_avg:200.28ms
+step:3338/4150 train_time:668567ms step_avg:200.29ms
+step:3339/4150 train_time:668801ms step_avg:200.30ms
+step:3340/4150 train_time:669036ms step_avg:200.31ms
+step:3341/4150 train_time:669275ms step_avg:200.32ms
+step:3342/4150 train_time:669513ms step_avg:200.33ms
+step:3343/4150 train_time:669750ms step_avg:200.34ms
+step:3344/4150 train_time:669987ms step_avg:200.36ms
+step:3345/4150 train_time:670220ms step_avg:200.36ms
+step:3346/4150 train_time:670460ms step_avg:200.38ms
+step:3347/4150 train_time:670693ms step_avg:200.39ms
+step:3348/4150 train_time:670931ms step_avg:200.40ms
+step:3349/4150 train_time:671167ms step_avg:200.41ms
+step:3350/4150 train_time:671406ms step_avg:200.42ms
+step:3351/4150 train_time:671639ms step_avg:200.43ms
+step:3352/4150 train_time:671879ms step_avg:200.44ms
+step:3353/4150 train_time:672113ms step_avg:200.45ms
+step:3354/4150 train_time:672351ms step_avg:200.46ms
+step:3355/4150 train_time:672585ms step_avg:200.47ms
+step:3356/4150 train_time:672825ms step_avg:200.48ms
+step:3357/4150 train_time:673060ms step_avg:200.49ms
+step:3358/4150 train_time:673297ms step_avg:200.51ms
+step:3359/4150 train_time:673536ms step_avg:200.52ms
+step:3360/4150 train_time:673772ms step_avg:200.53ms
+step:3361/4150 train_time:674007ms step_avg:200.54ms
+step:3362/4150 train_time:674247ms step_avg:200.55ms
+step:3363/4150 train_time:674481ms step_avg:200.56ms
+step:3364/4150 train_time:674721ms step_avg:200.57ms
+step:3365/4150 train_time:674956ms step_avg:200.58ms
+step:3366/4150 train_time:675194ms step_avg:200.59ms
+step:3367/4150 train_time:675424ms step_avg:200.60ms
+step:3368/4150 train_time:675661ms step_avg:200.61ms
+step:3369/4150 train_time:675895ms step_avg:200.62ms
+step:3370/4150 train_time:676134ms step_avg:200.63ms
+step:3371/4150 train_time:676369ms step_avg:200.64ms
+step:3372/4150 train_time:676606ms step_avg:200.65ms
+step:3373/4150 train_time:676839ms step_avg:200.66ms
+step:3374/4150 train_time:677076ms step_avg:200.67ms
+step:3375/4150 train_time:677311ms step_avg:200.68ms
+step:3376/4150 train_time:677552ms step_avg:200.70ms
+step:3377/4150 train_time:677787ms step_avg:200.71ms
+step:3378/4150 train_time:678027ms step_avg:200.72ms
+step:3379/4150 train_time:678263ms step_avg:200.73ms
+step:3380/4150 train_time:678499ms step_avg:200.74ms
+step:3381/4150 train_time:678732ms step_avg:200.75ms
+step:3382/4150 train_time:678969ms step_avg:200.76ms
+step:3383/4150 train_time:679201ms step_avg:200.77ms
+step:3384/4150 train_time:679438ms step_avg:200.78ms
+step:3385/4150 train_time:679678ms step_avg:200.79ms
+step:3386/4150 train_time:679917ms step_avg:200.80ms
+step:3387/4150 train_time:680151ms step_avg:200.81ms
+step:3388/4150 train_time:680391ms step_avg:200.82ms
+step:3389/4150 train_time:680625ms step_avg:200.83ms
+step:3390/4150 train_time:680861ms step_avg:200.84ms
+step:3391/4150 train_time:681095ms step_avg:200.85ms
+step:3392/4150 train_time:681334ms step_avg:200.86ms
+step:3393/4150 train_time:681571ms step_avg:200.88ms
+step:3394/4150 train_time:681811ms step_avg:200.89ms
+step:3395/4150 train_time:682046ms step_avg:200.90ms
+step:3396/4150 train_time:682283ms step_avg:200.91ms
+step:3397/4150 train_time:682520ms step_avg:200.92ms
+step:3398/4150 train_time:682757ms step_avg:200.93ms
+step:3399/4150 train_time:682990ms step_avg:200.94ms
+step:3400/4150 train_time:683229ms step_avg:200.95ms
+step:3401/4150 train_time:683466ms step_avg:200.96ms
+step:3402/4150 train_time:683706ms step_avg:200.97ms
+step:3403/4150 train_time:683942ms step_avg:200.98ms
+step:3404/4150 train_time:684178ms step_avg:200.99ms
+step:3405/4150 train_time:684412ms step_avg:201.00ms
+step:3406/4150 train_time:684650ms step_avg:201.01ms
+step:3407/4150 train_time:684884ms step_avg:201.02ms
+step:3408/4150 train_time:685123ms step_avg:201.03ms
+step:3409/4150 train_time:685358ms step_avg:201.04ms
+step:3410/4150 train_time:685600ms step_avg:201.06ms
+step:3411/4150 train_time:685832ms step_avg:201.06ms
+step:3412/4150 train_time:686072ms step_avg:201.08ms
+step:3413/4150 train_time:686307ms step_avg:201.09ms
+step:3414/4150 train_time:686546ms step_avg:201.10ms
+step:3415/4150 train_time:686782ms step_avg:201.11ms
+step:3416/4150 train_time:687018ms step_avg:201.12ms
+step:3417/4150 train_time:687252ms step_avg:201.13ms
+step:3418/4150 train_time:687492ms step_avg:201.14ms
+step:3419/4150 train_time:687728ms step_avg:201.15ms
+step:3420/4150 train_time:687963ms step_avg:201.16ms
+step:3421/4150 train_time:688198ms step_avg:201.17ms
+step:3422/4150 train_time:688436ms step_avg:201.18ms
+step:3423/4150 train_time:688672ms step_avg:201.19ms
+step:3424/4150 train_time:688907ms step_avg:201.20ms
+step:3425/4150 train_time:689142ms step_avg:201.21ms
+step:3426/4150 train_time:689379ms step_avg:201.22ms
+step:3427/4150 train_time:689615ms step_avg:201.23ms
+step:3428/4150 train_time:689849ms step_avg:201.24ms
+step:3429/4150 train_time:690085ms step_avg:201.25ms
+step:3430/4150 train_time:690325ms step_avg:201.26ms
+step:3431/4150 train_time:690561ms step_avg:201.27ms
+step:3432/4150 train_time:690797ms step_avg:201.28ms
+step:3433/4150 train_time:691030ms step_avg:201.29ms
+step:3434/4150 train_time:691269ms step_avg:201.30ms
+step:3435/4150 train_time:691503ms step_avg:201.31ms
+step:3436/4150 train_time:691743ms step_avg:201.32ms
+step:3437/4150 train_time:691979ms step_avg:201.33ms
+step:3438/4150 train_time:692219ms step_avg:201.34ms
+step:3439/4150 train_time:692453ms step_avg:201.35ms
+step:3440/4150 train_time:692694ms step_avg:201.36ms
+step:3441/4150 train_time:692932ms step_avg:201.38ms
+step:3442/4150 train_time:693169ms step_avg:201.39ms
+step:3443/4150 train_time:693402ms step_avg:201.39ms
+step:3444/4150 train_time:693639ms step_avg:201.41ms
+step:3445/4150 train_time:693876ms step_avg:201.42ms
+step:3446/4150 train_time:694113ms step_avg:201.43ms
+step:3447/4150 train_time:694348ms step_avg:201.44ms
+step:3448/4150 train_time:694584ms step_avg:201.45ms
+step:3449/4150 train_time:694818ms step_avg:201.45ms
+step:3450/4150 train_time:695055ms step_avg:201.47ms
+step:3451/4150 train_time:695287ms step_avg:201.47ms
+step:3452/4150 train_time:695526ms step_avg:201.48ms
+step:3453/4150 train_time:695762ms step_avg:201.49ms
+step:3454/4150 train_time:696001ms step_avg:201.51ms
+step:3455/4150 train_time:696238ms step_avg:201.52ms
+step:3456/4150 train_time:696478ms step_avg:201.53ms
+step:3457/4150 train_time:696714ms step_avg:201.54ms
+step:3458/4150 train_time:696952ms step_avg:201.55ms
+step:3459/4150 train_time:697189ms step_avg:201.56ms
+step:3460/4150 train_time:697428ms step_avg:201.57ms
+step:3461/4150 train_time:697660ms step_avg:201.58ms
+step:3462/4150 train_time:697897ms step_avg:201.59ms
+step:3463/4150 train_time:698133ms step_avg:201.60ms
+step:3464/4150 train_time:698372ms step_avg:201.61ms
+step:3465/4150 train_time:698606ms step_avg:201.62ms
+step:3466/4150 train_time:698846ms step_avg:201.63ms
+step:3467/4150 train_time:699079ms step_avg:201.64ms
+step:3468/4150 train_time:699316ms step_avg:201.65ms
+step:3469/4150 train_time:699550ms step_avg:201.66ms
+step:3470/4150 train_time:699787ms step_avg:201.67ms
+step:3471/4150 train_time:700020ms step_avg:201.68ms
+step:3472/4150 train_time:700261ms step_avg:201.69ms
+step:3473/4150 train_time:700494ms step_avg:201.70ms
+step:3474/4150 train_time:700729ms step_avg:201.71ms
+step:3475/4150 train_time:700963ms step_avg:201.72ms
+step:3476/4150 train_time:701201ms step_avg:201.73ms
+step:3477/4150 train_time:701434ms step_avg:201.74ms
+step:3478/4150 train_time:701670ms step_avg:201.75ms
+step:3479/4150 train_time:701904ms step_avg:201.75ms
+step:3480/4150 train_time:702146ms step_avg:201.77ms
+step:3481/4150 train_time:702381ms step_avg:201.78ms
+step:3482/4150 train_time:702615ms step_avg:201.78ms
+step:3483/4150 train_time:702851ms step_avg:201.79ms
+step:3484/4150 train_time:703087ms step_avg:201.80ms
+step:3485/4150 train_time:703323ms step_avg:201.81ms
+step:3486/4150 train_time:703560ms step_avg:201.82ms
+step:3487/4150 train_time:703795ms step_avg:201.83ms
+step:3488/4150 train_time:704032ms step_avg:201.84ms
+step:3489/4150 train_time:704267ms step_avg:201.85ms
+step:3490/4150 train_time:704505ms step_avg:201.86ms
+step:3491/4150 train_time:704740ms step_avg:201.87ms
+step:3492/4150 train_time:704975ms step_avg:201.88ms
+step:3493/4150 train_time:705211ms step_avg:201.89ms
+step:3494/4150 train_time:705450ms step_avg:201.90ms
+step:3495/4150 train_time:705687ms step_avg:201.91ms
+step:3496/4150 train_time:705925ms step_avg:201.92ms
+step:3497/4150 train_time:706160ms step_avg:201.93ms
+step:3498/4150 train_time:706396ms step_avg:201.94ms
+step:3499/4150 train_time:706630ms step_avg:201.95ms
+step:3500/4150 train_time:706869ms step_avg:201.96ms
+step:3500/4150 val_loss:2.9787 train_time:707087ms step_avg:202.02ms
+step:3501/4150 train_time:707110ms step_avg:201.97ms
+step:3502/4150 train_time:707349ms step_avg:201.98ms
+step:3503/4150 train_time:707585ms step_avg:201.99ms
+step:3504/4150 train_time:707819ms step_avg:202.00ms
+step:3505/4150 train_time:708049ms step_avg:202.01ms
+step:3506/4150 train_time:708289ms step_avg:202.02ms
+step:3507/4150 train_time:708526ms step_avg:202.03ms
+step:3508/4150 train_time:708765ms step_avg:202.04ms
+step:3509/4150 train_time:708999ms step_avg:202.05ms
+step:3510/4150 train_time:709242ms step_avg:202.06ms
+step:3511/4150 train_time:709478ms step_avg:202.07ms
+step:3512/4150 train_time:709715ms step_avg:202.08ms
+step:3513/4150 train_time:709947ms step_avg:202.09ms
+step:3514/4150 train_time:710184ms step_avg:202.10ms
+step:3515/4150 train_time:710421ms step_avg:202.11ms
+step:3516/4150 train_time:710658ms step_avg:202.12ms
+step:3517/4150 train_time:710893ms step_avg:202.13ms
+step:3518/4150 train_time:711128ms step_avg:202.14ms
+step:3519/4150 train_time:711362ms step_avg:202.15ms
+step:3520/4150 train_time:711601ms step_avg:202.16ms
+step:3521/4150 train_time:711833ms step_avg:202.17ms
+step:3522/4150 train_time:712071ms step_avg:202.18ms
+step:3523/4150 train_time:712307ms step_avg:202.19ms
+step:3524/4150 train_time:712545ms step_avg:202.20ms
+step:3525/4150 train_time:712778ms step_avg:202.21ms
+step:3526/4150 train_time:713014ms step_avg:202.22ms
+step:3527/4150 train_time:713248ms step_avg:202.23ms
+step:3528/4150 train_time:713485ms step_avg:202.23ms
+step:3529/4150 train_time:713721ms step_avg:202.24ms
+step:3530/4150 train_time:713957ms step_avg:202.25ms
+step:3531/4150 train_time:714192ms step_avg:202.26ms
+step:3532/4150 train_time:714429ms step_avg:202.27ms
+step:3533/4150 train_time:714663ms step_avg:202.28ms
+step:3534/4150 train_time:714903ms step_avg:202.29ms
+step:3535/4150 train_time:715136ms step_avg:202.30ms
+step:3536/4150 train_time:715376ms step_avg:202.31ms
+step:3537/4150 train_time:715613ms step_avg:202.32ms
+step:3538/4150 train_time:715851ms step_avg:202.33ms
+step:3539/4150 train_time:716085ms step_avg:202.34ms
+step:3540/4150 train_time:716323ms step_avg:202.35ms
+step:3541/4150 train_time:716556ms step_avg:202.36ms
+step:3542/4150 train_time:716793ms step_avg:202.37ms
+step:3543/4150 train_time:717029ms step_avg:202.38ms
+step:3544/4150 train_time:717265ms step_avg:202.39ms
+step:3545/4150 train_time:717501ms step_avg:202.40ms
+step:3546/4150 train_time:717742ms step_avg:202.41ms
+step:3547/4150 train_time:717977ms step_avg:202.42ms
+step:3548/4150 train_time:718215ms step_avg:202.43ms
+step:3549/4150 train_time:718448ms step_avg:202.44ms
+step:3550/4150 train_time:718684ms step_avg:202.45ms
+step:3551/4150 train_time:718918ms step_avg:202.46ms
+step:3552/4150 train_time:719156ms step_avg:202.47ms
+step:3553/4150 train_time:719392ms step_avg:202.47ms
+step:3554/4150 train_time:719627ms step_avg:202.48ms
+step:3555/4150 train_time:719863ms step_avg:202.49ms
+step:3556/4150 train_time:720099ms step_avg:202.50ms
+step:3557/4150 train_time:720333ms step_avg:202.51ms
+step:3558/4150 train_time:720571ms step_avg:202.52ms
+step:3559/4150 train_time:720809ms step_avg:202.53ms
+step:3560/4150 train_time:721045ms step_avg:202.54ms
+step:3561/4150 train_time:721278ms step_avg:202.55ms
+step:3562/4150 train_time:721518ms step_avg:202.56ms
+step:3563/4150 train_time:721755ms step_avg:202.57ms
+step:3564/4150 train_time:721993ms step_avg:202.58ms
+step:3565/4150 train_time:722227ms step_avg:202.59ms
+step:3566/4150 train_time:722464ms step_avg:202.60ms
+step:3567/4150 train_time:722703ms step_avg:202.61ms
+step:3568/4150 train_time:722939ms step_avg:202.62ms
+step:3569/4150 train_time:723172ms step_avg:202.63ms
+step:3570/4150 train_time:723409ms step_avg:202.64ms
+step:3571/4150 train_time:723643ms step_avg:202.64ms
+step:3572/4150 train_time:723878ms step_avg:202.65ms
+step:3573/4150 train_time:724113ms step_avg:202.66ms
+step:3574/4150 train_time:724350ms step_avg:202.67ms
+step:3575/4150 train_time:724583ms step_avg:202.68ms
+step:3576/4150 train_time:724819ms step_avg:202.69ms
+step:3577/4150 train_time:725055ms step_avg:202.70ms
+step:3578/4150 train_time:725292ms step_avg:202.71ms
+step:3579/4150 train_time:725528ms step_avg:202.72ms
+step:3580/4150 train_time:725767ms step_avg:202.73ms
+step:3581/4150 train_time:726007ms step_avg:202.74ms
+step:3582/4150 train_time:726243ms step_avg:202.75ms
+step:3583/4150 train_time:726477ms step_avg:202.76ms
+step:3584/4150 train_time:726714ms step_avg:202.77ms
+step:3585/4150 train_time:726950ms step_avg:202.78ms
+step:3586/4150 train_time:727186ms step_avg:202.78ms
+step:3587/4150 train_time:727419ms step_avg:202.79ms
+step:3588/4150 train_time:727657ms step_avg:202.80ms
+step:3589/4150 train_time:727895ms step_avg:202.81ms
+step:3590/4150 train_time:728133ms step_avg:202.82ms
+step:3591/4150 train_time:728368ms step_avg:202.83ms
+step:3592/4150 train_time:728606ms step_avg:202.84ms
+step:3593/4150 train_time:728845ms step_avg:202.85ms
+step:3594/4150 train_time:729080ms step_avg:202.86ms
+step:3595/4150 train_time:729315ms step_avg:202.87ms
+step:3596/4150 train_time:729553ms step_avg:202.88ms
+step:3597/4150 train_time:729788ms step_avg:202.89ms
+step:3598/4150 train_time:730024ms step_avg:202.90ms
+step:3599/4150 train_time:730256ms step_avg:202.91ms
+step:3600/4150 train_time:730495ms step_avg:202.92ms
+step:3601/4150 train_time:730730ms step_avg:202.92ms
+step:3602/4150 train_time:730967ms step_avg:202.93ms
+step:3603/4150 train_time:731202ms step_avg:202.94ms
+step:3604/4150 train_time:731443ms step_avg:202.95ms
+step:3605/4150 train_time:731678ms step_avg:202.96ms
+step:3606/4150 train_time:731916ms step_avg:202.97ms
+step:3607/4150 train_time:732150ms step_avg:202.98ms
+step:3608/4150 train_time:732389ms step_avg:202.99ms
+step:3609/4150 train_time:732624ms step_avg:203.00ms
+step:3610/4150 train_time:732864ms step_avg:203.01ms
+step:3611/4150 train_time:733097ms step_avg:203.02ms
+step:3612/4150 train_time:733336ms step_avg:203.03ms
+step:3613/4150 train_time:733569ms step_avg:203.04ms
+step:3614/4150 train_time:733807ms step_avg:203.05ms
+step:3615/4150 train_time:734038ms step_avg:203.05ms
+step:3616/4150 train_time:734275ms step_avg:203.06ms
+step:3617/4150 train_time:734511ms step_avg:203.07ms
+step:3618/4150 train_time:734748ms step_avg:203.08ms
+step:3619/4150 train_time:734984ms step_avg:203.09ms
+step:3620/4150 train_time:735220ms step_avg:203.10ms
+step:3621/4150 train_time:735455ms step_avg:203.11ms
+step:3622/4150 train_time:735693ms step_avg:203.12ms
+step:3623/4150 train_time:735927ms step_avg:203.13ms
+step:3624/4150 train_time:736163ms step_avg:203.14ms
+step:3625/4150 train_time:736396ms step_avg:203.14ms
+step:3626/4150 train_time:736634ms step_avg:203.15ms
+step:3627/4150 train_time:736868ms step_avg:203.16ms
+step:3628/4150 train_time:737104ms step_avg:203.17ms
+step:3629/4150 train_time:737339ms step_avg:203.18ms
+step:3630/4150 train_time:737577ms step_avg:203.19ms
+step:3631/4150 train_time:737811ms step_avg:203.20ms
+step:3632/4150 train_time:738047ms step_avg:203.21ms
+step:3633/4150 train_time:738279ms step_avg:203.21ms
+step:3634/4150 train_time:738517ms step_avg:203.22ms
+step:3635/4150 train_time:738752ms step_avg:203.23ms
+step:3636/4150 train_time:738989ms step_avg:203.24ms
+step:3637/4150 train_time:739223ms step_avg:203.25ms
+step:3638/4150 train_time:739459ms step_avg:203.26ms
+step:3639/4150 train_time:739693ms step_avg:203.27ms
+step:3640/4150 train_time:739930ms step_avg:203.28ms
+step:3641/4150 train_time:740164ms step_avg:203.29ms
+step:3642/4150 train_time:740402ms step_avg:203.30ms
+step:3643/4150 train_time:740637ms step_avg:203.30ms
+step:3644/4150 train_time:740876ms step_avg:203.31ms
+step:3645/4150 train_time:741112ms step_avg:203.32ms
+step:3646/4150 train_time:741349ms step_avg:203.33ms
+step:3647/4150 train_time:741582ms step_avg:203.34ms
+step:3648/4150 train_time:741820ms step_avg:203.35ms
+step:3649/4150 train_time:742056ms step_avg:203.36ms
+step:3650/4150 train_time:742293ms step_avg:203.37ms
+step:3651/4150 train_time:742526ms step_avg:203.38ms
+step:3652/4150 train_time:742764ms step_avg:203.39ms
+step:3653/4150 train_time:742997ms step_avg:203.39ms
+step:3654/4150 train_time:743236ms step_avg:203.40ms
+step:3655/4150 train_time:743470ms step_avg:203.41ms
+step:3656/4150 train_time:743708ms step_avg:203.42ms
+step:3657/4150 train_time:743946ms step_avg:203.43ms
+step:3658/4150 train_time:744185ms step_avg:203.44ms
+step:3659/4150 train_time:744419ms step_avg:203.45ms
+step:3660/4150 train_time:744657ms step_avg:203.46ms
+step:3661/4150 train_time:744888ms step_avg:203.47ms
+step:3662/4150 train_time:745126ms step_avg:203.48ms
+step:3663/4150 train_time:745361ms step_avg:203.48ms
+step:3664/4150 train_time:745601ms step_avg:203.49ms
+step:3665/4150 train_time:745838ms step_avg:203.50ms
+step:3666/4150 train_time:746076ms step_avg:203.51ms
+step:3667/4150 train_time:746310ms step_avg:203.52ms
+step:3668/4150 train_time:746548ms step_avg:203.53ms
+step:3669/4150 train_time:746785ms step_avg:203.54ms
+step:3670/4150 train_time:747023ms step_avg:203.55ms
+step:3671/4150 train_time:747257ms step_avg:203.56ms
+step:3672/4150 train_time:747493ms step_avg:203.57ms
+step:3673/4150 train_time:747728ms step_avg:203.57ms
+step:3674/4150 train_time:747969ms step_avg:203.58ms
+step:3675/4150 train_time:748205ms step_avg:203.59ms
+step:3676/4150 train_time:748443ms step_avg:203.60ms
+step:3677/4150 train_time:748680ms step_avg:203.61ms
+step:3678/4150 train_time:748917ms step_avg:203.62ms
+step:3679/4150 train_time:749152ms step_avg:203.63ms
+step:3680/4150 train_time:749388ms step_avg:203.64ms
+step:3681/4150 train_time:749621ms step_avg:203.65ms
+step:3682/4150 train_time:749862ms step_avg:203.66ms
+step:3683/4150 train_time:750097ms step_avg:203.66ms
+step:3684/4150 train_time:750335ms step_avg:203.67ms
+step:3685/4150 train_time:750569ms step_avg:203.68ms
+step:3686/4150 train_time:750805ms step_avg:203.69ms
+step:3687/4150 train_time:751038ms step_avg:203.70ms
+step:3688/4150 train_time:751276ms step_avg:203.71ms
+step:3689/4150 train_time:751509ms step_avg:203.72ms
+step:3690/4150 train_time:751747ms step_avg:203.73ms
+step:3691/4150 train_time:751983ms step_avg:203.73ms
+step:3692/4150 train_time:752220ms step_avg:203.74ms
+step:3693/4150 train_time:752456ms step_avg:203.75ms
+step:3694/4150 train_time:752693ms step_avg:203.76ms
+step:3695/4150 train_time:752927ms step_avg:203.77ms
+step:3696/4150 train_time:753163ms step_avg:203.78ms
+step:3697/4150 train_time:753396ms step_avg:203.79ms
+step:3698/4150 train_time:753636ms step_avg:203.80ms
+step:3699/4150 train_time:753868ms step_avg:203.80ms
+step:3700/4150 train_time:754107ms step_avg:203.81ms
+step:3701/4150 train_time:754342ms step_avg:203.82ms
+step:3702/4150 train_time:754581ms step_avg:203.83ms
+step:3703/4150 train_time:754817ms step_avg:203.84ms
+step:3704/4150 train_time:755054ms step_avg:203.85ms
+step:3705/4150 train_time:755289ms step_avg:203.86ms
+step:3706/4150 train_time:755528ms step_avg:203.87ms
+step:3707/4150 train_time:755761ms step_avg:203.87ms
+step:3708/4150 train_time:755999ms step_avg:203.88ms
+step:3709/4150 train_time:756235ms step_avg:203.89ms
+step:3710/4150 train_time:756473ms step_avg:203.90ms
+step:3711/4150 train_time:756708ms step_avg:203.91ms
+step:3712/4150 train_time:756947ms step_avg:203.92ms
+step:3713/4150 train_time:757179ms step_avg:203.93ms
+step:3714/4150 train_time:757416ms step_avg:203.94ms
+step:3715/4150 train_time:757656ms step_avg:203.95ms
+step:3716/4150 train_time:757893ms step_avg:203.95ms
+step:3717/4150 train_time:758127ms step_avg:203.96ms
+step:3718/4150 train_time:758364ms step_avg:203.97ms
+step:3719/4150 train_time:758603ms step_avg:203.98ms
+step:3720/4150 train_time:758842ms step_avg:203.99ms
+step:3721/4150 train_time:759078ms step_avg:204.00ms
+step:3722/4150 train_time:759314ms step_avg:204.01ms
+step:3723/4150 train_time:759551ms step_avg:204.02ms
+step:3724/4150 train_time:759787ms step_avg:204.02ms
+step:3725/4150 train_time:760025ms step_avg:204.03ms
+step:3726/4150 train_time:760259ms step_avg:204.04ms
+step:3727/4150 train_time:760496ms step_avg:204.05ms
+step:3728/4150 train_time:760735ms step_avg:204.06ms
+step:3729/4150 train_time:760972ms step_avg:204.07ms
+step:3730/4150 train_time:761206ms step_avg:204.08ms
+step:3731/4150 train_time:761442ms step_avg:204.09ms
+step:3732/4150 train_time:761682ms step_avg:204.09ms
+step:3733/4150 train_time:761918ms step_avg:204.10ms
+step:3734/4150 train_time:762158ms step_avg:204.11ms
+step:3735/4150 train_time:762392ms step_avg:204.12ms
+step:3736/4150 train_time:762629ms step_avg:204.13ms
+step:3737/4150 train_time:762862ms step_avg:204.14ms
+step:3738/4150 train_time:763107ms step_avg:204.15ms
+step:3739/4150 train_time:763343ms step_avg:204.16ms
+step:3740/4150 train_time:763582ms step_avg:204.17ms
+step:3741/4150 train_time:763819ms step_avg:204.18ms
+step:3742/4150 train_time:764055ms step_avg:204.18ms
+step:3743/4150 train_time:764289ms step_avg:204.19ms
+step:3744/4150 train_time:764525ms step_avg:204.20ms
+step:3745/4150 train_time:764763ms step_avg:204.21ms
+step:3746/4150 train_time:764999ms step_avg:204.22ms
+step:3747/4150 train_time:765234ms step_avg:204.23ms
+step:3748/4150 train_time:765471ms step_avg:204.23ms
+step:3749/4150 train_time:765708ms step_avg:204.24ms
+step:3750/4150 train_time:765946ms step_avg:204.25ms
+step:3750/4150 val_loss:2.9512 train_time:766160ms step_avg:204.31ms
+step:3751/4150 train_time:766183ms step_avg:204.26ms
+step:3752/4150 train_time:766421ms step_avg:204.27ms
+step:3753/4150 train_time:766653ms step_avg:204.28ms
+step:3754/4150 train_time:766887ms step_avg:204.29ms
+step:3755/4150 train_time:767122ms step_avg:204.29ms
+step:3756/4150 train_time:767363ms step_avg:204.30ms
+step:3757/4150 train_time:767600ms step_avg:204.31ms
+step:3758/4150 train_time:767834ms step_avg:204.32ms
+step:3759/4150 train_time:768066ms step_avg:204.33ms
+step:3760/4150 train_time:768305ms step_avg:204.34ms
+step:3761/4150 train_time:768542ms step_avg:204.34ms
+step:3762/4150 train_time:768776ms step_avg:204.35ms
+step:3763/4150 train_time:769007ms step_avg:204.36ms
+step:3764/4150 train_time:769242ms step_avg:204.37ms
+step:3765/4150 train_time:769478ms step_avg:204.38ms
+step:3766/4150 train_time:769715ms step_avg:204.39ms
+step:3767/4150 train_time:769952ms step_avg:204.39ms
+step:3768/4150 train_time:770189ms step_avg:204.40ms
+step:3769/4150 train_time:770424ms step_avg:204.41ms
+step:3770/4150 train_time:770662ms step_avg:204.42ms
+step:3771/4150 train_time:770896ms step_avg:204.43ms
+step:3772/4150 train_time:771133ms step_avg:204.44ms
+step:3773/4150 train_time:771368ms step_avg:204.44ms
+step:3774/4150 train_time:771608ms step_avg:204.45ms
+step:3775/4150 train_time:771846ms step_avg:204.46ms
+step:3776/4150 train_time:772089ms step_avg:204.47ms
+step:3777/4150 train_time:772325ms step_avg:204.48ms
+step:3778/4150 train_time:772565ms step_avg:204.49ms
+step:3779/4150 train_time:772799ms step_avg:204.50ms
+step:3780/4150 train_time:773035ms step_avg:204.51ms
+step:3781/4150 train_time:773270ms step_avg:204.51ms
+step:3782/4150 train_time:773510ms step_avg:204.52ms
+step:3783/4150 train_time:773745ms step_avg:204.53ms
+step:3784/4150 train_time:773982ms step_avg:204.54ms
+step:3785/4150 train_time:774217ms step_avg:204.55ms
+step:3786/4150 train_time:774455ms step_avg:204.56ms
+step:3787/4150 train_time:774688ms step_avg:204.56ms
+step:3788/4150 train_time:774926ms step_avg:204.57ms
+step:3789/4150 train_time:775158ms step_avg:204.58ms
+step:3790/4150 train_time:775398ms step_avg:204.59ms
+step:3791/4150 train_time:775631ms step_avg:204.60ms
+step:3792/4150 train_time:775869ms step_avg:204.61ms
+step:3793/4150 train_time:776103ms step_avg:204.61ms
+step:3794/4150 train_time:776340ms step_avg:204.62ms
+step:3795/4150 train_time:776575ms step_avg:204.63ms
+step:3796/4150 train_time:776814ms step_avg:204.64ms
+step:3797/4150 train_time:777050ms step_avg:204.65ms
+step:3798/4150 train_time:777286ms step_avg:204.66ms
+step:3799/4150 train_time:777523ms step_avg:204.67ms
+step:3800/4150 train_time:777758ms step_avg:204.67ms
+step:3801/4150 train_time:777992ms step_avg:204.68ms
+step:3802/4150 train_time:778232ms step_avg:204.69ms
+step:3803/4150 train_time:778466ms step_avg:204.70ms
+step:3804/4150 train_time:778703ms step_avg:204.71ms
+step:3805/4150 train_time:778937ms step_avg:204.71ms
+step:3806/4150 train_time:779175ms step_avg:204.72ms
+step:3807/4150 train_time:779411ms step_avg:204.73ms
+step:3808/4150 train_time:779647ms step_avg:204.74ms
+step:3809/4150 train_time:779882ms step_avg:204.75ms
+step:3810/4150 train_time:780119ms step_avg:204.76ms
+step:3811/4150 train_time:780352ms step_avg:204.76ms
+step:3812/4150 train_time:780589ms step_avg:204.77ms
+step:3813/4150 train_time:780823ms step_avg:204.78ms
+step:3814/4150 train_time:781060ms step_avg:204.79ms
+step:3815/4150 train_time:781293ms step_avg:204.79ms
+step:3816/4150 train_time:781528ms step_avg:204.80ms
+step:3817/4150 train_time:781762ms step_avg:204.81ms
+step:3818/4150 train_time:782003ms step_avg:204.82ms
+step:3819/4150 train_time:782235ms step_avg:204.83ms
+step:3820/4150 train_time:782470ms step_avg:204.84ms
+step:3821/4150 train_time:782704ms step_avg:204.84ms
+step:3822/4150 train_time:782943ms step_avg:204.85ms
+step:3823/4150 train_time:783177ms step_avg:204.86ms
+step:3824/4150 train_time:783415ms step_avg:204.87ms
+step:3825/4150 train_time:783647ms step_avg:204.87ms
+step:3826/4150 train_time:783891ms step_avg:204.89ms
+step:3827/4150 train_time:784125ms step_avg:204.89ms
+step:3828/4150 train_time:784361ms step_avg:204.90ms
+step:3829/4150 train_time:784597ms step_avg:204.91ms
+step:3830/4150 train_time:784835ms step_avg:204.92ms
+step:3831/4150 train_time:785073ms step_avg:204.93ms
+step:3832/4150 train_time:785310ms step_avg:204.93ms
+step:3833/4150 train_time:785543ms step_avg:204.94ms
+step:3834/4150 train_time:785780ms step_avg:204.95ms
+step:3835/4150 train_time:786013ms step_avg:204.96ms
+step:3836/4150 train_time:786248ms step_avg:204.97ms
+step:3837/4150 train_time:786485ms step_avg:204.97ms
+step:3838/4150 train_time:786724ms step_avg:204.98ms
+step:3839/4150 train_time:786960ms step_avg:204.99ms
+step:3840/4150 train_time:787196ms step_avg:205.00ms
+step:3841/4150 train_time:787429ms step_avg:205.01ms
+step:3842/4150 train_time:787665ms step_avg:205.01ms
+step:3843/4150 train_time:787901ms step_avg:205.02ms
+step:3844/4150 train_time:788137ms step_avg:205.03ms
+step:3845/4150 train_time:788371ms step_avg:205.04ms
+step:3846/4150 train_time:788608ms step_avg:205.05ms
+step:3847/4150 train_time:788844ms step_avg:205.05ms
+step:3848/4150 train_time:789081ms step_avg:205.06ms
+step:3849/4150 train_time:789315ms step_avg:205.07ms
+step:3850/4150 train_time:789548ms step_avg:205.08ms
+step:3851/4150 train_time:789785ms step_avg:205.09ms
+step:3852/4150 train_time:790023ms step_avg:205.09ms
+step:3853/4150 train_time:790263ms step_avg:205.10ms
+step:3854/4150 train_time:790502ms step_avg:205.11ms
+step:3855/4150 train_time:790738ms step_avg:205.12ms
+step:3856/4150 train_time:790975ms step_avg:205.13ms
+step:3857/4150 train_time:791209ms step_avg:205.14ms
+step:3858/4150 train_time:791449ms step_avg:205.14ms
+step:3859/4150 train_time:791681ms step_avg:205.15ms
+step:3860/4150 train_time:791921ms step_avg:205.16ms
+step:3861/4150 train_time:792154ms step_avg:205.17ms
+step:3862/4150 train_time:792392ms step_avg:205.18ms
+step:3863/4150 train_time:792625ms step_avg:205.18ms
+step:3864/4150 train_time:792864ms step_avg:205.19ms
+step:3865/4150 train_time:793098ms step_avg:205.20ms
+step:3866/4150 train_time:793337ms step_avg:205.21ms
+step:3867/4150 train_time:793572ms step_avg:205.22ms
+step:3868/4150 train_time:793815ms step_avg:205.23ms
+step:3869/4150 train_time:794047ms step_avg:205.23ms
+step:3870/4150 train_time:794285ms step_avg:205.24ms
+step:3871/4150 train_time:794520ms step_avg:205.25ms
+step:3872/4150 train_time:794759ms step_avg:205.26ms
+step:3873/4150 train_time:794992ms step_avg:205.27ms
+step:3874/4150 train_time:795225ms step_avg:205.27ms
+step:3875/4150 train_time:795462ms step_avg:205.28ms
+step:3876/4150 train_time:795701ms step_avg:205.29ms
+step:3877/4150 train_time:795938ms step_avg:205.30ms
+step:3878/4150 train_time:796173ms step_avg:205.31ms
+step:3879/4150 train_time:796412ms step_avg:205.31ms
+step:3880/4150 train_time:796648ms step_avg:205.32ms
+step:3881/4150 train_time:796882ms step_avg:205.33ms
+step:3882/4150 train_time:797118ms step_avg:205.34ms
+step:3883/4150 train_time:797353ms step_avg:205.34ms
+step:3884/4150 train_time:797590ms step_avg:205.35ms
+step:3885/4150 train_time:797827ms step_avg:205.36ms
+step:3886/4150 train_time:798067ms step_avg:205.37ms
+step:3887/4150 train_time:798301ms step_avg:205.38ms
+step:3888/4150 train_time:798538ms step_avg:205.39ms
+step:3889/4150 train_time:798774ms step_avg:205.39ms
+step:3890/4150 train_time:799011ms step_avg:205.40ms
+step:3891/4150 train_time:799247ms step_avg:205.41ms
+step:3892/4150 train_time:799484ms step_avg:205.42ms
+step:3893/4150 train_time:799719ms step_avg:205.42ms
+step:3894/4150 train_time:799954ms step_avg:205.43ms
+step:3895/4150 train_time:800191ms step_avg:205.44ms
+step:3896/4150 train_time:800429ms step_avg:205.45ms
+step:3897/4150 train_time:800665ms step_avg:205.46ms
+step:3898/4150 train_time:800902ms step_avg:205.46ms
+step:3899/4150 train_time:801138ms step_avg:205.47ms
+step:3900/4150 train_time:801375ms step_avg:205.48ms
+step:3901/4150 train_time:801610ms step_avg:205.49ms
+step:3902/4150 train_time:801850ms step_avg:205.50ms
+step:3903/4150 train_time:802084ms step_avg:205.50ms
+step:3904/4150 train_time:802322ms step_avg:205.51ms
+step:3905/4150 train_time:802554ms step_avg:205.52ms
+step:3906/4150 train_time:802792ms step_avg:205.53ms
+step:3907/4150 train_time:803026ms step_avg:205.54ms
+step:3908/4150 train_time:803265ms step_avg:205.54ms
+step:3909/4150 train_time:803501ms step_avg:205.55ms
+step:3910/4150 train_time:803739ms step_avg:205.56ms
+step:3911/4150 train_time:803977ms step_avg:205.57ms
+step:3912/4150 train_time:804212ms step_avg:205.58ms
+step:3913/4150 train_time:804445ms step_avg:205.58ms
+step:3914/4150 train_time:804686ms step_avg:205.59ms
+step:3915/4150 train_time:804920ms step_avg:205.60ms
+step:3916/4150 train_time:805158ms step_avg:205.61ms
+step:3917/4150 train_time:805393ms step_avg:205.61ms
+step:3918/4150 train_time:805628ms step_avg:205.62ms
+step:3919/4150 train_time:805861ms step_avg:205.63ms
+step:3920/4150 train_time:806100ms step_avg:205.64ms
+step:3921/4150 train_time:806335ms step_avg:205.65ms
+step:3922/4150 train_time:806574ms step_avg:205.65ms
+step:3923/4150 train_time:806807ms step_avg:205.66ms
+step:3924/4150 train_time:807049ms step_avg:205.67ms
+step:3925/4150 train_time:807286ms step_avg:205.68ms
+step:3926/4150 train_time:807527ms step_avg:205.69ms
+step:3927/4150 train_time:807761ms step_avg:205.69ms
+step:3928/4150 train_time:808000ms step_avg:205.70ms
+step:3929/4150 train_time:808234ms step_avg:205.71ms
+step:3930/4150 train_time:808474ms step_avg:205.72ms
+step:3931/4150 train_time:808711ms step_avg:205.73ms
+step:3932/4150 train_time:808949ms step_avg:205.73ms
+step:3933/4150 train_time:809184ms step_avg:205.74ms
+step:3934/4150 train_time:809420ms step_avg:205.75ms
+step:3935/4150 train_time:809655ms step_avg:205.76ms
+step:3936/4150 train_time:809897ms step_avg:205.77ms
+step:3937/4150 train_time:810132ms step_avg:205.77ms
+step:3938/4150 train_time:810371ms step_avg:205.78ms
+step:3939/4150 train_time:810606ms step_avg:205.79ms
+step:3940/4150 train_time:810845ms step_avg:205.80ms
+step:3941/4150 train_time:811080ms step_avg:205.81ms
+step:3942/4150 train_time:811315ms step_avg:205.81ms
+step:3943/4150 train_time:811548ms step_avg:205.82ms
+step:3944/4150 train_time:811788ms step_avg:205.83ms
+step:3945/4150 train_time:812023ms step_avg:205.84ms
+step:3946/4150 train_time:812260ms step_avg:205.84ms
+step:3947/4150 train_time:812497ms step_avg:205.85ms
+step:3948/4150 train_time:812737ms step_avg:205.86ms
+step:3949/4150 train_time:812970ms step_avg:205.87ms
+step:3950/4150 train_time:813211ms step_avg:205.88ms
+step:3951/4150 train_time:813449ms step_avg:205.88ms
+step:3952/4150 train_time:813688ms step_avg:205.89ms
+step:3953/4150 train_time:813924ms step_avg:205.90ms
+step:3954/4150 train_time:814158ms step_avg:205.91ms
+step:3955/4150 train_time:814393ms step_avg:205.91ms
+step:3956/4150 train_time:814628ms step_avg:205.92ms
+step:3957/4150 train_time:814864ms step_avg:205.93ms
+step:3958/4150 train_time:815101ms step_avg:205.94ms
+step:3959/4150 train_time:815337ms step_avg:205.95ms
+step:3960/4150 train_time:815575ms step_avg:205.95ms
+step:3961/4150 train_time:815810ms step_avg:205.96ms
+step:3962/4150 train_time:816047ms step_avg:205.97ms
+step:3963/4150 train_time:816279ms step_avg:205.98ms
+step:3964/4150 train_time:816518ms step_avg:205.98ms
+step:3965/4150 train_time:816752ms step_avg:205.99ms
+step:3966/4150 train_time:816989ms step_avg:206.00ms
+step:3967/4150 train_time:817223ms step_avg:206.01ms
+step:3968/4150 train_time:817462ms step_avg:206.01ms
+step:3969/4150 train_time:817696ms step_avg:206.02ms
+step:3970/4150 train_time:817937ms step_avg:206.03ms
+step:3971/4150 train_time:818168ms step_avg:206.04ms
+step:3972/4150 train_time:818405ms step_avg:206.04ms
+step:3973/4150 train_time:818639ms step_avg:206.05ms
+step:3974/4150 train_time:818876ms step_avg:206.06ms
+step:3975/4150 train_time:819108ms step_avg:206.06ms
+step:3976/4150 train_time:819349ms step_avg:206.07ms
+step:3977/4150 train_time:819585ms step_avg:206.08ms
+step:3978/4150 train_time:819822ms step_avg:206.09ms
+step:3979/4150 train_time:820055ms step_avg:206.10ms
+step:3980/4150 train_time:820292ms step_avg:206.10ms
+step:3981/4150 train_time:820526ms step_avg:206.11ms
+step:3982/4150 train_time:820763ms step_avg:206.12ms
+step:3983/4150 train_time:820999ms step_avg:206.13ms
+step:3984/4150 train_time:821234ms step_avg:206.13ms
+step:3985/4150 train_time:821467ms step_avg:206.14ms
+step:3986/4150 train_time:821708ms step_avg:206.15ms
+step:3987/4150 train_time:821941ms step_avg:206.16ms
+step:3988/4150 train_time:822181ms step_avg:206.16ms
+step:3989/4150 train_time:822412ms step_avg:206.17ms
+step:3990/4150 train_time:822650ms step_avg:206.18ms
+step:3991/4150 train_time:822884ms step_avg:206.18ms
+step:3992/4150 train_time:823122ms step_avg:206.19ms
+step:3993/4150 train_time:823356ms step_avg:206.20ms
+step:3994/4150 train_time:823596ms step_avg:206.21ms
+step:3995/4150 train_time:823832ms step_avg:206.22ms
+step:3996/4150 train_time:824072ms step_avg:206.22ms
+step:3997/4150 train_time:824308ms step_avg:206.23ms
+step:3998/4150 train_time:824545ms step_avg:206.24ms
+step:3999/4150 train_time:824780ms step_avg:206.25ms
+step:4000/4150 train_time:825018ms step_avg:206.25ms
+step:4000/4150 val_loss:2.9282 train_time:825233ms step_avg:206.31ms
+step:4001/4150 train_time:825256ms step_avg:206.26ms
+step:4002/4150 train_time:825501ms step_avg:206.27ms
+step:4003/4150 train_time:825734ms step_avg:206.28ms
+step:4004/4150 train_time:825968ms step_avg:206.29ms
+step:4005/4150 train_time:826201ms step_avg:206.29ms
+step:4006/4150 train_time:826443ms step_avg:206.30ms
+step:4007/4150 train_time:826681ms step_avg:206.31ms
+step:4008/4150 train_time:826916ms step_avg:206.32ms
+step:4009/4150 train_time:827147ms step_avg:206.32ms
+step:4010/4150 train_time:827383ms step_avg:206.33ms
+step:4011/4150 train_time:827623ms step_avg:206.34ms
+step:4012/4150 train_time:827859ms step_avg:206.35ms
+step:4013/4150 train_time:828092ms step_avg:206.35ms
+step:4014/4150 train_time:828327ms step_avg:206.36ms
+step:4015/4150 train_time:828562ms step_avg:206.37ms
+step:4016/4150 train_time:828805ms step_avg:206.38ms
+step:4017/4150 train_time:829035ms step_avg:206.38ms
+step:4018/4150 train_time:829274ms step_avg:206.39ms
+step:4019/4150 train_time:829511ms step_avg:206.40ms
+step:4020/4150 train_time:829748ms step_avg:206.40ms
+step:4021/4150 train_time:829983ms step_avg:206.41ms
+step:4022/4150 train_time:830219ms step_avg:206.42ms
+step:4023/4150 train_time:830453ms step_avg:206.43ms
+step:4024/4150 train_time:830693ms step_avg:206.43ms
+step:4025/4150 train_time:830929ms step_avg:206.44ms
+step:4026/4150 train_time:831163ms step_avg:206.45ms
+step:4027/4150 train_time:831395ms step_avg:206.46ms
+step:4028/4150 train_time:831632ms step_avg:206.46ms
+step:4029/4150 train_time:831866ms step_avg:206.47ms
+step:4030/4150 train_time:832103ms step_avg:206.48ms
+step:4031/4150 train_time:832338ms step_avg:206.48ms
+step:4032/4150 train_time:832577ms step_avg:206.49ms
+step:4033/4150 train_time:832812ms step_avg:206.50ms
+step:4034/4150 train_time:833051ms step_avg:206.51ms
+step:4035/4150 train_time:833284ms step_avg:206.51ms
+step:4036/4150 train_time:833520ms step_avg:206.52ms
+step:4037/4150 train_time:833757ms step_avg:206.53ms
+step:4038/4150 train_time:833997ms step_avg:206.54ms
+step:4039/4150 train_time:834230ms step_avg:206.54ms
+step:4040/4150 train_time:834468ms step_avg:206.55ms
+step:4041/4150 train_time:834701ms step_avg:206.56ms
+step:4042/4150 train_time:834939ms step_avg:206.57ms
+step:4043/4150 train_time:835171ms step_avg:206.57ms
+step:4044/4150 train_time:835408ms step_avg:206.58ms
+step:4045/4150 train_time:835642ms step_avg:206.59ms
+step:4046/4150 train_time:835879ms step_avg:206.59ms
+step:4047/4150 train_time:836112ms step_avg:206.60ms
+step:4048/4150 train_time:836347ms step_avg:206.61ms
+step:4049/4150 train_time:836580ms step_avg:206.61ms
+step:4050/4150 train_time:836820ms step_avg:206.62ms
+step:4051/4150 train_time:837055ms step_avg:206.63ms
+step:4052/4150 train_time:837290ms step_avg:206.64ms
+step:4053/4150 train_time:837527ms step_avg:206.64ms
+step:4054/4150 train_time:837769ms step_avg:206.65ms
+step:4055/4150 train_time:838003ms step_avg:206.66ms
+step:4056/4150 train_time:838241ms step_avg:206.67ms
+step:4057/4150 train_time:838475ms step_avg:206.67ms
+step:4058/4150 train_time:838712ms step_avg:206.68ms
+step:4059/4150 train_time:838949ms step_avg:206.69ms
+step:4060/4150 train_time:839186ms step_avg:206.70ms
+step:4061/4150 train_time:839423ms step_avg:206.70ms
+step:4062/4150 train_time:839660ms step_avg:206.71ms
+step:4063/4150 train_time:839894ms step_avg:206.72ms
+step:4064/4150 train_time:840132ms step_avg:206.73ms
+step:4065/4150 train_time:840367ms step_avg:206.73ms
+step:4066/4150 train_time:840605ms step_avg:206.74ms
+step:4067/4150 train_time:840843ms step_avg:206.75ms
+step:4068/4150 train_time:841081ms step_avg:206.76ms
+step:4069/4150 train_time:841320ms step_avg:206.76ms
+step:4070/4150 train_time:841559ms step_avg:206.77ms
+step:4071/4150 train_time:841792ms step_avg:206.78ms
+step:4072/4150 train_time:842028ms step_avg:206.78ms
+step:4073/4150 train_time:842263ms step_avg:206.79ms
+step:4074/4150 train_time:842501ms step_avg:206.80ms
+step:4075/4150 train_time:842737ms step_avg:206.81ms
+step:4076/4150 train_time:842973ms step_avg:206.81ms
+step:4077/4150 train_time:843208ms step_avg:206.82ms
+step:4078/4150 train_time:843446ms step_avg:206.83ms
+step:4079/4150 train_time:843684ms step_avg:206.84ms
+step:4080/4150 train_time:843920ms step_avg:206.84ms
+step:4081/4150 train_time:844155ms step_avg:206.85ms
+step:4082/4150 train_time:844393ms step_avg:206.86ms
+step:4083/4150 train_time:844629ms step_avg:206.86ms
+step:4084/4150 train_time:844870ms step_avg:206.87ms
+step:4085/4150 train_time:845106ms step_avg:206.88ms
+step:4086/4150 train_time:845343ms step_avg:206.89ms
+step:4087/4150 train_time:845578ms step_avg:206.89ms
+step:4088/4150 train_time:845815ms step_avg:206.90ms
+step:4089/4150 train_time:846049ms step_avg:206.91ms
+step:4090/4150 train_time:846291ms step_avg:206.92ms
+step:4091/4150 train_time:846528ms step_avg:206.92ms
+step:4092/4150 train_time:846768ms step_avg:206.93ms
+step:4093/4150 train_time:847000ms step_avg:206.94ms
+step:4094/4150 train_time:847238ms step_avg:206.95ms
+step:4095/4150 train_time:847472ms step_avg:206.95ms
+step:4096/4150 train_time:847710ms step_avg:206.96ms
+step:4097/4150 train_time:847944ms step_avg:206.97ms
+step:4098/4150 train_time:848181ms step_avg:206.97ms
+step:4099/4150 train_time:848415ms step_avg:206.98ms
+step:4100/4150 train_time:848654ms step_avg:206.99ms
+step:4101/4150 train_time:848892ms step_avg:207.00ms
+step:4102/4150 train_time:849131ms step_avg:207.00ms
+step:4103/4150 train_time:849364ms step_avg:207.01ms
+step:4104/4150 train_time:849603ms step_avg:207.02ms
+step:4105/4150 train_time:849837ms step_avg:207.02ms
+step:4106/4150 train_time:850075ms step_avg:207.03ms
+step:4107/4150 train_time:850309ms step_avg:207.04ms
+step:4108/4150 train_time:850547ms step_avg:207.05ms
+step:4109/4150 train_time:850782ms step_avg:207.05ms
+step:4110/4150 train_time:851019ms step_avg:207.06ms
+step:4111/4150 train_time:851252ms step_avg:207.07ms
+step:4112/4150 train_time:851488ms step_avg:207.07ms
+step:4113/4150 train_time:851723ms step_avg:207.08ms
+step:4114/4150 train_time:851961ms step_avg:207.09ms
+step:4115/4150 train_time:852196ms step_avg:207.10ms
+step:4116/4150 train_time:852432ms step_avg:207.10ms
+step:4117/4150 train_time:852667ms step_avg:207.11ms
+step:4118/4150 train_time:852904ms step_avg:207.12ms
+step:4119/4150 train_time:853141ms step_avg:207.12ms
+step:4120/4150 train_time:853378ms step_avg:207.13ms
+step:4121/4150 train_time:853612ms step_avg:207.14ms
+step:4122/4150 train_time:853847ms step_avg:207.14ms
+step:4123/4150 train_time:854083ms step_avg:207.15ms
+step:4124/4150 train_time:854323ms step_avg:207.16ms
+step:4125/4150 train_time:854557ms step_avg:207.17ms
+step:4126/4150 train_time:854794ms step_avg:207.17ms
+step:4127/4150 train_time:855027ms step_avg:207.18ms
+step:4128/4150 train_time:855268ms step_avg:207.19ms
+step:4129/4150 train_time:855504ms step_avg:207.19ms
+step:4130/4150 train_time:855738ms step_avg:207.20ms
+step:4131/4150 train_time:855972ms step_avg:207.21ms
+step:4132/4150 train_time:856213ms step_avg:207.22ms
+step:4133/4150 train_time:856451ms step_avg:207.22ms
+step:4134/4150 train_time:856688ms step_avg:207.23ms
+step:4135/4150 train_time:856923ms step_avg:207.24ms
+step:4136/4150 train_time:857160ms step_avg:207.24ms
+step:4137/4150 train_time:857396ms step_avg:207.25ms
+step:4138/4150 train_time:857632ms step_avg:207.26ms
+step:4139/4150 train_time:857870ms step_avg:207.27ms
+step:4140/4150 train_time:858107ms step_avg:207.27ms
+step:4141/4150 train_time:858343ms step_avg:207.28ms
+step:4142/4150 train_time:858579ms step_avg:207.29ms
+step:4143/4150 train_time:858813ms step_avg:207.29ms
+step:4144/4150 train_time:859050ms step_avg:207.30ms
+step:4145/4150 train_time:859285ms step_avg:207.31ms
+step:4146/4150 train_time:859523ms step_avg:207.31ms
+step:4147/4150 train_time:859757ms step_avg:207.32ms
+step:4148/4150 train_time:859993ms step_avg:207.33ms
+step:4149/4150 train_time:860228ms step_avg:207.33ms
+step:4150/4150 train_time:860466ms step_avg:207.34ms
+step:4150/4150 val_loss:2.9172 train_time:860679ms step_avg:207.39ms
+peak memory allocated: 59977 MiB reserved: 60564 MiB

--- a/records/track_2_medium/2026-0427-MuddFormer/this_pr/d2b2ac31-11ac-4f5b-b850-941330378133.txt
+++ b/records/track_2_medium/2026-0427-MuddFormer/this_pr/d2b2ac31-11ac-4f5b-b850-941330378133.txt
@@ -1,0 +1,6376 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+import numpy as np
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
+
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = False # turn off fp8 for now -> requires tuning of scales which hasnt been done on medium track
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(16, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
+
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
+        self.yarn = Yarn(head_dim, max_seq_len)
+
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+        self.embed.weight.label = 'embed'
+
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
+        self.embed2.weight.label = 'embed2'
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [2, 4, 6]
+        skip_out = [9, 10, 11]
+        backout_layer = 11
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
+            short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
+
+        skip_idx = 0
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve_list[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
+            )
+            next_ve_gate = None
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
+                skip_idx += 1
+                x = x + skip_gate_out * skip_connections.pop()
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
+            else:
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                h_backout_snap = x
+
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
+        x = norm(x)
+
+        if not self.training:
+            loss = 0
+            for i in range(4):
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
+                logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+                loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
+            return loss
+
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return min(11,args.ws_schedule[ws_idx] // 2), args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/12:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/12:
+        lr_max = 1.73  # (24/8)**0.5
+    if x > 3/12:
+        lr_max = 2.0
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
+
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / (args.num_scheduled_iterations/4)
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        # only apply yarn for first few
+        if new_ws_long != self.ws_long and new_ws_long<=13:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
+                                524288, 524288, 524288, 524288,
+                                524288, 524288, 524288, 524288
+                               )
+    train_bs_extension: int = 32 * 2048 * 8
+    train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3/4
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11, 13,
+                          15, 17, 19, 21,
+                          23, 23, 23, 23)
+    ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
+    ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=16,
+    num_heads=8,
+    head_dim=128,
+    model_dim=1024,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.3 (main, Mar 23 2026, 19:04:32) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Mon Apr 27 06:47:52 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   42C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   36C    P0            115W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   42C    P0            115W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   37C    P0            127W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   38C    P0            123W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   37C    P0            120W /  700W |    1521MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          259943      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    1   N/A  N/A          259944      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    2   N/A  N/A          259945      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    3   N/A  N/A          259946      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    4   N/A  N/A          259947      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    5   N/A  N/A          259948      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    6   N/A  N/A          259949      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
+|    7   N/A  N/A          259950      C   ...ping/nano-gpt-env/bin/python3       1512MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 343, 344, 345, 687, 688, 689, 1031, 1032, 1033, 1374, 1375, 1376, 1718, 1719, 1720, 2062, 2063, 2064, 2406, 2407, 2408, 2749, 2750, 2751] for warmup
+Resetting Model
+step:0/4150 val_loss:10.8293 train_time:0ms step_avg:0.03ms
+step:1/4150 train_time:81ms step_avg:80.69ms
+step:2/4150 train_time:126ms step_avg:62.78ms
+step:3/4150 train_time:193ms step_avg:64.47ms
+step:4/4150 train_time:260ms step_avg:65.03ms
+step:5/4150 train_time:329ms step_avg:65.71ms
+step:6/4150 train_time:394ms step_avg:65.70ms
+step:7/4150 train_time:463ms step_avg:66.21ms
+step:8/4150 train_time:529ms step_avg:66.13ms
+step:9/4150 train_time:598ms step_avg:66.44ms
+step:10/4150 train_time:663ms step_avg:66.30ms
+step:11/4150 train_time:733ms step_avg:66.60ms
+step:12/4150 train_time:798ms step_avg:66.53ms
+step:13/4150 train_time:869ms step_avg:66.81ms
+step:14/4150 train_time:935ms step_avg:66.78ms
+step:15/4150 train_time:1006ms step_avg:67.05ms
+step:16/4150 train_time:1073ms step_avg:67.05ms
+step:17/4150 train_time:1143ms step_avg:67.26ms
+step:18/4150 train_time:1211ms step_avg:67.26ms
+step:19/4150 train_time:1280ms step_avg:67.37ms
+step:20/4150 train_time:1347ms step_avg:67.33ms
+step:21/4150 train_time:1416ms step_avg:67.43ms
+step:22/4150 train_time:1482ms step_avg:67.35ms
+step:23/4150 train_time:1552ms step_avg:67.48ms
+step:24/4150 train_time:1618ms step_avg:67.40ms
+step:25/4150 train_time:1687ms step_avg:67.50ms
+step:26/4150 train_time:1753ms step_avg:67.41ms
+step:27/4150 train_time:1822ms step_avg:67.48ms
+step:28/4150 train_time:1888ms step_avg:67.43ms
+step:29/4150 train_time:1959ms step_avg:67.54ms
+step:30/4150 train_time:2025ms step_avg:67.49ms
+step:31/4150 train_time:2095ms step_avg:67.57ms
+step:32/4150 train_time:2161ms step_avg:67.53ms
+step:33/4150 train_time:2233ms step_avg:67.66ms
+step:34/4150 train_time:2299ms step_avg:67.62ms
+step:35/4150 train_time:2369ms step_avg:67.68ms
+step:36/4150 train_time:2434ms step_avg:67.62ms
+step:37/4150 train_time:2505ms step_avg:67.70ms
+step:38/4150 train_time:2571ms step_avg:67.66ms
+step:39/4150 train_time:2641ms step_avg:67.71ms
+step:40/4150 train_time:2707ms step_avg:67.67ms
+step:41/4150 train_time:2776ms step_avg:67.72ms
+step:42/4150 train_time:2842ms step_avg:67.68ms
+step:43/4150 train_time:2912ms step_avg:67.73ms
+step:44/4150 train_time:2978ms step_avg:67.68ms
+step:45/4150 train_time:3047ms step_avg:67.72ms
+step:46/4150 train_time:3114ms step_avg:67.69ms
+step:47/4150 train_time:3183ms step_avg:67.73ms
+step:48/4150 train_time:3250ms step_avg:67.70ms
+step:49/4150 train_time:3320ms step_avg:67.75ms
+step:50/4150 train_time:3386ms step_avg:67.71ms
+step:51/4150 train_time:3456ms step_avg:67.76ms
+step:52/4150 train_time:3521ms step_avg:67.72ms
+step:53/4150 train_time:3591ms step_avg:67.75ms
+step:54/4150 train_time:3657ms step_avg:67.71ms
+step:55/4150 train_time:3727ms step_avg:67.76ms
+step:56/4150 train_time:3792ms step_avg:67.72ms
+step:57/4150 train_time:3862ms step_avg:67.75ms
+step:58/4150 train_time:3927ms step_avg:67.72ms
+step:59/4150 train_time:3997ms step_avg:67.74ms
+step:60/4150 train_time:4062ms step_avg:67.69ms
+step:61/4150 train_time:4132ms step_avg:67.73ms
+step:62/4150 train_time:4197ms step_avg:67.70ms
+step:63/4150 train_time:4267ms step_avg:67.73ms
+step:64/4150 train_time:4333ms step_avg:67.70ms
+step:65/4150 train_time:4402ms step_avg:67.72ms
+step:66/4150 train_time:4468ms step_avg:67.70ms
+step:67/4150 train_time:4537ms step_avg:67.72ms
+step:68/4150 train_time:4603ms step_avg:67.69ms
+step:69/4150 train_time:4673ms step_avg:67.73ms
+step:70/4150 train_time:4739ms step_avg:67.70ms
+step:71/4150 train_time:4809ms step_avg:67.74ms
+step:72/4150 train_time:4875ms step_avg:67.70ms
+step:73/4150 train_time:4945ms step_avg:67.73ms
+step:74/4150 train_time:5010ms step_avg:67.71ms
+step:75/4150 train_time:5080ms step_avg:67.74ms
+step:76/4150 train_time:5146ms step_avg:67.71ms
+step:77/4150 train_time:5215ms step_avg:67.73ms
+step:78/4150 train_time:5281ms step_avg:67.71ms
+step:79/4150 train_time:5351ms step_avg:67.74ms
+step:80/4150 train_time:5416ms step_avg:67.71ms
+step:81/4150 train_time:5486ms step_avg:67.73ms
+step:82/4150 train_time:5552ms step_avg:67.70ms
+step:83/4150 train_time:5621ms step_avg:67.72ms
+step:84/4150 train_time:5687ms step_avg:67.70ms
+step:85/4150 train_time:5757ms step_avg:67.73ms
+step:86/4150 train_time:5822ms step_avg:67.70ms
+step:87/4150 train_time:5892ms step_avg:67.73ms
+step:88/4150 train_time:5958ms step_avg:67.70ms
+step:89/4150 train_time:6028ms step_avg:67.73ms
+step:90/4150 train_time:6094ms step_avg:67.71ms
+step:91/4150 train_time:6164ms step_avg:67.74ms
+step:92/4150 train_time:6230ms step_avg:67.71ms
+step:93/4150 train_time:6299ms step_avg:67.73ms
+step:94/4150 train_time:6365ms step_avg:67.71ms
+step:95/4150 train_time:6436ms step_avg:67.75ms
+step:96/4150 train_time:6502ms step_avg:67.72ms
+step:97/4150 train_time:6572ms step_avg:67.75ms
+step:98/4150 train_time:6637ms step_avg:67.73ms
+step:99/4150 train_time:6707ms step_avg:67.75ms
+step:100/4150 train_time:6773ms step_avg:67.73ms
+step:101/4150 train_time:6844ms step_avg:67.76ms
+step:102/4150 train_time:6910ms step_avg:67.74ms
+step:103/4150 train_time:6979ms step_avg:67.75ms
+step:104/4150 train_time:7044ms step_avg:67.73ms
+step:105/4150 train_time:7113ms step_avg:67.74ms
+step:106/4150 train_time:7179ms step_avg:67.72ms
+step:107/4150 train_time:7249ms step_avg:67.74ms
+step:108/4150 train_time:7314ms step_avg:67.72ms
+step:109/4150 train_time:7384ms step_avg:67.74ms
+step:110/4150 train_time:7449ms step_avg:67.72ms
+step:111/4150 train_time:7518ms step_avg:67.73ms
+step:112/4150 train_time:7585ms step_avg:67.72ms
+step:113/4150 train_time:7655ms step_avg:67.74ms
+step:114/4150 train_time:7720ms step_avg:67.72ms
+step:115/4150 train_time:7790ms step_avg:67.74ms
+step:116/4150 train_time:7856ms step_avg:67.72ms
+step:117/4150 train_time:7926ms step_avg:67.75ms
+step:118/4150 train_time:7992ms step_avg:67.73ms
+step:119/4150 train_time:8061ms step_avg:67.74ms
+step:120/4150 train_time:8127ms step_avg:67.73ms
+step:121/4150 train_time:8197ms step_avg:67.74ms
+step:122/4150 train_time:8262ms step_avg:67.72ms
+step:123/4150 train_time:8333ms step_avg:67.74ms
+step:124/4150 train_time:8398ms step_avg:67.73ms
+step:125/4150 train_time:8467ms step_avg:67.74ms
+step:126/4150 train_time:8533ms step_avg:67.73ms
+step:127/4150 train_time:8603ms step_avg:67.74ms
+step:128/4150 train_time:8669ms step_avg:67.73ms
+step:129/4150 train_time:8739ms step_avg:67.75ms
+step:130/4150 train_time:8805ms step_avg:67.73ms
+step:131/4150 train_time:8875ms step_avg:67.75ms
+step:132/4150 train_time:8941ms step_avg:67.73ms
+step:133/4150 train_time:9011ms step_avg:67.75ms
+step:134/4150 train_time:9076ms step_avg:67.73ms
+step:135/4150 train_time:9146ms step_avg:67.75ms
+step:136/4150 train_time:9212ms step_avg:67.73ms
+step:137/4150 train_time:9281ms step_avg:67.74ms
+step:138/4150 train_time:9346ms step_avg:67.72ms
+step:139/4150 train_time:9415ms step_avg:67.73ms
+step:140/4150 train_time:9480ms step_avg:67.72ms
+step:141/4150 train_time:9550ms step_avg:67.73ms
+step:142/4150 train_time:9616ms step_avg:67.72ms
+step:143/4150 train_time:9685ms step_avg:67.73ms
+step:144/4150 train_time:9751ms step_avg:67.72ms
+step:145/4150 train_time:9821ms step_avg:67.73ms
+step:146/4150 train_time:9886ms step_avg:67.71ms
+step:147/4150 train_time:9956ms step_avg:67.73ms
+step:148/4150 train_time:10021ms step_avg:67.71ms
+step:149/4150 train_time:10091ms step_avg:67.72ms
+step:150/4150 train_time:10156ms step_avg:67.71ms
+step:151/4150 train_time:10226ms step_avg:67.72ms
+step:152/4150 train_time:10291ms step_avg:67.70ms
+step:153/4150 train_time:10361ms step_avg:67.72ms
+step:154/4150 train_time:10426ms step_avg:67.70ms
+step:155/4150 train_time:10496ms step_avg:67.71ms
+step:156/4150 train_time:10561ms step_avg:67.70ms
+step:157/4150 train_time:10630ms step_avg:67.71ms
+step:158/4150 train_time:10696ms step_avg:67.69ms
+step:159/4150 train_time:10765ms step_avg:67.70ms
+step:160/4150 train_time:10831ms step_avg:67.69ms
+step:161/4150 train_time:10900ms step_avg:67.70ms
+step:162/4150 train_time:10967ms step_avg:67.70ms
+step:163/4150 train_time:11036ms step_avg:67.71ms
+step:164/4150 train_time:11102ms step_avg:67.69ms
+step:165/4150 train_time:11171ms step_avg:67.70ms
+step:166/4150 train_time:11237ms step_avg:67.69ms
+step:167/4150 train_time:11307ms step_avg:67.71ms
+step:168/4150 train_time:11373ms step_avg:67.70ms
+step:169/4150 train_time:11443ms step_avg:67.71ms
+step:170/4150 train_time:11509ms step_avg:67.70ms
+step:171/4150 train_time:11578ms step_avg:67.71ms
+step:172/4150 train_time:11644ms step_avg:67.70ms
+step:173/4150 train_time:11713ms step_avg:67.71ms
+step:174/4150 train_time:11779ms step_avg:67.69ms
+step:175/4150 train_time:11847ms step_avg:67.70ms
+step:176/4150 train_time:11913ms step_avg:67.69ms
+step:177/4150 train_time:11982ms step_avg:67.70ms
+step:178/4150 train_time:12048ms step_avg:67.69ms
+step:179/4150 train_time:12118ms step_avg:67.70ms
+step:180/4150 train_time:12183ms step_avg:67.68ms
+step:181/4150 train_time:12252ms step_avg:67.69ms
+step:182/4150 train_time:12318ms step_avg:67.68ms
+step:183/4150 train_time:12387ms step_avg:67.69ms
+step:184/4150 train_time:12453ms step_avg:67.68ms
+step:185/4150 train_time:12522ms step_avg:67.69ms
+step:186/4150 train_time:12589ms step_avg:67.68ms
+step:187/4150 train_time:12658ms step_avg:67.69ms
+step:188/4150 train_time:12723ms step_avg:67.68ms
+step:189/4150 train_time:12793ms step_avg:67.69ms
+step:190/4150 train_time:12858ms step_avg:67.67ms
+step:191/4150 train_time:12927ms step_avg:67.68ms
+step:192/4150 train_time:12993ms step_avg:67.67ms
+step:193/4150 train_time:13062ms step_avg:67.68ms
+step:194/4150 train_time:13128ms step_avg:67.67ms
+step:195/4150 train_time:13197ms step_avg:67.68ms
+step:196/4150 train_time:13263ms step_avg:67.67ms
+step:197/4150 train_time:13333ms step_avg:67.68ms
+step:198/4150 train_time:13398ms step_avg:67.67ms
+step:199/4150 train_time:13468ms step_avg:67.68ms
+step:200/4150 train_time:13534ms step_avg:67.67ms
+step:201/4150 train_time:13604ms step_avg:67.68ms
+step:202/4150 train_time:13669ms step_avg:67.67ms
+step:203/4150 train_time:13738ms step_avg:67.68ms
+step:204/4150 train_time:13804ms step_avg:67.67ms
+step:205/4150 train_time:13873ms step_avg:67.68ms
+step:206/4150 train_time:13939ms step_avg:67.66ms
+step:207/4150 train_time:14007ms step_avg:67.67ms
+step:208/4150 train_time:14073ms step_avg:67.66ms
+step:209/4150 train_time:14142ms step_avg:67.66ms
+step:210/4150 train_time:14207ms step_avg:67.65ms
+step:211/4150 train_time:14276ms step_avg:67.66ms
+step:212/4150 train_time:14342ms step_avg:67.65ms
+step:213/4150 train_time:14411ms step_avg:67.66ms
+step:214/4150 train_time:14476ms step_avg:67.65ms
+step:215/4150 train_time:14545ms step_avg:67.65ms
+step:216/4150 train_time:14611ms step_avg:67.64ms
+step:217/4150 train_time:14679ms step_avg:67.65ms
+step:218/4150 train_time:14745ms step_avg:67.64ms
+step:219/4150 train_time:14814ms step_avg:67.64ms
+step:220/4150 train_time:14879ms step_avg:67.63ms
+step:221/4150 train_time:14949ms step_avg:67.64ms
+step:222/4150 train_time:15014ms step_avg:67.63ms
+step:223/4150 train_time:15084ms step_avg:67.64ms
+step:224/4150 train_time:15149ms step_avg:67.63ms
+step:225/4150 train_time:15218ms step_avg:67.64ms
+step:226/4150 train_time:15283ms step_avg:67.63ms
+step:227/4150 train_time:15354ms step_avg:67.64ms
+step:228/4150 train_time:15419ms step_avg:67.63ms
+step:229/4150 train_time:15489ms step_avg:67.64ms
+step:230/4150 train_time:15554ms step_avg:67.63ms
+step:231/4150 train_time:15624ms step_avg:67.64ms
+step:232/4150 train_time:15689ms step_avg:67.63ms
+step:233/4150 train_time:15759ms step_avg:67.64ms
+step:234/4150 train_time:15825ms step_avg:67.63ms
+step:235/4150 train_time:15894ms step_avg:67.63ms
+step:236/4150 train_time:15959ms step_avg:67.62ms
+step:237/4150 train_time:16028ms step_avg:67.63ms
+step:238/4150 train_time:16094ms step_avg:67.62ms
+step:239/4150 train_time:16163ms step_avg:67.63ms
+step:240/4150 train_time:16229ms step_avg:67.62ms
+step:241/4150 train_time:16298ms step_avg:67.63ms
+step:242/4150 train_time:16363ms step_avg:67.62ms
+step:243/4150 train_time:16433ms step_avg:67.63ms
+step:244/4150 train_time:16498ms step_avg:67.62ms
+step:245/4150 train_time:16568ms step_avg:67.62ms
+step:246/4150 train_time:16634ms step_avg:67.62ms
+step:247/4150 train_time:16703ms step_avg:67.62ms
+step:248/4150 train_time:16769ms step_avg:67.62ms
+step:249/4150 train_time:16838ms step_avg:67.62ms
+step:250/4150 train_time:16903ms step_avg:67.61ms
+step:250/4150 val_loss:4.4812 train_time:16969ms step_avg:67.87ms
+step:251/4150 train_time:16992ms step_avg:67.70ms
+step:252/4150 train_time:17042ms step_avg:67.63ms
+step:253/4150 train_time:17112ms step_avg:67.63ms
+step:254/4150 train_time:17178ms step_avg:67.63ms
+step:255/4150 train_time:17249ms step_avg:67.64ms
+step:256/4150 train_time:17317ms step_avg:67.64ms
+step:257/4150 train_time:17387ms step_avg:67.65ms
+step:258/4150 train_time:17453ms step_avg:67.65ms
+step:259/4150 train_time:17522ms step_avg:67.65ms
+step:260/4150 train_time:17587ms step_avg:67.64ms
+step:261/4150 train_time:17655ms step_avg:67.64ms
+step:262/4150 train_time:17721ms step_avg:67.64ms
+step:263/4150 train_time:17789ms step_avg:67.64ms
+step:264/4150 train_time:17855ms step_avg:67.63ms
+step:265/4150 train_time:17924ms step_avg:67.64ms
+step:266/4150 train_time:17989ms step_avg:67.63ms
+step:267/4150 train_time:18057ms step_avg:67.63ms
+step:268/4150 train_time:18122ms step_avg:67.62ms
+step:269/4150 train_time:18191ms step_avg:67.63ms
+step:270/4150 train_time:18257ms step_avg:67.62ms
+step:271/4150 train_time:18327ms step_avg:67.63ms
+step:272/4150 train_time:18393ms step_avg:67.62ms
+step:273/4150 train_time:18463ms step_avg:67.63ms
+step:274/4150 train_time:18528ms step_avg:67.62ms
+step:275/4150 train_time:18597ms step_avg:67.63ms
+step:276/4150 train_time:18662ms step_avg:67.62ms
+step:277/4150 train_time:18731ms step_avg:67.62ms
+step:278/4150 train_time:18797ms step_avg:67.61ms
+step:279/4150 train_time:18867ms step_avg:67.62ms
+step:280/4150 train_time:18933ms step_avg:67.62ms
+step:281/4150 train_time:19002ms step_avg:67.62ms
+step:282/4150 train_time:19068ms step_avg:67.62ms
+step:283/4150 train_time:19137ms step_avg:67.62ms
+step:284/4150 train_time:19202ms step_avg:67.61ms
+step:285/4150 train_time:19271ms step_avg:67.62ms
+step:286/4150 train_time:19338ms step_avg:67.62ms
+step:287/4150 train_time:19408ms step_avg:67.62ms
+step:288/4150 train_time:19474ms step_avg:67.62ms
+step:289/4150 train_time:19543ms step_avg:67.62ms
+step:290/4150 train_time:19608ms step_avg:67.61ms
+step:291/4150 train_time:19677ms step_avg:67.62ms
+step:292/4150 train_time:19742ms step_avg:67.61ms
+step:293/4150 train_time:19811ms step_avg:67.61ms
+step:294/4150 train_time:19876ms step_avg:67.61ms
+step:295/4150 train_time:19945ms step_avg:67.61ms
+step:296/4150 train_time:20011ms step_avg:67.60ms
+step:297/4150 train_time:20079ms step_avg:67.61ms
+step:298/4150 train_time:20144ms step_avg:67.60ms
+step:299/4150 train_time:20213ms step_avg:67.60ms
+step:300/4150 train_time:20279ms step_avg:67.60ms
+step:301/4150 train_time:20347ms step_avg:67.60ms
+step:302/4150 train_time:20414ms step_avg:67.60ms
+step:303/4150 train_time:20483ms step_avg:67.60ms
+step:304/4150 train_time:20549ms step_avg:67.60ms
+step:305/4150 train_time:20618ms step_avg:67.60ms
+step:306/4150 train_time:20683ms step_avg:67.59ms
+step:307/4150 train_time:20753ms step_avg:67.60ms
+step:308/4150 train_time:20818ms step_avg:67.59ms
+step:309/4150 train_time:20886ms step_avg:67.59ms
+step:310/4150 train_time:20952ms step_avg:67.59ms
+step:311/4150 train_time:21023ms step_avg:67.60ms
+step:312/4150 train_time:21088ms step_avg:67.59ms
+step:313/4150 train_time:21157ms step_avg:67.59ms
+step:314/4150 train_time:21221ms step_avg:67.58ms
+step:315/4150 train_time:21291ms step_avg:67.59ms
+step:316/4150 train_time:21356ms step_avg:67.58ms
+step:317/4150 train_time:21426ms step_avg:67.59ms
+step:318/4150 train_time:21492ms step_avg:67.58ms
+step:319/4150 train_time:21561ms step_avg:67.59ms
+step:320/4150 train_time:21627ms step_avg:67.58ms
+step:321/4150 train_time:21696ms step_avg:67.59ms
+step:322/4150 train_time:21761ms step_avg:67.58ms
+step:323/4150 train_time:21830ms step_avg:67.58ms
+step:324/4150 train_time:21895ms step_avg:67.58ms
+step:325/4150 train_time:21964ms step_avg:67.58ms
+step:326/4150 train_time:22029ms step_avg:67.57ms
+step:327/4150 train_time:22099ms step_avg:67.58ms
+step:328/4150 train_time:22163ms step_avg:67.57ms
+step:329/4150 train_time:22233ms step_avg:67.58ms
+step:330/4150 train_time:22298ms step_avg:67.57ms
+step:331/4150 train_time:22366ms step_avg:67.57ms
+step:332/4150 train_time:22432ms step_avg:67.57ms
+step:333/4150 train_time:22501ms step_avg:67.57ms
+step:334/4150 train_time:22566ms step_avg:67.56ms
+step:335/4150 train_time:22635ms step_avg:67.57ms
+step:336/4150 train_time:22701ms step_avg:67.56ms
+step:337/4150 train_time:22770ms step_avg:67.57ms
+step:338/4150 train_time:22835ms step_avg:67.56ms
+step:339/4150 train_time:22904ms step_avg:67.56ms
+step:340/4150 train_time:22969ms step_avg:67.56ms
+step:341/4150 train_time:23038ms step_avg:67.56ms
+step:342/4150 train_time:23103ms step_avg:67.55ms
+step:343/4150 train_time:23172ms step_avg:67.56ms
+step:344/4150 train_time:23237ms step_avg:67.55ms
+step:345/4150 train_time:23310ms step_avg:67.57ms
+step:346/4150 train_time:23431ms step_avg:67.72ms
+step:347/4150 train_time:23554ms step_avg:67.88ms
+step:348/4150 train_time:23677ms step_avg:68.04ms
+step:349/4150 train_time:23799ms step_avg:68.19ms
+step:350/4150 train_time:23919ms step_avg:68.34ms
+step:351/4150 train_time:24041ms step_avg:68.49ms
+step:352/4150 train_time:24164ms step_avg:68.65ms
+step:353/4150 train_time:24284ms step_avg:68.79ms
+step:354/4150 train_time:24404ms step_avg:68.94ms
+step:355/4150 train_time:24525ms step_avg:69.09ms
+step:356/4150 train_time:24647ms step_avg:69.23ms
+step:357/4150 train_time:24769ms step_avg:69.38ms
+step:358/4150 train_time:24891ms step_avg:69.53ms
+step:359/4150 train_time:25014ms step_avg:69.68ms
+step:360/4150 train_time:25136ms step_avg:69.82ms
+step:361/4150 train_time:25258ms step_avg:69.97ms
+step:362/4150 train_time:25378ms step_avg:70.10ms
+step:363/4150 train_time:25498ms step_avg:70.24ms
+step:364/4150 train_time:25619ms step_avg:70.38ms
+step:365/4150 train_time:25742ms step_avg:70.52ms
+step:366/4150 train_time:25861ms step_avg:70.66ms
+step:367/4150 train_time:25984ms step_avg:70.80ms
+step:368/4150 train_time:26106ms step_avg:70.94ms
+step:369/4150 train_time:26229ms step_avg:71.08ms
+step:370/4150 train_time:26350ms step_avg:71.22ms
+step:371/4150 train_time:26473ms step_avg:71.36ms
+step:372/4150 train_time:26595ms step_avg:71.49ms
+step:373/4150 train_time:26718ms step_avg:71.63ms
+step:374/4150 train_time:26837ms step_avg:71.76ms
+step:375/4150 train_time:26961ms step_avg:71.90ms
+step:376/4150 train_time:27081ms step_avg:72.03ms
+step:377/4150 train_time:27203ms step_avg:72.16ms
+step:378/4150 train_time:27323ms step_avg:72.28ms
+step:379/4150 train_time:27445ms step_avg:72.41ms
+step:380/4150 train_time:27566ms step_avg:72.54ms
+step:381/4150 train_time:27689ms step_avg:72.67ms
+step:382/4150 train_time:27809ms step_avg:72.80ms
+step:383/4150 train_time:27932ms step_avg:72.93ms
+step:384/4150 train_time:28054ms step_avg:73.06ms
+step:385/4150 train_time:28176ms step_avg:73.18ms
+step:386/4150 train_time:28296ms step_avg:73.31ms
+step:387/4150 train_time:28418ms step_avg:73.43ms
+step:388/4150 train_time:28539ms step_avg:73.55ms
+step:389/4150 train_time:28662ms step_avg:73.68ms
+step:390/4150 train_time:28781ms step_avg:73.80ms
+step:391/4150 train_time:28904ms step_avg:73.92ms
+step:392/4150 train_time:29025ms step_avg:74.04ms
+step:393/4150 train_time:29148ms step_avg:74.17ms
+step:394/4150 train_time:29270ms step_avg:74.29ms
+step:395/4150 train_time:29393ms step_avg:74.41ms
+step:396/4150 train_time:29513ms step_avg:74.53ms
+step:397/4150 train_time:29636ms step_avg:74.65ms
+step:398/4150 train_time:29758ms step_avg:74.77ms
+step:399/4150 train_time:29880ms step_avg:74.89ms
+step:400/4150 train_time:30000ms step_avg:75.00ms
+step:401/4150 train_time:30123ms step_avg:75.12ms
+step:402/4150 train_time:30243ms step_avg:75.23ms
+step:403/4150 train_time:30365ms step_avg:75.35ms
+step:404/4150 train_time:30485ms step_avg:75.46ms
+step:405/4150 train_time:30606ms step_avg:75.57ms
+step:406/4150 train_time:30728ms step_avg:75.68ms
+step:407/4150 train_time:30851ms step_avg:75.80ms
+step:408/4150 train_time:30970ms step_avg:75.91ms
+step:409/4150 train_time:31092ms step_avg:76.02ms
+step:410/4150 train_time:31212ms step_avg:76.13ms
+step:411/4150 train_time:31334ms step_avg:76.24ms
+step:412/4150 train_time:31454ms step_avg:76.35ms
+step:413/4150 train_time:31577ms step_avg:76.46ms
+step:414/4150 train_time:31697ms step_avg:76.56ms
+step:415/4150 train_time:31821ms step_avg:76.68ms
+step:416/4150 train_time:31942ms step_avg:76.78ms
+step:417/4150 train_time:32063ms step_avg:76.89ms
+step:418/4150 train_time:32184ms step_avg:77.00ms
+step:419/4150 train_time:32306ms step_avg:77.10ms
+step:420/4150 train_time:32427ms step_avg:77.21ms
+step:421/4150 train_time:32549ms step_avg:77.31ms
+step:422/4150 train_time:32669ms step_avg:77.41ms
+step:423/4150 train_time:32790ms step_avg:77.52ms
+step:424/4150 train_time:32912ms step_avg:77.62ms
+step:425/4150 train_time:33035ms step_avg:77.73ms
+step:426/4150 train_time:33156ms step_avg:77.83ms
+step:427/4150 train_time:33279ms step_avg:77.94ms
+step:428/4150 train_time:33399ms step_avg:78.03ms
+step:429/4150 train_time:33521ms step_avg:78.14ms
+step:430/4150 train_time:33641ms step_avg:78.24ms
+step:431/4150 train_time:33764ms step_avg:78.34ms
+step:432/4150 train_time:33884ms step_avg:78.43ms
+step:433/4150 train_time:34005ms step_avg:78.53ms
+step:434/4150 train_time:34126ms step_avg:78.63ms
+step:435/4150 train_time:34248ms step_avg:78.73ms
+step:436/4150 train_time:34370ms step_avg:78.83ms
+step:437/4150 train_time:34492ms step_avg:78.93ms
+step:438/4150 train_time:34613ms step_avg:79.02ms
+step:439/4150 train_time:34735ms step_avg:79.12ms
+step:440/4150 train_time:34857ms step_avg:79.22ms
+step:441/4150 train_time:34979ms step_avg:79.32ms
+step:442/4150 train_time:35100ms step_avg:79.41ms
+step:443/4150 train_time:35224ms step_avg:79.51ms
+step:444/4150 train_time:35342ms step_avg:79.60ms
+step:445/4150 train_time:35465ms step_avg:79.70ms
+step:446/4150 train_time:35585ms step_avg:79.79ms
+step:447/4150 train_time:35705ms step_avg:79.88ms
+step:448/4150 train_time:35826ms step_avg:79.97ms
+step:449/4150 train_time:35948ms step_avg:80.06ms
+step:450/4150 train_time:36070ms step_avg:80.15ms
+step:451/4150 train_time:36191ms step_avg:80.25ms
+step:452/4150 train_time:36311ms step_avg:80.34ms
+step:453/4150 train_time:36434ms step_avg:80.43ms
+step:454/4150 train_time:36556ms step_avg:80.52ms
+step:455/4150 train_time:36680ms step_avg:80.61ms
+step:456/4150 train_time:36800ms step_avg:80.70ms
+step:457/4150 train_time:36922ms step_avg:80.79ms
+step:458/4150 train_time:37042ms step_avg:80.88ms
+step:459/4150 train_time:37164ms step_avg:80.97ms
+step:460/4150 train_time:37284ms step_avg:81.05ms
+step:461/4150 train_time:37405ms step_avg:81.14ms
+step:462/4150 train_time:37527ms step_avg:81.23ms
+step:463/4150 train_time:37650ms step_avg:81.32ms
+step:464/4150 train_time:37769ms step_avg:81.40ms
+step:465/4150 train_time:37890ms step_avg:81.48ms
+step:466/4150 train_time:38011ms step_avg:81.57ms
+step:467/4150 train_time:38134ms step_avg:81.66ms
+step:468/4150 train_time:38254ms step_avg:81.74ms
+step:469/4150 train_time:38377ms step_avg:81.83ms
+step:470/4150 train_time:38498ms step_avg:81.91ms
+step:471/4150 train_time:38621ms step_avg:82.00ms
+step:472/4150 train_time:38741ms step_avg:82.08ms
+step:473/4150 train_time:38863ms step_avg:82.16ms
+step:474/4150 train_time:38983ms step_avg:82.24ms
+step:475/4150 train_time:39105ms step_avg:82.33ms
+step:476/4150 train_time:39226ms step_avg:82.41ms
+step:477/4150 train_time:39349ms step_avg:82.49ms
+step:478/4150 train_time:39469ms step_avg:82.57ms
+step:479/4150 train_time:39590ms step_avg:82.65ms
+step:480/4150 train_time:39711ms step_avg:82.73ms
+step:481/4150 train_time:39833ms step_avg:82.81ms
+step:482/4150 train_time:39954ms step_avg:82.89ms
+step:483/4150 train_time:40075ms step_avg:82.97ms
+step:484/4150 train_time:40195ms step_avg:83.05ms
+step:485/4150 train_time:40318ms step_avg:83.13ms
+step:486/4150 train_time:40439ms step_avg:83.21ms
+step:487/4150 train_time:40562ms step_avg:83.29ms
+step:488/4150 train_time:40682ms step_avg:83.36ms
+step:489/4150 train_time:40803ms step_avg:83.44ms
+step:490/4150 train_time:40923ms step_avg:83.52ms
+step:491/4150 train_time:41045ms step_avg:83.59ms
+step:492/4150 train_time:41165ms step_avg:83.67ms
+step:493/4150 train_time:41287ms step_avg:83.75ms
+step:494/4150 train_time:41407ms step_avg:83.82ms
+step:495/4150 train_time:41530ms step_avg:83.90ms
+step:496/4150 train_time:41651ms step_avg:83.97ms
+step:497/4150 train_time:41774ms step_avg:84.05ms
+step:498/4150 train_time:41894ms step_avg:84.13ms
+step:499/4150 train_time:42016ms step_avg:84.20ms
+step:500/4150 train_time:42137ms step_avg:84.27ms
+step:500/4150 val_loss:3.8979 train_time:42250ms step_avg:84.50ms
+step:501/4150 train_time:42272ms step_avg:84.37ms
+step:502/4150 train_time:42381ms step_avg:84.42ms
+step:503/4150 train_time:42507ms step_avg:84.51ms
+step:504/4150 train_time:42631ms step_avg:84.59ms
+step:505/4150 train_time:42754ms step_avg:84.66ms
+step:506/4150 train_time:42874ms step_avg:84.73ms
+step:507/4150 train_time:42996ms step_avg:84.80ms
+step:508/4150 train_time:43116ms step_avg:84.87ms
+step:509/4150 train_time:43237ms step_avg:84.95ms
+step:510/4150 train_time:43356ms step_avg:85.01ms
+step:511/4150 train_time:43479ms step_avg:85.09ms
+step:512/4150 train_time:43602ms step_avg:85.16ms
+step:513/4150 train_time:43724ms step_avg:85.23ms
+step:514/4150 train_time:43845ms step_avg:85.30ms
+step:515/4150 train_time:43968ms step_avg:85.37ms
+step:516/4150 train_time:44087ms step_avg:85.44ms
+step:517/4150 train_time:44209ms step_avg:85.51ms
+step:518/4150 train_time:44329ms step_avg:85.58ms
+step:519/4150 train_time:44451ms step_avg:85.65ms
+step:520/4150 train_time:44573ms step_avg:85.72ms
+step:521/4150 train_time:44698ms step_avg:85.79ms
+step:522/4150 train_time:44817ms step_avg:85.86ms
+step:523/4150 train_time:44940ms step_avg:85.93ms
+step:524/4150 train_time:45060ms step_avg:85.99ms
+step:525/4150 train_time:45181ms step_avg:86.06ms
+step:526/4150 train_time:45300ms step_avg:86.12ms
+step:527/4150 train_time:45422ms step_avg:86.19ms
+step:528/4150 train_time:45542ms step_avg:86.25ms
+step:529/4150 train_time:45665ms step_avg:86.32ms
+step:530/4150 train_time:45786ms step_avg:86.39ms
+step:531/4150 train_time:45910ms step_avg:86.46ms
+step:532/4150 train_time:46031ms step_avg:86.52ms
+step:533/4150 train_time:46153ms step_avg:86.59ms
+step:534/4150 train_time:46273ms step_avg:86.65ms
+step:535/4150 train_time:46395ms step_avg:86.72ms
+step:536/4150 train_time:46514ms step_avg:86.78ms
+step:537/4150 train_time:46636ms step_avg:86.85ms
+step:538/4150 train_time:46757ms step_avg:86.91ms
+step:539/4150 train_time:46880ms step_avg:86.98ms
+step:540/4150 train_time:47001ms step_avg:87.04ms
+step:541/4150 train_time:47121ms step_avg:87.10ms
+step:542/4150 train_time:47242ms step_avg:87.16ms
+step:543/4150 train_time:47363ms step_avg:87.23ms
+step:544/4150 train_time:47482ms step_avg:87.28ms
+step:545/4150 train_time:47604ms step_avg:87.35ms
+step:546/4150 train_time:47723ms step_avg:87.41ms
+step:547/4150 train_time:47846ms step_avg:87.47ms
+step:548/4150 train_time:47969ms step_avg:87.53ms
+step:549/4150 train_time:48091ms step_avg:87.60ms
+step:550/4150 train_time:48212ms step_avg:87.66ms
+step:551/4150 train_time:48333ms step_avg:87.72ms
+step:552/4150 train_time:48454ms step_avg:87.78ms
+step:553/4150 train_time:48578ms step_avg:87.84ms
+step:554/4150 train_time:48697ms step_avg:87.90ms
+step:555/4150 train_time:48819ms step_avg:87.96ms
+step:556/4150 train_time:48939ms step_avg:88.02ms
+step:557/4150 train_time:49061ms step_avg:88.08ms
+step:558/4150 train_time:49181ms step_avg:88.14ms
+step:559/4150 train_time:49303ms step_avg:88.20ms
+step:560/4150 train_time:49422ms step_avg:88.25ms
+step:561/4150 train_time:49545ms step_avg:88.31ms
+step:562/4150 train_time:49666ms step_avg:88.37ms
+step:563/4150 train_time:49787ms step_avg:88.43ms
+step:564/4150 train_time:49909ms step_avg:88.49ms
+step:565/4150 train_time:50032ms step_avg:88.55ms
+step:566/4150 train_time:50153ms step_avg:88.61ms
+step:567/4150 train_time:50276ms step_avg:88.67ms
+step:568/4150 train_time:50396ms step_avg:88.72ms
+step:569/4150 train_time:50518ms step_avg:88.78ms
+step:570/4150 train_time:50637ms step_avg:88.84ms
+step:571/4150 train_time:50760ms step_avg:88.90ms
+step:572/4150 train_time:50879ms step_avg:88.95ms
+step:573/4150 train_time:51001ms step_avg:89.01ms
+step:574/4150 train_time:51122ms step_avg:89.06ms
+step:575/4150 train_time:51245ms step_avg:89.12ms
+step:576/4150 train_time:51367ms step_avg:89.18ms
+step:577/4150 train_time:51489ms step_avg:89.24ms
+step:578/4150 train_time:51610ms step_avg:89.29ms
+step:579/4150 train_time:51731ms step_avg:89.35ms
+step:580/4150 train_time:51852ms step_avg:89.40ms
+step:581/4150 train_time:51974ms step_avg:89.46ms
+step:582/4150 train_time:52094ms step_avg:89.51ms
+step:583/4150 train_time:52217ms step_avg:89.57ms
+step:584/4150 train_time:52337ms step_avg:89.62ms
+step:585/4150 train_time:52459ms step_avg:89.67ms
+step:586/4150 train_time:52581ms step_avg:89.73ms
+step:587/4150 train_time:52702ms step_avg:89.78ms
+step:588/4150 train_time:52821ms step_avg:89.83ms
+step:589/4150 train_time:52941ms step_avg:89.88ms
+step:590/4150 train_time:53062ms step_avg:89.94ms
+step:591/4150 train_time:53184ms step_avg:89.99ms
+step:592/4150 train_time:53307ms step_avg:90.04ms
+step:593/4150 train_time:53429ms step_avg:90.10ms
+step:594/4150 train_time:53550ms step_avg:90.15ms
+step:595/4150 train_time:53674ms step_avg:90.21ms
+step:596/4150 train_time:53794ms step_avg:90.26ms
+step:597/4150 train_time:53916ms step_avg:90.31ms
+step:598/4150 train_time:54036ms step_avg:90.36ms
+step:599/4150 train_time:54159ms step_avg:90.41ms
+step:600/4150 train_time:54278ms step_avg:90.46ms
+step:601/4150 train_time:54400ms step_avg:90.52ms
+step:602/4150 train_time:54519ms step_avg:90.56ms
+step:603/4150 train_time:54641ms step_avg:90.62ms
+step:604/4150 train_time:54762ms step_avg:90.67ms
+step:605/4150 train_time:54885ms step_avg:90.72ms
+step:606/4150 train_time:55006ms step_avg:90.77ms
+step:607/4150 train_time:55127ms step_avg:90.82ms
+step:608/4150 train_time:55248ms step_avg:90.87ms
+step:609/4150 train_time:55371ms step_avg:90.92ms
+step:610/4150 train_time:55492ms step_avg:90.97ms
+step:611/4150 train_time:55614ms step_avg:91.02ms
+step:612/4150 train_time:55735ms step_avg:91.07ms
+step:613/4150 train_time:55858ms step_avg:91.12ms
+step:614/4150 train_time:55978ms step_avg:91.17ms
+step:615/4150 train_time:56100ms step_avg:91.22ms
+step:616/4150 train_time:56219ms step_avg:91.27ms
+step:617/4150 train_time:56341ms step_avg:91.31ms
+step:618/4150 train_time:56462ms step_avg:91.36ms
+step:619/4150 train_time:56584ms step_avg:91.41ms
+step:620/4150 train_time:56705ms step_avg:91.46ms
+step:621/4150 train_time:56827ms step_avg:91.51ms
+step:622/4150 train_time:56947ms step_avg:91.56ms
+step:623/4150 train_time:57070ms step_avg:91.61ms
+step:624/4150 train_time:57191ms step_avg:91.65ms
+step:625/4150 train_time:57313ms step_avg:91.70ms
+step:626/4150 train_time:57434ms step_avg:91.75ms
+step:627/4150 train_time:57556ms step_avg:91.80ms
+step:628/4150 train_time:57676ms step_avg:91.84ms
+step:629/4150 train_time:57799ms step_avg:91.89ms
+step:630/4150 train_time:57920ms step_avg:91.94ms
+step:631/4150 train_time:58041ms step_avg:91.98ms
+step:632/4150 train_time:58162ms step_avg:92.03ms
+step:633/4150 train_time:58285ms step_avg:92.08ms
+step:634/4150 train_time:58407ms step_avg:92.12ms
+step:635/4150 train_time:58529ms step_avg:92.17ms
+step:636/4150 train_time:58651ms step_avg:92.22ms
+step:637/4150 train_time:58775ms step_avg:92.27ms
+step:638/4150 train_time:58895ms step_avg:92.31ms
+step:639/4150 train_time:59017ms step_avg:92.36ms
+step:640/4150 train_time:59137ms step_avg:92.40ms
+step:641/4150 train_time:59258ms step_avg:92.45ms
+step:642/4150 train_time:59379ms step_avg:92.49ms
+step:643/4150 train_time:59500ms step_avg:92.54ms
+step:644/4150 train_time:59621ms step_avg:92.58ms
+step:645/4150 train_time:59743ms step_avg:92.62ms
+step:646/4150 train_time:59864ms step_avg:92.67ms
+step:647/4150 train_time:59985ms step_avg:92.71ms
+step:648/4150 train_time:60106ms step_avg:92.76ms
+step:649/4150 train_time:60226ms step_avg:92.80ms
+step:650/4150 train_time:60346ms step_avg:92.84ms
+step:651/4150 train_time:60470ms step_avg:92.89ms
+step:652/4150 train_time:60592ms step_avg:92.93ms
+step:653/4150 train_time:60715ms step_avg:92.98ms
+step:654/4150 train_time:60836ms step_avg:93.02ms
+step:655/4150 train_time:60957ms step_avg:93.06ms
+step:656/4150 train_time:61077ms step_avg:93.11ms
+step:657/4150 train_time:61200ms step_avg:93.15ms
+step:658/4150 train_time:61320ms step_avg:93.19ms
+step:659/4150 train_time:61442ms step_avg:93.24ms
+step:660/4150 train_time:61562ms step_avg:93.28ms
+step:661/4150 train_time:61685ms step_avg:93.32ms
+step:662/4150 train_time:61805ms step_avg:93.36ms
+step:663/4150 train_time:61926ms step_avg:93.40ms
+step:664/4150 train_time:62049ms step_avg:93.45ms
+step:665/4150 train_time:62171ms step_avg:93.49ms
+step:666/4150 train_time:62293ms step_avg:93.53ms
+step:667/4150 train_time:62414ms step_avg:93.57ms
+step:668/4150 train_time:62535ms step_avg:93.62ms
+step:669/4150 train_time:62657ms step_avg:93.66ms
+step:670/4150 train_time:62777ms step_avg:93.70ms
+step:671/4150 train_time:62899ms step_avg:93.74ms
+step:672/4150 train_time:63018ms step_avg:93.78ms
+step:673/4150 train_time:63141ms step_avg:93.82ms
+step:674/4150 train_time:63261ms step_avg:93.86ms
+step:675/4150 train_time:63384ms step_avg:93.90ms
+step:676/4150 train_time:63503ms step_avg:93.94ms
+step:677/4150 train_time:63626ms step_avg:93.98ms
+step:678/4150 train_time:63746ms step_avg:94.02ms
+step:679/4150 train_time:63869ms step_avg:94.06ms
+step:680/4150 train_time:63991ms step_avg:94.10ms
+step:681/4150 train_time:64115ms step_avg:94.15ms
+step:682/4150 train_time:64235ms step_avg:94.19ms
+step:683/4150 train_time:64356ms step_avg:94.23ms
+step:684/4150 train_time:64476ms step_avg:94.26ms
+step:685/4150 train_time:64597ms step_avg:94.30ms
+step:686/4150 train_time:64717ms step_avg:94.34ms
+step:687/4150 train_time:64838ms step_avg:94.38ms
+step:688/4150 train_time:64958ms step_avg:94.42ms
+step:689/4150 train_time:65086ms step_avg:94.46ms
+step:690/4150 train_time:65266ms step_avg:94.59ms
+step:691/4150 train_time:65443ms step_avg:94.71ms
+step:692/4150 train_time:65623ms step_avg:94.83ms
+step:693/4150 train_time:65801ms step_avg:94.95ms
+step:694/4150 train_time:65982ms step_avg:95.08ms
+step:695/4150 train_time:66163ms step_avg:95.20ms
+step:696/4150 train_time:66343ms step_avg:95.32ms
+step:697/4150 train_time:66522ms step_avg:95.44ms
+step:698/4150 train_time:66701ms step_avg:95.56ms
+step:699/4150 train_time:66880ms step_avg:95.68ms
+step:700/4150 train_time:67062ms step_avg:95.80ms
+step:701/4150 train_time:67240ms step_avg:95.92ms
+step:702/4150 train_time:67420ms step_avg:96.04ms
+step:703/4150 train_time:67596ms step_avg:96.15ms
+step:704/4150 train_time:67775ms step_avg:96.27ms
+step:705/4150 train_time:67953ms step_avg:96.39ms
+step:706/4150 train_time:68134ms step_avg:96.51ms
+step:707/4150 train_time:68313ms step_avg:96.62ms
+step:708/4150 train_time:68493ms step_avg:96.74ms
+step:709/4150 train_time:68671ms step_avg:96.86ms
+step:710/4150 train_time:68851ms step_avg:96.97ms
+step:711/4150 train_time:69030ms step_avg:97.09ms
+step:712/4150 train_time:69211ms step_avg:97.21ms
+step:713/4150 train_time:69390ms step_avg:97.32ms
+step:714/4150 train_time:69568ms step_avg:97.43ms
+step:715/4150 train_time:69747ms step_avg:97.55ms
+step:716/4150 train_time:69926ms step_avg:97.66ms
+step:717/4150 train_time:70104ms step_avg:97.77ms
+step:718/4150 train_time:70284ms step_avg:97.89ms
+step:719/4150 train_time:70462ms step_avg:98.00ms
+step:720/4150 train_time:70641ms step_avg:98.11ms
+step:721/4150 train_time:70820ms step_avg:98.22ms
+step:722/4150 train_time:70998ms step_avg:98.34ms
+step:723/4150 train_time:71177ms step_avg:98.45ms
+step:724/4150 train_time:71357ms step_avg:98.56ms
+step:725/4150 train_time:71537ms step_avg:98.67ms
+step:726/4150 train_time:71716ms step_avg:98.78ms
+step:727/4150 train_time:71894ms step_avg:98.89ms
+step:728/4150 train_time:72077ms step_avg:99.01ms
+step:729/4150 train_time:72256ms step_avg:99.12ms
+step:730/4150 train_time:72436ms step_avg:99.23ms
+step:731/4150 train_time:72616ms step_avg:99.34ms
+step:732/4150 train_time:72796ms step_avg:99.45ms
+step:733/4150 train_time:72973ms step_avg:99.55ms
+step:734/4150 train_time:73153ms step_avg:99.66ms
+step:735/4150 train_time:73331ms step_avg:99.77ms
+step:736/4150 train_time:73511ms step_avg:99.88ms
+step:737/4150 train_time:73692ms step_avg:99.99ms
+step:738/4150 train_time:73874ms step_avg:100.10ms
+step:739/4150 train_time:74055ms step_avg:100.21ms
+step:740/4150 train_time:74235ms step_avg:100.32ms
+step:741/4150 train_time:74413ms step_avg:100.42ms
+step:742/4150 train_time:74591ms step_avg:100.53ms
+step:743/4150 train_time:74770ms step_avg:100.63ms
+step:744/4150 train_time:74951ms step_avg:100.74ms
+step:745/4150 train_time:75130ms step_avg:100.85ms
+step:746/4150 train_time:75311ms step_avg:100.95ms
+step:747/4150 train_time:75491ms step_avg:101.06ms
+step:748/4150 train_time:75669ms step_avg:101.16ms
+step:749/4150 train_time:75848ms step_avg:101.27ms
+step:750/4150 train_time:76029ms step_avg:101.37ms
+step:750/4150 val_loss:3.5661 train_time:76193ms step_avg:101.59ms
+step:751/4150 train_time:76217ms step_avg:101.49ms
+step:752/4150 train_time:76389ms step_avg:101.58ms
+step:753/4150 train_time:76578ms step_avg:101.70ms
+step:754/4150 train_time:76760ms step_avg:101.80ms
+step:755/4150 train_time:76937ms step_avg:101.90ms
+step:756/4150 train_time:77114ms step_avg:102.00ms
+step:757/4150 train_time:77293ms step_avg:102.10ms
+step:758/4150 train_time:77479ms step_avg:102.22ms
+step:759/4150 train_time:77660ms step_avg:102.32ms
+step:760/4150 train_time:77839ms step_avg:102.42ms
+step:761/4150 train_time:78017ms step_avg:102.52ms
+step:762/4150 train_time:78194ms step_avg:102.62ms
+step:763/4150 train_time:78372ms step_avg:102.72ms
+step:764/4150 train_time:78558ms step_avg:102.82ms
+step:765/4150 train_time:78739ms step_avg:102.93ms
+step:766/4150 train_time:78918ms step_avg:103.03ms
+step:767/4150 train_time:79095ms step_avg:103.12ms
+step:768/4150 train_time:79273ms step_avg:103.22ms
+step:769/4150 train_time:79452ms step_avg:103.32ms
+step:770/4150 train_time:79634ms step_avg:103.42ms
+step:771/4150 train_time:79815ms step_avg:103.52ms
+step:772/4150 train_time:79994ms step_avg:103.62ms
+step:773/4150 train_time:80171ms step_avg:103.71ms
+step:774/4150 train_time:80349ms step_avg:103.81ms
+step:775/4150 train_time:80528ms step_avg:103.91ms
+step:776/4150 train_time:80710ms step_avg:104.01ms
+step:777/4150 train_time:80889ms step_avg:104.10ms
+step:778/4150 train_time:81069ms step_avg:104.20ms
+step:779/4150 train_time:81248ms step_avg:104.30ms
+step:780/4150 train_time:81427ms step_avg:104.39ms
+step:781/4150 train_time:81604ms step_avg:104.49ms
+step:782/4150 train_time:81784ms step_avg:104.58ms
+step:783/4150 train_time:81964ms step_avg:104.68ms
+step:784/4150 train_time:82144ms step_avg:104.77ms
+step:785/4150 train_time:82322ms step_avg:104.87ms
+step:786/4150 train_time:82503ms step_avg:104.97ms
+step:787/4150 train_time:82682ms step_avg:105.06ms
+step:788/4150 train_time:82861ms step_avg:105.15ms
+step:789/4150 train_time:83039ms step_avg:105.25ms
+step:790/4150 train_time:83217ms step_avg:105.34ms
+step:791/4150 train_time:83396ms step_avg:105.43ms
+step:792/4150 train_time:83576ms step_avg:105.52ms
+step:793/4150 train_time:83755ms step_avg:105.62ms
+step:794/4150 train_time:83936ms step_avg:105.71ms
+step:795/4150 train_time:84115ms step_avg:105.81ms
+step:796/4150 train_time:84294ms step_avg:105.90ms
+step:797/4150 train_time:84472ms step_avg:105.99ms
+step:798/4150 train_time:84652ms step_avg:106.08ms
+step:799/4150 train_time:84831ms step_avg:106.17ms
+step:800/4150 train_time:85012ms step_avg:106.26ms
+step:801/4150 train_time:85191ms step_avg:106.36ms
+step:802/4150 train_time:85371ms step_avg:106.45ms
+step:803/4150 train_time:85550ms step_avg:106.54ms
+step:804/4150 train_time:85729ms step_avg:106.63ms
+step:805/4150 train_time:85908ms step_avg:106.72ms
+step:806/4150 train_time:86089ms step_avg:106.81ms
+step:807/4150 train_time:86269ms step_avg:106.90ms
+step:808/4150 train_time:86450ms step_avg:106.99ms
+step:809/4150 train_time:86626ms step_avg:107.08ms
+step:810/4150 train_time:86807ms step_avg:107.17ms
+step:811/4150 train_time:86984ms step_avg:107.25ms
+step:812/4150 train_time:87163ms step_avg:107.34ms
+step:813/4150 train_time:87341ms step_avg:107.43ms
+step:814/4150 train_time:87520ms step_avg:107.52ms
+step:815/4150 train_time:87698ms step_avg:107.60ms
+step:816/4150 train_time:87877ms step_avg:107.69ms
+step:817/4150 train_time:88056ms step_avg:107.78ms
+step:818/4150 train_time:88236ms step_avg:107.87ms
+step:819/4150 train_time:88416ms step_avg:107.96ms
+step:820/4150 train_time:88597ms step_avg:108.05ms
+step:821/4150 train_time:88779ms step_avg:108.14ms
+step:822/4150 train_time:88958ms step_avg:108.22ms
+step:823/4150 train_time:89138ms step_avg:108.31ms
+step:824/4150 train_time:89318ms step_avg:108.40ms
+step:825/4150 train_time:89494ms step_avg:108.48ms
+step:826/4150 train_time:89675ms step_avg:108.56ms
+step:827/4150 train_time:89853ms step_avg:108.65ms
+step:828/4150 train_time:90034ms step_avg:108.74ms
+step:829/4150 train_time:90213ms step_avg:108.82ms
+step:830/4150 train_time:90394ms step_avg:108.91ms
+step:831/4150 train_time:90574ms step_avg:108.99ms
+step:832/4150 train_time:90755ms step_avg:109.08ms
+step:833/4150 train_time:90933ms step_avg:109.16ms
+step:834/4150 train_time:91113ms step_avg:109.25ms
+step:835/4150 train_time:91292ms step_avg:109.33ms
+step:836/4150 train_time:91473ms step_avg:109.42ms
+step:837/4150 train_time:91653ms step_avg:109.50ms
+step:838/4150 train_time:91834ms step_avg:109.59ms
+step:839/4150 train_time:92012ms step_avg:109.67ms
+step:840/4150 train_time:92192ms step_avg:109.75ms
+step:841/4150 train_time:92370ms step_avg:109.83ms
+step:842/4150 train_time:92550ms step_avg:109.92ms
+step:843/4150 train_time:92727ms step_avg:110.00ms
+step:844/4150 train_time:92908ms step_avg:110.08ms
+step:845/4150 train_time:93087ms step_avg:110.16ms
+step:846/4150 train_time:93265ms step_avg:110.24ms
+step:847/4150 train_time:93444ms step_avg:110.32ms
+step:848/4150 train_time:93624ms step_avg:110.41ms
+step:849/4150 train_time:93802ms step_avg:110.49ms
+step:850/4150 train_time:93981ms step_avg:110.57ms
+step:851/4150 train_time:94159ms step_avg:110.65ms
+step:852/4150 train_time:94338ms step_avg:110.73ms
+step:853/4150 train_time:94517ms step_avg:110.81ms
+step:854/4150 train_time:94697ms step_avg:110.89ms
+step:855/4150 train_time:94877ms step_avg:110.97ms
+step:856/4150 train_time:95057ms step_avg:111.05ms
+step:857/4150 train_time:95234ms step_avg:111.13ms
+step:858/4150 train_time:95415ms step_avg:111.21ms
+step:859/4150 train_time:95592ms step_avg:111.28ms
+step:860/4150 train_time:95772ms step_avg:111.36ms
+step:861/4150 train_time:95950ms step_avg:111.44ms
+step:862/4150 train_time:96129ms step_avg:111.52ms
+step:863/4150 train_time:96307ms step_avg:111.60ms
+step:864/4150 train_time:96487ms step_avg:111.68ms
+step:865/4150 train_time:96666ms step_avg:111.75ms
+step:866/4150 train_time:96847ms step_avg:111.83ms
+step:867/4150 train_time:97024ms step_avg:111.91ms
+step:868/4150 train_time:97205ms step_avg:111.99ms
+step:869/4150 train_time:97383ms step_avg:112.06ms
+step:870/4150 train_time:97562ms step_avg:112.14ms
+step:871/4150 train_time:97741ms step_avg:112.22ms
+step:872/4150 train_time:97920ms step_avg:112.29ms
+step:873/4150 train_time:98098ms step_avg:112.37ms
+step:874/4150 train_time:98279ms step_avg:112.45ms
+step:875/4150 train_time:98458ms step_avg:112.52ms
+step:876/4150 train_time:98637ms step_avg:112.60ms
+step:877/4150 train_time:98815ms step_avg:112.67ms
+step:878/4150 train_time:98995ms step_avg:112.75ms
+step:879/4150 train_time:99174ms step_avg:112.83ms
+step:880/4150 train_time:99357ms step_avg:112.91ms
+step:881/4150 train_time:99541ms step_avg:112.99ms
+step:882/4150 train_time:99719ms step_avg:113.06ms
+step:883/4150 train_time:99898ms step_avg:113.13ms
+step:884/4150 train_time:100079ms step_avg:113.21ms
+step:885/4150 train_time:100260ms step_avg:113.29ms
+step:886/4150 train_time:100441ms step_avg:113.36ms
+step:887/4150 train_time:100620ms step_avg:113.44ms
+step:888/4150 train_time:100800ms step_avg:113.51ms
+step:889/4150 train_time:100976ms step_avg:113.58ms
+step:890/4150 train_time:101159ms step_avg:113.66ms
+step:891/4150 train_time:101339ms step_avg:113.74ms
+step:892/4150 train_time:101520ms step_avg:113.81ms
+step:893/4150 train_time:101698ms step_avg:113.88ms
+step:894/4150 train_time:101877ms step_avg:113.96ms
+step:895/4150 train_time:102055ms step_avg:114.03ms
+step:896/4150 train_time:102236ms step_avg:114.10ms
+step:897/4150 train_time:102415ms step_avg:114.17ms
+step:898/4150 train_time:102596ms step_avg:114.25ms
+step:899/4150 train_time:102774ms step_avg:114.32ms
+step:900/4150 train_time:102954ms step_avg:114.39ms
+step:901/4150 train_time:103131ms step_avg:114.46ms
+step:902/4150 train_time:103312ms step_avg:114.54ms
+step:903/4150 train_time:103490ms step_avg:114.61ms
+step:904/4150 train_time:103671ms step_avg:114.68ms
+step:905/4150 train_time:103852ms step_avg:114.75ms
+step:906/4150 train_time:104035ms step_avg:114.83ms
+step:907/4150 train_time:104211ms step_avg:114.90ms
+step:908/4150 train_time:104390ms step_avg:114.97ms
+step:909/4150 train_time:104567ms step_avg:115.04ms
+step:910/4150 train_time:104747ms step_avg:115.11ms
+step:911/4150 train_time:104924ms step_avg:115.17ms
+step:912/4150 train_time:105104ms step_avg:115.25ms
+step:913/4150 train_time:105282ms step_avg:115.31ms
+step:914/4150 train_time:105462ms step_avg:115.38ms
+step:915/4150 train_time:105640ms step_avg:115.45ms
+step:916/4150 train_time:105820ms step_avg:115.52ms
+step:917/4150 train_time:105999ms step_avg:115.59ms
+step:918/4150 train_time:106178ms step_avg:115.66ms
+step:919/4150 train_time:106358ms step_avg:115.73ms
+step:920/4150 train_time:106538ms step_avg:115.80ms
+step:921/4150 train_time:106718ms step_avg:115.87ms
+step:922/4150 train_time:106899ms step_avg:115.94ms
+step:923/4150 train_time:107078ms step_avg:116.01ms
+step:924/4150 train_time:107257ms step_avg:116.08ms
+step:925/4150 train_time:107435ms step_avg:116.15ms
+step:926/4150 train_time:107615ms step_avg:116.21ms
+step:927/4150 train_time:107796ms step_avg:116.29ms
+step:928/4150 train_time:107977ms step_avg:116.35ms
+step:929/4150 train_time:108156ms step_avg:116.42ms
+step:930/4150 train_time:108335ms step_avg:116.49ms
+step:931/4150 train_time:108513ms step_avg:116.56ms
+step:932/4150 train_time:108693ms step_avg:116.62ms
+step:933/4150 train_time:108874ms step_avg:116.69ms
+step:934/4150 train_time:109054ms step_avg:116.76ms
+step:935/4150 train_time:109232ms step_avg:116.83ms
+step:936/4150 train_time:109411ms step_avg:116.89ms
+step:937/4150 train_time:109589ms step_avg:116.96ms
+step:938/4150 train_time:109770ms step_avg:117.03ms
+step:939/4150 train_time:109949ms step_avg:117.09ms
+step:940/4150 train_time:110131ms step_avg:117.16ms
+step:941/4150 train_time:110312ms step_avg:117.23ms
+step:942/4150 train_time:110492ms step_avg:117.29ms
+step:943/4150 train_time:110669ms step_avg:117.36ms
+step:944/4150 train_time:110851ms step_avg:117.43ms
+step:945/4150 train_time:111028ms step_avg:117.49ms
+step:946/4150 train_time:111208ms step_avg:117.56ms
+step:947/4150 train_time:111387ms step_avg:117.62ms
+step:948/4150 train_time:111567ms step_avg:117.69ms
+step:949/4150 train_time:111744ms step_avg:117.75ms
+step:950/4150 train_time:111922ms step_avg:117.81ms
+step:951/4150 train_time:112099ms step_avg:117.87ms
+step:952/4150 train_time:112280ms step_avg:117.94ms
+step:953/4150 train_time:112458ms step_avg:118.00ms
+step:954/4150 train_time:112639ms step_avg:118.07ms
+step:955/4150 train_time:112817ms step_avg:118.13ms
+step:956/4150 train_time:112996ms step_avg:118.20ms
+step:957/4150 train_time:113175ms step_avg:118.26ms
+step:958/4150 train_time:113355ms step_avg:118.32ms
+step:959/4150 train_time:113534ms step_avg:118.39ms
+step:960/4150 train_time:113715ms step_avg:118.45ms
+step:961/4150 train_time:113894ms step_avg:118.52ms
+step:962/4150 train_time:114075ms step_avg:118.58ms
+step:963/4150 train_time:114254ms step_avg:118.64ms
+step:964/4150 train_time:114437ms step_avg:118.71ms
+step:965/4150 train_time:114615ms step_avg:118.77ms
+step:966/4150 train_time:114794ms step_avg:118.83ms
+step:967/4150 train_time:114972ms step_avg:118.90ms
+step:968/4150 train_time:115153ms step_avg:118.96ms
+step:969/4150 train_time:115332ms step_avg:119.02ms
+step:970/4150 train_time:115512ms step_avg:119.08ms
+step:971/4150 train_time:115690ms step_avg:119.15ms
+step:972/4150 train_time:115870ms step_avg:119.21ms
+step:973/4150 train_time:116048ms step_avg:119.27ms
+step:974/4150 train_time:116228ms step_avg:119.33ms
+step:975/4150 train_time:116406ms step_avg:119.39ms
+step:976/4150 train_time:116585ms step_avg:119.45ms
+step:977/4150 train_time:116765ms step_avg:119.51ms
+step:978/4150 train_time:116946ms step_avg:119.58ms
+step:979/4150 train_time:117123ms step_avg:119.63ms
+step:980/4150 train_time:117303ms step_avg:119.70ms
+step:981/4150 train_time:117480ms step_avg:119.76ms
+step:982/4150 train_time:117661ms step_avg:119.82ms
+step:983/4150 train_time:117838ms step_avg:119.88ms
+step:984/4150 train_time:118019ms step_avg:119.94ms
+step:985/4150 train_time:118198ms step_avg:120.00ms
+step:986/4150 train_time:118377ms step_avg:120.06ms
+step:987/4150 train_time:118555ms step_avg:120.12ms
+step:988/4150 train_time:118736ms step_avg:120.18ms
+step:989/4150 train_time:118915ms step_avg:120.24ms
+step:990/4150 train_time:119094ms step_avg:120.30ms
+step:991/4150 train_time:119274ms step_avg:120.36ms
+step:992/4150 train_time:119457ms step_avg:120.42ms
+step:993/4150 train_time:119636ms step_avg:120.48ms
+step:994/4150 train_time:119815ms step_avg:120.54ms
+step:995/4150 train_time:119993ms step_avg:120.60ms
+step:996/4150 train_time:120175ms step_avg:120.66ms
+step:997/4150 train_time:120352ms step_avg:120.71ms
+step:998/4150 train_time:120532ms step_avg:120.77ms
+step:999/4150 train_time:120711ms step_avg:120.83ms
+step:1000/4150 train_time:120891ms step_avg:120.89ms
+step:1000/4150 val_loss:3.4389 train_time:121057ms step_avg:121.06ms
+step:1001/4150 train_time:121080ms step_avg:120.96ms
+step:1002/4150 train_time:121254ms step_avg:121.01ms
+step:1003/4150 train_time:121437ms step_avg:121.07ms
+step:1004/4150 train_time:121616ms step_avg:121.13ms
+step:1005/4150 train_time:121792ms step_avg:121.19ms
+step:1006/4150 train_time:121972ms step_avg:121.24ms
+step:1007/4150 train_time:122150ms step_avg:121.30ms
+step:1008/4150 train_time:122334ms step_avg:121.36ms
+step:1009/4150 train_time:122516ms step_avg:121.42ms
+step:1010/4150 train_time:122695ms step_avg:121.48ms
+step:1011/4150 train_time:122873ms step_avg:121.54ms
+step:1012/4150 train_time:123052ms step_avg:121.59ms
+step:1013/4150 train_time:123229ms step_avg:121.65ms
+step:1014/4150 train_time:123412ms step_avg:121.71ms
+step:1015/4150 train_time:123594ms step_avg:121.77ms
+step:1016/4150 train_time:123773ms step_avg:121.82ms
+step:1017/4150 train_time:123952ms step_avg:121.88ms
+step:1018/4150 train_time:124128ms step_avg:121.93ms
+step:1019/4150 train_time:124306ms step_avg:121.99ms
+step:1020/4150 train_time:124488ms step_avg:122.05ms
+step:1021/4150 train_time:124665ms step_avg:122.10ms
+step:1022/4150 train_time:124846ms step_avg:122.16ms
+step:1023/4150 train_time:125023ms step_avg:122.21ms
+step:1024/4150 train_time:125200ms step_avg:122.27ms
+step:1025/4150 train_time:125379ms step_avg:122.32ms
+step:1026/4150 train_time:125558ms step_avg:122.38ms
+step:1027/4150 train_time:125737ms step_avg:122.43ms
+step:1028/4150 train_time:125918ms step_avg:122.49ms
+step:1029/4150 train_time:126097ms step_avg:122.54ms
+step:1030/4150 train_time:126276ms step_avg:122.60ms
+step:1031/4150 train_time:126456ms step_avg:122.65ms
+step:1032/4150 train_time:126637ms step_avg:122.71ms
+step:1033/4150 train_time:126819ms step_avg:122.77ms
+step:1034/4150 train_time:127053ms step_avg:122.88ms
+step:1035/4150 train_time:127287ms step_avg:122.98ms
+step:1036/4150 train_time:127525ms step_avg:123.09ms
+step:1037/4150 train_time:127755ms step_avg:123.20ms
+step:1038/4150 train_time:127990ms step_avg:123.30ms
+step:1039/4150 train_time:128220ms step_avg:123.41ms
+step:1040/4150 train_time:128455ms step_avg:123.51ms
+step:1041/4150 train_time:128687ms step_avg:123.62ms
+step:1042/4150 train_time:128921ms step_avg:123.72ms
+step:1043/4150 train_time:129152ms step_avg:123.83ms
+step:1044/4150 train_time:129390ms step_avg:123.94ms
+step:1045/4150 train_time:129621ms step_avg:124.04ms
+step:1046/4150 train_time:129855ms step_avg:124.14ms
+step:1047/4150 train_time:130089ms step_avg:124.25ms
+step:1048/4150 train_time:130326ms step_avg:124.36ms
+step:1049/4150 train_time:130556ms step_avg:124.46ms
+step:1050/4150 train_time:130795ms step_avg:124.57ms
+step:1051/4150 train_time:131031ms step_avg:124.67ms
+step:1052/4150 train_time:131266ms step_avg:124.78ms
+step:1053/4150 train_time:131497ms step_avg:124.88ms
+step:1054/4150 train_time:131734ms step_avg:124.98ms
+step:1055/4150 train_time:131967ms step_avg:125.09ms
+step:1056/4150 train_time:132202ms step_avg:125.19ms
+step:1057/4150 train_time:132433ms step_avg:125.29ms
+step:1058/4150 train_time:132667ms step_avg:125.39ms
+step:1059/4150 train_time:132899ms step_avg:125.49ms
+step:1060/4150 train_time:133134ms step_avg:125.60ms
+step:1061/4150 train_time:133364ms step_avg:125.70ms
+step:1062/4150 train_time:133600ms step_avg:125.80ms
+step:1063/4150 train_time:133831ms step_avg:125.90ms
+step:1064/4150 train_time:134067ms step_avg:126.00ms
+step:1065/4150 train_time:134299ms step_avg:126.10ms
+step:1066/4150 train_time:134532ms step_avg:126.20ms
+step:1067/4150 train_time:134765ms step_avg:126.30ms
+step:1068/4150 train_time:134998ms step_avg:126.40ms
+step:1069/4150 train_time:135230ms step_avg:126.50ms
+step:1070/4150 train_time:135466ms step_avg:126.60ms
+step:1071/4150 train_time:135697ms step_avg:126.70ms
+step:1072/4150 train_time:135933ms step_avg:126.80ms
+step:1073/4150 train_time:136166ms step_avg:126.90ms
+step:1074/4150 train_time:136402ms step_avg:127.00ms
+step:1075/4150 train_time:136635ms step_avg:127.10ms
+step:1076/4150 train_time:136869ms step_avg:127.20ms
+step:1077/4150 train_time:137102ms step_avg:127.30ms
+step:1078/4150 train_time:137336ms step_avg:127.40ms
+step:1079/4150 train_time:137570ms step_avg:127.50ms
+step:1080/4150 train_time:137804ms step_avg:127.60ms
+step:1081/4150 train_time:138037ms step_avg:127.69ms
+step:1082/4150 train_time:138270ms step_avg:127.79ms
+step:1083/4150 train_time:138503ms step_avg:127.89ms
+step:1084/4150 train_time:138737ms step_avg:127.99ms
+step:1085/4150 train_time:138968ms step_avg:128.08ms
+step:1086/4150 train_time:139203ms step_avg:128.18ms
+step:1087/4150 train_time:139436ms step_avg:128.28ms
+step:1088/4150 train_time:139671ms step_avg:128.37ms
+step:1089/4150 train_time:139901ms step_avg:128.47ms
+step:1090/4150 train_time:140135ms step_avg:128.56ms
+step:1091/4150 train_time:140366ms step_avg:128.66ms
+step:1092/4150 train_time:140601ms step_avg:128.76ms
+step:1093/4150 train_time:140834ms step_avg:128.85ms
+step:1094/4150 train_time:141069ms step_avg:128.95ms
+step:1095/4150 train_time:141302ms step_avg:129.04ms
+step:1096/4150 train_time:141535ms step_avg:129.14ms
+step:1097/4150 train_time:141769ms step_avg:129.23ms
+step:1098/4150 train_time:142003ms step_avg:129.33ms
+step:1099/4150 train_time:142235ms step_avg:129.42ms
+step:1100/4150 train_time:142469ms step_avg:129.52ms
+step:1101/4150 train_time:142700ms step_avg:129.61ms
+step:1102/4150 train_time:142932ms step_avg:129.70ms
+step:1103/4150 train_time:143162ms step_avg:129.79ms
+step:1104/4150 train_time:143398ms step_avg:129.89ms
+step:1105/4150 train_time:143630ms step_avg:129.98ms
+step:1106/4150 train_time:143866ms step_avg:130.08ms
+step:1107/4150 train_time:144098ms step_avg:130.17ms
+step:1108/4150 train_time:144334ms step_avg:130.27ms
+step:1109/4150 train_time:144566ms step_avg:130.36ms
+step:1110/4150 train_time:144800ms step_avg:130.45ms
+step:1111/4150 train_time:145033ms step_avg:130.54ms
+step:1112/4150 train_time:145268ms step_avg:130.64ms
+step:1113/4150 train_time:145500ms step_avg:130.73ms
+step:1114/4150 train_time:145734ms step_avg:130.82ms
+step:1115/4150 train_time:145967ms step_avg:130.91ms
+step:1116/4150 train_time:146203ms step_avg:131.01ms
+step:1117/4150 train_time:146434ms step_avg:131.10ms
+step:1118/4150 train_time:146670ms step_avg:131.19ms
+step:1119/4150 train_time:146904ms step_avg:131.28ms
+step:1120/4150 train_time:147138ms step_avg:131.37ms
+step:1121/4150 train_time:147370ms step_avg:131.46ms
+step:1122/4150 train_time:147606ms step_avg:131.56ms
+step:1123/4150 train_time:147836ms step_avg:131.64ms
+step:1124/4150 train_time:148075ms step_avg:131.74ms
+step:1125/4150 train_time:148308ms step_avg:131.83ms
+step:1126/4150 train_time:148540ms step_avg:131.92ms
+step:1127/4150 train_time:148772ms step_avg:132.01ms
+step:1128/4150 train_time:149011ms step_avg:132.10ms
+step:1129/4150 train_time:149242ms step_avg:132.19ms
+step:1130/4150 train_time:149477ms step_avg:132.28ms
+step:1131/4150 train_time:149709ms step_avg:132.37ms
+step:1132/4150 train_time:149943ms step_avg:132.46ms
+step:1133/4150 train_time:150173ms step_avg:132.54ms
+step:1134/4150 train_time:150408ms step_avg:132.63ms
+step:1135/4150 train_time:150637ms step_avg:132.72ms
+step:1136/4150 train_time:150872ms step_avg:132.81ms
+step:1137/4150 train_time:151104ms step_avg:132.90ms
+step:1138/4150 train_time:151339ms step_avg:132.99ms
+step:1139/4150 train_time:151571ms step_avg:133.07ms
+step:1140/4150 train_time:151808ms step_avg:133.16ms
+step:1141/4150 train_time:152040ms step_avg:133.25ms
+step:1142/4150 train_time:152274ms step_avg:133.34ms
+step:1143/4150 train_time:152508ms step_avg:133.43ms
+step:1144/4150 train_time:152741ms step_avg:133.51ms
+step:1145/4150 train_time:152975ms step_avg:133.60ms
+step:1146/4150 train_time:153209ms step_avg:133.69ms
+step:1147/4150 train_time:153439ms step_avg:133.77ms
+step:1148/4150 train_time:153675ms step_avg:133.86ms
+step:1149/4150 train_time:153908ms step_avg:133.95ms
+step:1150/4150 train_time:154145ms step_avg:134.04ms
+step:1151/4150 train_time:154376ms step_avg:134.12ms
+step:1152/4150 train_time:154611ms step_avg:134.21ms
+step:1153/4150 train_time:154844ms step_avg:134.30ms
+step:1154/4150 train_time:155080ms step_avg:134.38ms
+step:1155/4150 train_time:155311ms step_avg:134.47ms
+step:1156/4150 train_time:155547ms step_avg:134.56ms
+step:1157/4150 train_time:155777ms step_avg:134.64ms
+step:1158/4150 train_time:156011ms step_avg:134.72ms
+step:1159/4150 train_time:156242ms step_avg:134.81ms
+step:1160/4150 train_time:156476ms step_avg:134.89ms
+step:1161/4150 train_time:156709ms step_avg:134.98ms
+step:1162/4150 train_time:156946ms step_avg:135.07ms
+step:1163/4150 train_time:157176ms step_avg:135.15ms
+step:1164/4150 train_time:157410ms step_avg:135.23ms
+step:1165/4150 train_time:157641ms step_avg:135.31ms
+step:1166/4150 train_time:157876ms step_avg:135.40ms
+step:1167/4150 train_time:158109ms step_avg:135.48ms
+step:1168/4150 train_time:158343ms step_avg:135.57ms
+step:1169/4150 train_time:158572ms step_avg:135.65ms
+step:1170/4150 train_time:158807ms step_avg:135.73ms
+step:1171/4150 train_time:159037ms step_avg:135.81ms
+step:1172/4150 train_time:159273ms step_avg:135.90ms
+step:1173/4150 train_time:159506ms step_avg:135.98ms
+step:1174/4150 train_time:159741ms step_avg:136.07ms
+step:1175/4150 train_time:159972ms step_avg:136.15ms
+step:1176/4150 train_time:160207ms step_avg:136.23ms
+step:1177/4150 train_time:160438ms step_avg:136.31ms
+step:1178/4150 train_time:160672ms step_avg:136.39ms
+step:1179/4150 train_time:160902ms step_avg:136.47ms
+step:1180/4150 train_time:161137ms step_avg:136.56ms
+step:1181/4150 train_time:161370ms step_avg:136.64ms
+step:1182/4150 train_time:161607ms step_avg:136.72ms
+step:1183/4150 train_time:161838ms step_avg:136.80ms
+step:1184/4150 train_time:162073ms step_avg:136.89ms
+step:1185/4150 train_time:162305ms step_avg:136.97ms
+step:1186/4150 train_time:162539ms step_avg:137.05ms
+step:1187/4150 train_time:162771ms step_avg:137.13ms
+step:1188/4150 train_time:163009ms step_avg:137.21ms
+step:1189/4150 train_time:163237ms step_avg:137.29ms
+step:1190/4150 train_time:163472ms step_avg:137.37ms
+step:1191/4150 train_time:163702ms step_avg:137.45ms
+step:1192/4150 train_time:163939ms step_avg:137.53ms
+step:1193/4150 train_time:164169ms step_avg:137.61ms
+step:1194/4150 train_time:164405ms step_avg:137.69ms
+step:1195/4150 train_time:164637ms step_avg:137.77ms
+step:1196/4150 train_time:164872ms step_avg:137.85ms
+step:1197/4150 train_time:165103ms step_avg:137.93ms
+step:1198/4150 train_time:165336ms step_avg:138.01ms
+step:1199/4150 train_time:165567ms step_avg:138.09ms
+step:1200/4150 train_time:165802ms step_avg:138.17ms
+step:1201/4150 train_time:166034ms step_avg:138.25ms
+step:1202/4150 train_time:166268ms step_avg:138.33ms
+step:1203/4150 train_time:166499ms step_avg:138.40ms
+step:1204/4150 train_time:166736ms step_avg:138.48ms
+step:1205/4150 train_time:166971ms step_avg:138.57ms
+step:1206/4150 train_time:167210ms step_avg:138.65ms
+step:1207/4150 train_time:167438ms step_avg:138.72ms
+step:1208/4150 train_time:167673ms step_avg:138.80ms
+step:1209/4150 train_time:167904ms step_avg:138.88ms
+step:1210/4150 train_time:168139ms step_avg:138.96ms
+step:1211/4150 train_time:168370ms step_avg:139.03ms
+step:1212/4150 train_time:168606ms step_avg:139.11ms
+step:1213/4150 train_time:168838ms step_avg:139.19ms
+step:1214/4150 train_time:169073ms step_avg:139.27ms
+step:1215/4150 train_time:169305ms step_avg:139.35ms
+step:1216/4150 train_time:169539ms step_avg:139.42ms
+step:1217/4150 train_time:169771ms step_avg:139.50ms
+step:1218/4150 train_time:170006ms step_avg:139.58ms
+step:1219/4150 train_time:170237ms step_avg:139.65ms
+step:1220/4150 train_time:170472ms step_avg:139.73ms
+step:1221/4150 train_time:170702ms step_avg:139.80ms
+step:1222/4150 train_time:170935ms step_avg:139.88ms
+step:1223/4150 train_time:171167ms step_avg:139.96ms
+step:1224/4150 train_time:171400ms step_avg:140.03ms
+step:1225/4150 train_time:171631ms step_avg:140.11ms
+step:1226/4150 train_time:171865ms step_avg:140.18ms
+step:1227/4150 train_time:172098ms step_avg:140.26ms
+step:1228/4150 train_time:172331ms step_avg:140.33ms
+step:1229/4150 train_time:172562ms step_avg:140.41ms
+step:1230/4150 train_time:172798ms step_avg:140.49ms
+step:1231/4150 train_time:173031ms step_avg:140.56ms
+step:1232/4150 train_time:173266ms step_avg:140.64ms
+step:1233/4150 train_time:173497ms step_avg:140.71ms
+step:1234/4150 train_time:173732ms step_avg:140.79ms
+step:1235/4150 train_time:173963ms step_avg:140.86ms
+step:1236/4150 train_time:174200ms step_avg:140.94ms
+step:1237/4150 train_time:174433ms step_avg:141.01ms
+step:1238/4150 train_time:174668ms step_avg:141.09ms
+step:1239/4150 train_time:174901ms step_avg:141.16ms
+step:1240/4150 train_time:175133ms step_avg:141.24ms
+step:1241/4150 train_time:175366ms step_avg:141.31ms
+step:1242/4150 train_time:175600ms step_avg:141.38ms
+step:1243/4150 train_time:175830ms step_avg:141.46ms
+step:1244/4150 train_time:176064ms step_avg:141.53ms
+step:1245/4150 train_time:176294ms step_avg:141.60ms
+step:1246/4150 train_time:176530ms step_avg:141.68ms
+step:1247/4150 train_time:176760ms step_avg:141.75ms
+step:1248/4150 train_time:176994ms step_avg:141.82ms
+step:1249/4150 train_time:177227ms step_avg:141.89ms
+step:1250/4150 train_time:177461ms step_avg:141.97ms
+step:1250/4150 val_loss:3.3547 train_time:177675ms step_avg:142.14ms
+step:1251/4150 train_time:177698ms step_avg:142.04ms
+step:1252/4150 train_time:177934ms step_avg:142.12ms
+step:1253/4150 train_time:178169ms step_avg:142.19ms
+step:1254/4150 train_time:178402ms step_avg:142.27ms
+step:1255/4150 train_time:178630ms step_avg:142.33ms
+step:1256/4150 train_time:178866ms step_avg:142.41ms
+step:1257/4150 train_time:179100ms step_avg:142.48ms
+step:1258/4150 train_time:179332ms step_avg:142.55ms
+step:1259/4150 train_time:179563ms step_avg:142.62ms
+step:1260/4150 train_time:179797ms step_avg:142.70ms
+step:1261/4150 train_time:180031ms step_avg:142.77ms
+step:1262/4150 train_time:180269ms step_avg:142.84ms
+step:1263/4150 train_time:180497ms step_avg:142.91ms
+step:1264/4150 train_time:180731ms step_avg:142.98ms
+step:1265/4150 train_time:180963ms step_avg:143.05ms
+step:1266/4150 train_time:181198ms step_avg:143.13ms
+step:1267/4150 train_time:181429ms step_avg:143.20ms
+step:1268/4150 train_time:181663ms step_avg:143.27ms
+step:1269/4150 train_time:181895ms step_avg:143.34ms
+step:1270/4150 train_time:182131ms step_avg:143.41ms
+step:1271/4150 train_time:182366ms step_avg:143.48ms
+step:1272/4150 train_time:182600ms step_avg:143.55ms
+step:1273/4150 train_time:182831ms step_avg:143.62ms
+step:1274/4150 train_time:183066ms step_avg:143.69ms
+step:1275/4150 train_time:183297ms step_avg:143.76ms
+step:1276/4150 train_time:183531ms step_avg:143.83ms
+step:1277/4150 train_time:183762ms step_avg:143.90ms
+step:1278/4150 train_time:183997ms step_avg:143.97ms
+step:1279/4150 train_time:184230ms step_avg:144.04ms
+step:1280/4150 train_time:184465ms step_avg:144.11ms
+step:1281/4150 train_time:184697ms step_avg:144.18ms
+step:1282/4150 train_time:184931ms step_avg:144.25ms
+step:1283/4150 train_time:185164ms step_avg:144.32ms
+step:1284/4150 train_time:185399ms step_avg:144.39ms
+step:1285/4150 train_time:185631ms step_avg:144.46ms
+step:1286/4150 train_time:185863ms step_avg:144.53ms
+step:1287/4150 train_time:186097ms step_avg:144.60ms
+step:1288/4150 train_time:186332ms step_avg:144.67ms
+step:1289/4150 train_time:186563ms step_avg:144.73ms
+step:1290/4150 train_time:186796ms step_avg:144.80ms
+step:1291/4150 train_time:187028ms step_avg:144.87ms
+step:1292/4150 train_time:187264ms step_avg:144.94ms
+step:1293/4150 train_time:187495ms step_avg:145.01ms
+step:1294/4150 train_time:187730ms step_avg:145.08ms
+step:1295/4150 train_time:187960ms step_avg:145.14ms
+step:1296/4150 train_time:188195ms step_avg:145.21ms
+step:1297/4150 train_time:188428ms step_avg:145.28ms
+step:1298/4150 train_time:188662ms step_avg:145.35ms
+step:1299/4150 train_time:188893ms step_avg:145.41ms
+step:1300/4150 train_time:189127ms step_avg:145.48ms
+step:1301/4150 train_time:189359ms step_avg:145.55ms
+step:1302/4150 train_time:189595ms step_avg:145.62ms
+step:1303/4150 train_time:189826ms step_avg:145.68ms
+step:1304/4150 train_time:190061ms step_avg:145.75ms
+step:1305/4150 train_time:190293ms step_avg:145.82ms
+step:1306/4150 train_time:190530ms step_avg:145.89ms
+step:1307/4150 train_time:190758ms step_avg:145.95ms
+step:1308/4150 train_time:190994ms step_avg:146.02ms
+step:1309/4150 train_time:191226ms step_avg:146.09ms
+step:1310/4150 train_time:191463ms step_avg:146.16ms
+step:1311/4150 train_time:191695ms step_avg:146.22ms
+step:1312/4150 train_time:191929ms step_avg:146.29ms
+step:1313/4150 train_time:192160ms step_avg:146.35ms
+step:1314/4150 train_time:192395ms step_avg:146.42ms
+step:1315/4150 train_time:192627ms step_avg:146.48ms
+step:1316/4150 train_time:192861ms step_avg:146.55ms
+step:1317/4150 train_time:193091ms step_avg:146.61ms
+step:1318/4150 train_time:193329ms step_avg:146.68ms
+step:1319/4150 train_time:193559ms step_avg:146.75ms
+step:1320/4150 train_time:193795ms step_avg:146.81ms
+step:1321/4150 train_time:194027ms step_avg:146.88ms
+step:1322/4150 train_time:194258ms step_avg:146.94ms
+step:1323/4150 train_time:194491ms step_avg:147.01ms
+step:1324/4150 train_time:194729ms step_avg:147.08ms
+step:1325/4150 train_time:194959ms step_avg:147.14ms
+step:1326/4150 train_time:195192ms step_avg:147.20ms
+step:1327/4150 train_time:195428ms step_avg:147.27ms
+step:1328/4150 train_time:195663ms step_avg:147.34ms
+step:1329/4150 train_time:195896ms step_avg:147.40ms
+step:1330/4150 train_time:196130ms step_avg:147.47ms
+step:1331/4150 train_time:196359ms step_avg:147.53ms
+step:1332/4150 train_time:196592ms step_avg:147.59ms
+step:1333/4150 train_time:196824ms step_avg:147.65ms
+step:1334/4150 train_time:197057ms step_avg:147.72ms
+step:1335/4150 train_time:197289ms step_avg:147.78ms
+step:1336/4150 train_time:197527ms step_avg:147.85ms
+step:1337/4150 train_time:197757ms step_avg:147.91ms
+step:1338/4150 train_time:197992ms step_avg:147.98ms
+step:1339/4150 train_time:198224ms step_avg:148.04ms
+step:1340/4150 train_time:198459ms step_avg:148.10ms
+step:1341/4150 train_time:198691ms step_avg:148.17ms
+step:1342/4150 train_time:198926ms step_avg:148.23ms
+step:1343/4150 train_time:199156ms step_avg:148.29ms
+step:1344/4150 train_time:199392ms step_avg:148.36ms
+step:1345/4150 train_time:199622ms step_avg:148.42ms
+step:1346/4150 train_time:199856ms step_avg:148.48ms
+step:1347/4150 train_time:200091ms step_avg:148.55ms
+step:1348/4150 train_time:200326ms step_avg:148.61ms
+step:1349/4150 train_time:200556ms step_avg:148.67ms
+step:1350/4150 train_time:200791ms step_avg:148.73ms
+step:1351/4150 train_time:201021ms step_avg:148.79ms
+step:1352/4150 train_time:201254ms step_avg:148.86ms
+step:1353/4150 train_time:201486ms step_avg:148.92ms
+step:1354/4150 train_time:201722ms step_avg:148.98ms
+step:1355/4150 train_time:201953ms step_avg:149.04ms
+step:1356/4150 train_time:202188ms step_avg:149.11ms
+step:1357/4150 train_time:202422ms step_avg:149.17ms
+step:1358/4150 train_time:202654ms step_avg:149.23ms
+step:1359/4150 train_time:202886ms step_avg:149.29ms
+step:1360/4150 train_time:203119ms step_avg:149.35ms
+step:1361/4150 train_time:203351ms step_avg:149.41ms
+step:1362/4150 train_time:203588ms step_avg:149.48ms
+step:1363/4150 train_time:203818ms step_avg:149.54ms
+step:1364/4150 train_time:204051ms step_avg:149.60ms
+step:1365/4150 train_time:204283ms step_avg:149.66ms
+step:1366/4150 train_time:204517ms step_avg:149.72ms
+step:1367/4150 train_time:204750ms step_avg:149.78ms
+step:1368/4150 train_time:204985ms step_avg:149.84ms
+step:1369/4150 train_time:205216ms step_avg:149.90ms
+step:1370/4150 train_time:205450ms step_avg:149.96ms
+step:1371/4150 train_time:205682ms step_avg:150.02ms
+step:1372/4150 train_time:205916ms step_avg:150.08ms
+step:1373/4150 train_time:206148ms step_avg:150.14ms
+step:1374/4150 train_time:206383ms step_avg:150.21ms
+step:1375/4150 train_time:206613ms step_avg:150.26ms
+step:1376/4150 train_time:206849ms step_avg:150.33ms
+step:1377/4150 train_time:207082ms step_avg:150.39ms
+step:1378/4150 train_time:207316ms step_avg:150.45ms
+step:1379/4150 train_time:207551ms step_avg:150.51ms
+step:1380/4150 train_time:207786ms step_avg:150.57ms
+step:1381/4150 train_time:208018ms step_avg:150.63ms
+step:1382/4150 train_time:208253ms step_avg:150.69ms
+step:1383/4150 train_time:208487ms step_avg:150.75ms
+step:1384/4150 train_time:208723ms step_avg:150.81ms
+step:1385/4150 train_time:208955ms step_avg:150.87ms
+step:1386/4150 train_time:209191ms step_avg:150.93ms
+step:1387/4150 train_time:209423ms step_avg:150.99ms
+step:1388/4150 train_time:209657ms step_avg:151.05ms
+step:1389/4150 train_time:209889ms step_avg:151.11ms
+step:1390/4150 train_time:210126ms step_avg:151.17ms
+step:1391/4150 train_time:210357ms step_avg:151.23ms
+step:1392/4150 train_time:210590ms step_avg:151.29ms
+step:1393/4150 train_time:210821ms step_avg:151.34ms
+step:1394/4150 train_time:211056ms step_avg:151.40ms
+step:1395/4150 train_time:211290ms step_avg:151.46ms
+step:1396/4150 train_time:211525ms step_avg:151.52ms
+step:1397/4150 train_time:211758ms step_avg:151.58ms
+step:1398/4150 train_time:211992ms step_avg:151.64ms
+step:1399/4150 train_time:212227ms step_avg:151.70ms
+step:1400/4150 train_time:212461ms step_avg:151.76ms
+step:1401/4150 train_time:212692ms step_avg:151.81ms
+step:1402/4150 train_time:212927ms step_avg:151.87ms
+step:1403/4150 train_time:213158ms step_avg:151.93ms
+step:1404/4150 train_time:213394ms step_avg:151.99ms
+step:1405/4150 train_time:213627ms step_avg:152.05ms
+step:1406/4150 train_time:213862ms step_avg:152.11ms
+step:1407/4150 train_time:214095ms step_avg:152.16ms
+step:1408/4150 train_time:214332ms step_avg:152.22ms
+step:1409/4150 train_time:214566ms step_avg:152.28ms
+step:1410/4150 train_time:214801ms step_avg:152.34ms
+step:1411/4150 train_time:215032ms step_avg:152.40ms
+step:1412/4150 train_time:215270ms step_avg:152.46ms
+step:1413/4150 train_time:215503ms step_avg:152.51ms
+step:1414/4150 train_time:215736ms step_avg:152.57ms
+step:1415/4150 train_time:215967ms step_avg:152.63ms
+step:1416/4150 train_time:216203ms step_avg:152.69ms
+step:1417/4150 train_time:216435ms step_avg:152.74ms
+step:1418/4150 train_time:216671ms step_avg:152.80ms
+step:1419/4150 train_time:216904ms step_avg:152.86ms
+step:1420/4150 train_time:217137ms step_avg:152.91ms
+step:1421/4150 train_time:217370ms step_avg:152.97ms
+step:1422/4150 train_time:217606ms step_avg:153.03ms
+step:1423/4150 train_time:217838ms step_avg:153.08ms
+step:1424/4150 train_time:218073ms step_avg:153.14ms
+step:1425/4150 train_time:218307ms step_avg:153.20ms
+step:1426/4150 train_time:218544ms step_avg:153.26ms
+step:1427/4150 train_time:218775ms step_avg:153.31ms
+step:1428/4150 train_time:219011ms step_avg:153.37ms
+step:1429/4150 train_time:219245ms step_avg:153.43ms
+step:1430/4150 train_time:219479ms step_avg:153.48ms
+step:1431/4150 train_time:219710ms step_avg:153.54ms
+step:1432/4150 train_time:219949ms step_avg:153.60ms
+step:1433/4150 train_time:220178ms step_avg:153.65ms
+step:1434/4150 train_time:220413ms step_avg:153.70ms
+step:1435/4150 train_time:220646ms step_avg:153.76ms
+step:1436/4150 train_time:220881ms step_avg:153.82ms
+step:1437/4150 train_time:221112ms step_avg:153.87ms
+step:1438/4150 train_time:221348ms step_avg:153.93ms
+step:1439/4150 train_time:221580ms step_avg:153.98ms
+step:1440/4150 train_time:221817ms step_avg:154.04ms
+step:1441/4150 train_time:222051ms step_avg:154.09ms
+step:1442/4150 train_time:222285ms step_avg:154.15ms
+step:1443/4150 train_time:222516ms step_avg:154.20ms
+step:1444/4150 train_time:222751ms step_avg:154.26ms
+step:1445/4150 train_time:222985ms step_avg:154.31ms
+step:1446/4150 train_time:223219ms step_avg:154.37ms
+step:1447/4150 train_time:223449ms step_avg:154.42ms
+step:1448/4150 train_time:223685ms step_avg:154.48ms
+step:1449/4150 train_time:223915ms step_avg:154.53ms
+step:1450/4150 train_time:224150ms step_avg:154.59ms
+step:1451/4150 train_time:224381ms step_avg:154.64ms
+step:1452/4150 train_time:224615ms step_avg:154.69ms
+step:1453/4150 train_time:224850ms step_avg:154.75ms
+step:1454/4150 train_time:225087ms step_avg:154.81ms
+step:1455/4150 train_time:225319ms step_avg:154.86ms
+step:1456/4150 train_time:225555ms step_avg:154.91ms
+step:1457/4150 train_time:225790ms step_avg:154.97ms
+step:1458/4150 train_time:226027ms step_avg:155.03ms
+step:1459/4150 train_time:226258ms step_avg:155.08ms
+step:1460/4150 train_time:226493ms step_avg:155.13ms
+step:1461/4150 train_time:226729ms step_avg:155.19ms
+step:1462/4150 train_time:226964ms step_avg:155.24ms
+step:1463/4150 train_time:227196ms step_avg:155.29ms
+step:1464/4150 train_time:227431ms step_avg:155.35ms
+step:1465/4150 train_time:227662ms step_avg:155.40ms
+step:1466/4150 train_time:227897ms step_avg:155.45ms
+step:1467/4150 train_time:228131ms step_avg:155.51ms
+step:1468/4150 train_time:228367ms step_avg:155.56ms
+step:1469/4150 train_time:228596ms step_avg:155.61ms
+step:1470/4150 train_time:228833ms step_avg:155.67ms
+step:1471/4150 train_time:229065ms step_avg:155.72ms
+step:1472/4150 train_time:229302ms step_avg:155.78ms
+step:1473/4150 train_time:229533ms step_avg:155.83ms
+step:1474/4150 train_time:229768ms step_avg:155.88ms
+step:1475/4150 train_time:230001ms step_avg:155.93ms
+step:1476/4150 train_time:230236ms step_avg:155.99ms
+step:1477/4150 train_time:230468ms step_avg:156.04ms
+step:1478/4150 train_time:230703ms step_avg:156.09ms
+step:1479/4150 train_time:230937ms step_avg:156.14ms
+step:1480/4150 train_time:231171ms step_avg:156.20ms
+step:1481/4150 train_time:231405ms step_avg:156.25ms
+step:1482/4150 train_time:231642ms step_avg:156.30ms
+step:1483/4150 train_time:231875ms step_avg:156.36ms
+step:1484/4150 train_time:232112ms step_avg:156.41ms
+step:1485/4150 train_time:232348ms step_avg:156.46ms
+step:1486/4150 train_time:232584ms step_avg:156.52ms
+step:1487/4150 train_time:232815ms step_avg:156.57ms
+step:1488/4150 train_time:233050ms step_avg:156.62ms
+step:1489/4150 train_time:233281ms step_avg:156.67ms
+step:1490/4150 train_time:233517ms step_avg:156.72ms
+step:1491/4150 train_time:233750ms step_avg:156.77ms
+step:1492/4150 train_time:233986ms step_avg:156.83ms
+step:1493/4150 train_time:234217ms step_avg:156.88ms
+step:1494/4150 train_time:234452ms step_avg:156.93ms
+step:1495/4150 train_time:234685ms step_avg:156.98ms
+step:1496/4150 train_time:234922ms step_avg:157.03ms
+step:1497/4150 train_time:235156ms step_avg:157.08ms
+step:1498/4150 train_time:235389ms step_avg:157.14ms
+step:1499/4150 train_time:235621ms step_avg:157.19ms
+step:1500/4150 train_time:235857ms step_avg:157.24ms
+step:1500/4150 val_loss:3.3061 train_time:236071ms step_avg:157.38ms
+step:1501/4150 train_time:236094ms step_avg:157.29ms
+step:1502/4150 train_time:236332ms step_avg:157.35ms
+step:1503/4150 train_time:236569ms step_avg:157.40ms
+step:1504/4150 train_time:236801ms step_avg:157.45ms
+step:1505/4150 train_time:237031ms step_avg:157.50ms
+step:1506/4150 train_time:237265ms step_avg:157.55ms
+step:1507/4150 train_time:237504ms step_avg:157.60ms
+step:1508/4150 train_time:237740ms step_avg:157.65ms
+step:1509/4150 train_time:237967ms step_avg:157.70ms
+step:1510/4150 train_time:238203ms step_avg:157.75ms
+step:1511/4150 train_time:238439ms step_avg:157.80ms
+step:1512/4150 train_time:238674ms step_avg:157.85ms
+step:1513/4150 train_time:238904ms step_avg:157.90ms
+step:1514/4150 train_time:239138ms step_avg:157.95ms
+step:1515/4150 train_time:239370ms step_avg:158.00ms
+step:1516/4150 train_time:239609ms step_avg:158.05ms
+step:1517/4150 train_time:239839ms step_avg:158.10ms
+step:1518/4150 train_time:240071ms step_avg:158.15ms
+step:1519/4150 train_time:240304ms step_avg:158.20ms
+step:1520/4150 train_time:240540ms step_avg:158.25ms
+step:1521/4150 train_time:240771ms step_avg:158.30ms
+step:1522/4150 train_time:241007ms step_avg:158.35ms
+step:1523/4150 train_time:241237ms step_avg:158.40ms
+step:1524/4150 train_time:241475ms step_avg:158.45ms
+step:1525/4150 train_time:241708ms step_avg:158.50ms
+step:1526/4150 train_time:241944ms step_avg:158.55ms
+step:1527/4150 train_time:242174ms step_avg:158.59ms
+step:1528/4150 train_time:242408ms step_avg:158.64ms
+step:1529/4150 train_time:242642ms step_avg:158.69ms
+step:1530/4150 train_time:242877ms step_avg:158.74ms
+step:1531/4150 train_time:243109ms step_avg:158.79ms
+step:1532/4150 train_time:243344ms step_avg:158.84ms
+step:1533/4150 train_time:243577ms step_avg:158.89ms
+step:1534/4150 train_time:243811ms step_avg:158.94ms
+step:1535/4150 train_time:244042ms step_avg:158.99ms
+step:1536/4150 train_time:244277ms step_avg:159.03ms
+step:1537/4150 train_time:244509ms step_avg:159.08ms
+step:1538/4150 train_time:244746ms step_avg:159.13ms
+step:1539/4150 train_time:244981ms step_avg:159.18ms
+step:1540/4150 train_time:245218ms step_avg:159.23ms
+step:1541/4150 train_time:245450ms step_avg:159.28ms
+step:1542/4150 train_time:245685ms step_avg:159.33ms
+step:1543/4150 train_time:245914ms step_avg:159.37ms
+step:1544/4150 train_time:246150ms step_avg:159.42ms
+step:1545/4150 train_time:246383ms step_avg:159.47ms
+step:1546/4150 train_time:246619ms step_avg:159.52ms
+step:1547/4150 train_time:246852ms step_avg:159.57ms
+step:1548/4150 train_time:247087ms step_avg:159.62ms
+step:1549/4150 train_time:247321ms step_avg:159.66ms
+step:1550/4150 train_time:247557ms step_avg:159.71ms
+step:1551/4150 train_time:247788ms step_avg:159.76ms
+step:1552/4150 train_time:248022ms step_avg:159.81ms
+step:1553/4150 train_time:248251ms step_avg:159.85ms
+step:1554/4150 train_time:248485ms step_avg:159.90ms
+step:1555/4150 train_time:248720ms step_avg:159.95ms
+step:1556/4150 train_time:248955ms step_avg:160.00ms
+step:1557/4150 train_time:249188ms step_avg:160.04ms
+step:1558/4150 train_time:249422ms step_avg:160.09ms
+step:1559/4150 train_time:249654ms step_avg:160.14ms
+step:1560/4150 train_time:249889ms step_avg:160.19ms
+step:1561/4150 train_time:250125ms step_avg:160.23ms
+step:1562/4150 train_time:250360ms step_avg:160.28ms
+step:1563/4150 train_time:250592ms step_avg:160.33ms
+step:1564/4150 train_time:250829ms step_avg:160.38ms
+step:1565/4150 train_time:251063ms step_avg:160.42ms
+step:1566/4150 train_time:251300ms step_avg:160.47ms
+step:1567/4150 train_time:251532ms step_avg:160.52ms
+step:1568/4150 train_time:251767ms step_avg:160.57ms
+step:1569/4150 train_time:251999ms step_avg:160.61ms
+step:1570/4150 train_time:252232ms step_avg:160.66ms
+step:1571/4150 train_time:252466ms step_avg:160.70ms
+step:1572/4150 train_time:252701ms step_avg:160.75ms
+step:1573/4150 train_time:252932ms step_avg:160.80ms
+step:1574/4150 train_time:253164ms step_avg:160.84ms
+step:1575/4150 train_time:253399ms step_avg:160.89ms
+step:1576/4150 train_time:253635ms step_avg:160.94ms
+step:1577/4150 train_time:253868ms step_avg:160.98ms
+step:1578/4150 train_time:254103ms step_avg:161.03ms
+step:1579/4150 train_time:254336ms step_avg:161.07ms
+step:1580/4150 train_time:254570ms step_avg:161.12ms
+step:1581/4150 train_time:254805ms step_avg:161.17ms
+step:1582/4150 train_time:255041ms step_avg:161.21ms
+step:1583/4150 train_time:255274ms step_avg:161.26ms
+step:1584/4150 train_time:255509ms step_avg:161.31ms
+step:1585/4150 train_time:255741ms step_avg:161.35ms
+step:1586/4150 train_time:255977ms step_avg:161.40ms
+step:1587/4150 train_time:256207ms step_avg:161.44ms
+step:1588/4150 train_time:256443ms step_avg:161.49ms
+step:1589/4150 train_time:256674ms step_avg:161.53ms
+step:1590/4150 train_time:256907ms step_avg:161.58ms
+step:1591/4150 train_time:257138ms step_avg:161.62ms
+step:1592/4150 train_time:257371ms step_avg:161.67ms
+step:1593/4150 train_time:257602ms step_avg:161.71ms
+step:1594/4150 train_time:257838ms step_avg:161.76ms
+step:1595/4150 train_time:258067ms step_avg:161.80ms
+step:1596/4150 train_time:258305ms step_avg:161.85ms
+step:1597/4150 train_time:258536ms step_avg:161.89ms
+step:1598/4150 train_time:258772ms step_avg:161.93ms
+step:1599/4150 train_time:259004ms step_avg:161.98ms
+step:1600/4150 train_time:259239ms step_avg:162.02ms
+step:1601/4150 train_time:259472ms step_avg:162.07ms
+step:1602/4150 train_time:259708ms step_avg:162.11ms
+step:1603/4150 train_time:259941ms step_avg:162.16ms
+step:1604/4150 train_time:260175ms step_avg:162.20ms
+step:1605/4150 train_time:260407ms step_avg:162.25ms
+step:1606/4150 train_time:260645ms step_avg:162.29ms
+step:1607/4150 train_time:260880ms step_avg:162.34ms
+step:1608/4150 train_time:261113ms step_avg:162.38ms
+step:1609/4150 train_time:261346ms step_avg:162.43ms
+step:1610/4150 train_time:261580ms step_avg:162.47ms
+step:1611/4150 train_time:261812ms step_avg:162.52ms
+step:1612/4150 train_time:262048ms step_avg:162.56ms
+step:1613/4150 train_time:262281ms step_avg:162.60ms
+step:1614/4150 train_time:262517ms step_avg:162.65ms
+step:1615/4150 train_time:262748ms step_avg:162.69ms
+step:1616/4150 train_time:262982ms step_avg:162.74ms
+step:1617/4150 train_time:263212ms step_avg:162.78ms
+step:1618/4150 train_time:263447ms step_avg:162.82ms
+step:1619/4150 train_time:263679ms step_avg:162.87ms
+step:1620/4150 train_time:263912ms step_avg:162.91ms
+step:1621/4150 train_time:264146ms step_avg:162.95ms
+step:1622/4150 train_time:264382ms step_avg:163.00ms
+step:1623/4150 train_time:264616ms step_avg:163.04ms
+step:1624/4150 train_time:264850ms step_avg:163.08ms
+step:1625/4150 train_time:265084ms step_avg:163.13ms
+step:1626/4150 train_time:265320ms step_avg:163.17ms
+step:1627/4150 train_time:265553ms step_avg:163.22ms
+step:1628/4150 train_time:265789ms step_avg:163.26ms
+step:1629/4150 train_time:266020ms step_avg:163.30ms
+step:1630/4150 train_time:266254ms step_avg:163.35ms
+step:1631/4150 train_time:266486ms step_avg:163.39ms
+step:1632/4150 train_time:266723ms step_avg:163.43ms
+step:1633/4150 train_time:266955ms step_avg:163.48ms
+step:1634/4150 train_time:267188ms step_avg:163.52ms
+step:1635/4150 train_time:267421ms step_avg:163.56ms
+step:1636/4150 train_time:267657ms step_avg:163.60ms
+step:1637/4150 train_time:267890ms step_avg:163.65ms
+step:1638/4150 train_time:268126ms step_avg:163.69ms
+step:1639/4150 train_time:268363ms step_avg:163.74ms
+step:1640/4150 train_time:268602ms step_avg:163.78ms
+step:1641/4150 train_time:268835ms step_avg:163.82ms
+step:1642/4150 train_time:269069ms step_avg:163.87ms
+step:1643/4150 train_time:269301ms step_avg:163.91ms
+step:1644/4150 train_time:269539ms step_avg:163.95ms
+step:1645/4150 train_time:269771ms step_avg:163.99ms
+step:1646/4150 train_time:270005ms step_avg:164.04ms
+step:1647/4150 train_time:270234ms step_avg:164.08ms
+step:1648/4150 train_time:270469ms step_avg:164.12ms
+step:1649/4150 train_time:270701ms step_avg:164.16ms
+step:1650/4150 train_time:270938ms step_avg:164.20ms
+step:1651/4150 train_time:271169ms step_avg:164.25ms
+step:1652/4150 train_time:271403ms step_avg:164.29ms
+step:1653/4150 train_time:271634ms step_avg:164.33ms
+step:1654/4150 train_time:271868ms step_avg:164.37ms
+step:1655/4150 train_time:272100ms step_avg:164.41ms
+step:1656/4150 train_time:272337ms step_avg:164.45ms
+step:1657/4150 train_time:272571ms step_avg:164.50ms
+step:1658/4150 train_time:272806ms step_avg:164.54ms
+step:1659/4150 train_time:273039ms step_avg:164.58ms
+step:1660/4150 train_time:273275ms step_avg:164.62ms
+step:1661/4150 train_time:273509ms step_avg:164.67ms
+step:1662/4150 train_time:273746ms step_avg:164.71ms
+step:1663/4150 train_time:273978ms step_avg:164.75ms
+step:1664/4150 train_time:274212ms step_avg:164.79ms
+step:1665/4150 train_time:274446ms step_avg:164.83ms
+step:1666/4150 train_time:274681ms step_avg:164.87ms
+step:1667/4150 train_time:274913ms step_avg:164.91ms
+step:1668/4150 train_time:275147ms step_avg:164.96ms
+step:1669/4150 train_time:275378ms step_avg:165.00ms
+step:1670/4150 train_time:275611ms step_avg:165.04ms
+step:1671/4150 train_time:275844ms step_avg:165.08ms
+step:1672/4150 train_time:276078ms step_avg:165.12ms
+step:1673/4150 train_time:276310ms step_avg:165.16ms
+step:1674/4150 train_time:276546ms step_avg:165.20ms
+step:1675/4150 train_time:276778ms step_avg:165.24ms
+step:1676/4150 train_time:277014ms step_avg:165.28ms
+step:1677/4150 train_time:277247ms step_avg:165.32ms
+step:1678/4150 train_time:277480ms step_avg:165.36ms
+step:1679/4150 train_time:277710ms step_avg:165.40ms
+step:1680/4150 train_time:277947ms step_avg:165.44ms
+step:1681/4150 train_time:278181ms step_avg:165.49ms
+step:1682/4150 train_time:278417ms step_avg:165.53ms
+step:1683/4150 train_time:278649ms step_avg:165.57ms
+step:1684/4150 train_time:278884ms step_avg:165.61ms
+step:1685/4150 train_time:279118ms step_avg:165.65ms
+step:1686/4150 train_time:279352ms step_avg:165.69ms
+step:1687/4150 train_time:279585ms step_avg:165.73ms
+step:1688/4150 train_time:279819ms step_avg:165.77ms
+step:1689/4150 train_time:280051ms step_avg:165.81ms
+step:1690/4150 train_time:280285ms step_avg:165.85ms
+step:1691/4150 train_time:280517ms step_avg:165.89ms
+step:1692/4150 train_time:280751ms step_avg:165.93ms
+step:1693/4150 train_time:280983ms step_avg:165.97ms
+step:1694/4150 train_time:281223ms step_avg:166.01ms
+step:1695/4150 train_time:281454ms step_avg:166.05ms
+step:1696/4150 train_time:281689ms step_avg:166.09ms
+step:1697/4150 train_time:281921ms step_avg:166.13ms
+step:1698/4150 train_time:282160ms step_avg:166.17ms
+step:1699/4150 train_time:282392ms step_avg:166.21ms
+step:1700/4150 train_time:282626ms step_avg:166.25ms
+step:1701/4150 train_time:282856ms step_avg:166.29ms
+step:1702/4150 train_time:283091ms step_avg:166.33ms
+step:1703/4150 train_time:283325ms step_avg:166.37ms
+step:1704/4150 train_time:283563ms step_avg:166.41ms
+step:1705/4150 train_time:283792ms step_avg:166.45ms
+step:1706/4150 train_time:284026ms step_avg:166.49ms
+step:1707/4150 train_time:284257ms step_avg:166.52ms
+step:1708/4150 train_time:284492ms step_avg:166.56ms
+step:1709/4150 train_time:284725ms step_avg:166.60ms
+step:1710/4150 train_time:284960ms step_avg:166.64ms
+step:1711/4150 train_time:285190ms step_avg:166.68ms
+step:1712/4150 train_time:285425ms step_avg:166.72ms
+step:1713/4150 train_time:285658ms step_avg:166.76ms
+step:1714/4150 train_time:285893ms step_avg:166.80ms
+step:1715/4150 train_time:286125ms step_avg:166.84ms
+step:1716/4150 train_time:286359ms step_avg:166.88ms
+step:1717/4150 train_time:286591ms step_avg:166.91ms
+step:1718/4150 train_time:286829ms step_avg:166.95ms
+step:1719/4150 train_time:287063ms step_avg:166.99ms
+step:1720/4150 train_time:287300ms step_avg:167.03ms
+step:1721/4150 train_time:287535ms step_avg:167.07ms
+step:1722/4150 train_time:287771ms step_avg:167.11ms
+step:1723/4150 train_time:288002ms step_avg:167.15ms
+step:1724/4150 train_time:288240ms step_avg:167.19ms
+step:1725/4150 train_time:288474ms step_avg:167.23ms
+step:1726/4150 train_time:288710ms step_avg:167.27ms
+step:1727/4150 train_time:288944ms step_avg:167.31ms
+step:1728/4150 train_time:289183ms step_avg:167.35ms
+step:1729/4150 train_time:289414ms step_avg:167.39ms
+step:1730/4150 train_time:289649ms step_avg:167.43ms
+step:1731/4150 train_time:289882ms step_avg:167.47ms
+step:1732/4150 train_time:290118ms step_avg:167.50ms
+step:1733/4150 train_time:290347ms step_avg:167.54ms
+step:1734/4150 train_time:290583ms step_avg:167.58ms
+step:1735/4150 train_time:290814ms step_avg:167.62ms
+step:1736/4150 train_time:291051ms step_avg:167.66ms
+step:1737/4150 train_time:291285ms step_avg:167.69ms
+step:1738/4150 train_time:291523ms step_avg:167.73ms
+step:1739/4150 train_time:291753ms step_avg:167.77ms
+step:1740/4150 train_time:291989ms step_avg:167.81ms
+step:1741/4150 train_time:292222ms step_avg:167.85ms
+step:1742/4150 train_time:292462ms step_avg:167.89ms
+step:1743/4150 train_time:292693ms step_avg:167.92ms
+step:1744/4150 train_time:292928ms step_avg:167.96ms
+step:1745/4150 train_time:293161ms step_avg:168.00ms
+step:1746/4150 train_time:293400ms step_avg:168.04ms
+step:1747/4150 train_time:293634ms step_avg:168.08ms
+step:1748/4150 train_time:293868ms step_avg:168.12ms
+step:1749/4150 train_time:294101ms step_avg:168.15ms
+step:1750/4150 train_time:294340ms step_avg:168.19ms
+step:1750/4150 val_loss:3.2264 train_time:294554ms step_avg:168.32ms
+step:1751/4150 train_time:294579ms step_avg:168.23ms
+step:1752/4150 train_time:294820ms step_avg:168.28ms
+step:1753/4150 train_time:295050ms step_avg:168.31ms
+step:1754/4150 train_time:295282ms step_avg:168.35ms
+step:1755/4150 train_time:295514ms step_avg:168.38ms
+step:1756/4150 train_time:295752ms step_avg:168.42ms
+step:1757/4150 train_time:295990ms step_avg:168.46ms
+step:1758/4150 train_time:296227ms step_avg:168.50ms
+step:1759/4150 train_time:296459ms step_avg:168.54ms
+step:1760/4150 train_time:296695ms step_avg:168.58ms
+step:1761/4150 train_time:296929ms step_avg:168.61ms
+step:1762/4150 train_time:297163ms step_avg:168.65ms
+step:1763/4150 train_time:297393ms step_avg:168.69ms
+step:1764/4150 train_time:297630ms step_avg:168.72ms
+step:1765/4150 train_time:297864ms step_avg:168.76ms
+step:1766/4150 train_time:298101ms step_avg:168.80ms
+step:1767/4150 train_time:298332ms step_avg:168.84ms
+step:1768/4150 train_time:298569ms step_avg:168.87ms
+step:1769/4150 train_time:298804ms step_avg:168.91ms
+step:1770/4150 train_time:299040ms step_avg:168.95ms
+step:1771/4150 train_time:299271ms step_avg:168.98ms
+step:1772/4150 train_time:299508ms step_avg:169.02ms
+step:1773/4150 train_time:299740ms step_avg:169.06ms
+step:1774/4150 train_time:299977ms step_avg:169.10ms
+step:1775/4150 train_time:300209ms step_avg:169.13ms
+step:1776/4150 train_time:300444ms step_avg:169.17ms
+step:1777/4150 train_time:300678ms step_avg:169.21ms
+step:1778/4150 train_time:300912ms step_avg:169.24ms
+step:1779/4150 train_time:301145ms step_avg:169.28ms
+step:1780/4150 train_time:301381ms step_avg:169.32ms
+step:1781/4150 train_time:301613ms step_avg:169.35ms
+step:1782/4150 train_time:301854ms step_avg:169.39ms
+step:1783/4150 train_time:302089ms step_avg:169.43ms
+step:1784/4150 train_time:302323ms step_avg:169.46ms
+step:1785/4150 train_time:302556ms step_avg:169.50ms
+step:1786/4150 train_time:302794ms step_avg:169.54ms
+step:1787/4150 train_time:303027ms step_avg:169.57ms
+step:1788/4150 train_time:303263ms step_avg:169.61ms
+step:1789/4150 train_time:303495ms step_avg:169.64ms
+step:1790/4150 train_time:303730ms step_avg:169.68ms
+step:1791/4150 train_time:303963ms step_avg:169.72ms
+step:1792/4150 train_time:304198ms step_avg:169.75ms
+step:1793/4150 train_time:304430ms step_avg:169.79ms
+step:1794/4150 train_time:304665ms step_avg:169.82ms
+step:1795/4150 train_time:304899ms step_avg:169.86ms
+step:1796/4150 train_time:305136ms step_avg:169.90ms
+step:1797/4150 train_time:305369ms step_avg:169.93ms
+step:1798/4150 train_time:305607ms step_avg:169.97ms
+step:1799/4150 train_time:305840ms step_avg:170.01ms
+step:1800/4150 train_time:306077ms step_avg:170.04ms
+step:1801/4150 train_time:306312ms step_avg:170.08ms
+step:1802/4150 train_time:306550ms step_avg:170.12ms
+step:1803/4150 train_time:306783ms step_avg:170.15ms
+step:1804/4150 train_time:307017ms step_avg:170.19ms
+step:1805/4150 train_time:307252ms step_avg:170.22ms
+step:1806/4150 train_time:307490ms step_avg:170.26ms
+step:1807/4150 train_time:307721ms step_avg:170.29ms
+step:1808/4150 train_time:307957ms step_avg:170.33ms
+step:1809/4150 train_time:308188ms step_avg:170.36ms
+step:1810/4150 train_time:308425ms step_avg:170.40ms
+step:1811/4150 train_time:308659ms step_avg:170.44ms
+step:1812/4150 train_time:308894ms step_avg:170.47ms
+step:1813/4150 train_time:309125ms step_avg:170.50ms
+step:1814/4150 train_time:309361ms step_avg:170.54ms
+step:1815/4150 train_time:309596ms step_avg:170.58ms
+step:1816/4150 train_time:309832ms step_avg:170.61ms
+step:1817/4150 train_time:310068ms step_avg:170.65ms
+step:1818/4150 train_time:310301ms step_avg:170.68ms
+step:1819/4150 train_time:310537ms step_avg:170.72ms
+step:1820/4150 train_time:310772ms step_avg:170.75ms
+step:1821/4150 train_time:311006ms step_avg:170.79ms
+step:1822/4150 train_time:311241ms step_avg:170.82ms
+step:1823/4150 train_time:311475ms step_avg:170.86ms
+step:1824/4150 train_time:311712ms step_avg:170.89ms
+step:1825/4150 train_time:311948ms step_avg:170.93ms
+step:1826/4150 train_time:312183ms step_avg:170.97ms
+step:1827/4150 train_time:312417ms step_avg:171.00ms
+step:1828/4150 train_time:312652ms step_avg:171.04ms
+step:1829/4150 train_time:312884ms step_avg:171.07ms
+step:1830/4150 train_time:313120ms step_avg:171.10ms
+step:1831/4150 train_time:313354ms step_avg:171.14ms
+step:1832/4150 train_time:313590ms step_avg:171.17ms
+step:1833/4150 train_time:313822ms step_avg:171.21ms
+step:1834/4150 train_time:314060ms step_avg:171.24ms
+step:1835/4150 train_time:314294ms step_avg:171.28ms
+step:1836/4150 train_time:314530ms step_avg:171.31ms
+step:1837/4150 train_time:314761ms step_avg:171.35ms
+step:1838/4150 train_time:314996ms step_avg:171.38ms
+step:1839/4150 train_time:315230ms step_avg:171.41ms
+step:1840/4150 train_time:315465ms step_avg:171.45ms
+step:1841/4150 train_time:315698ms step_avg:171.48ms
+step:1842/4150 train_time:315934ms step_avg:171.52ms
+step:1843/4150 train_time:316169ms step_avg:171.55ms
+step:1844/4150 train_time:316407ms step_avg:171.59ms
+step:1845/4150 train_time:316638ms step_avg:171.62ms
+step:1846/4150 train_time:316877ms step_avg:171.66ms
+step:1847/4150 train_time:317113ms step_avg:171.69ms
+step:1848/4150 train_time:317350ms step_avg:171.73ms
+step:1849/4150 train_time:317582ms step_avg:171.76ms
+step:1850/4150 train_time:317818ms step_avg:171.79ms
+step:1851/4150 train_time:318052ms step_avg:171.83ms
+step:1852/4150 train_time:318291ms step_avg:171.86ms
+step:1853/4150 train_time:318523ms step_avg:171.90ms
+step:1854/4150 train_time:318758ms step_avg:171.93ms
+step:1855/4150 train_time:318992ms step_avg:171.96ms
+step:1856/4150 train_time:319233ms step_avg:172.00ms
+step:1857/4150 train_time:319465ms step_avg:172.03ms
+step:1858/4150 train_time:319698ms step_avg:172.07ms
+step:1859/4150 train_time:319931ms step_avg:172.10ms
+step:1860/4150 train_time:320167ms step_avg:172.13ms
+step:1861/4150 train_time:320399ms step_avg:172.16ms
+step:1862/4150 train_time:320635ms step_avg:172.20ms
+step:1863/4150 train_time:320869ms step_avg:172.23ms
+step:1864/4150 train_time:321106ms step_avg:172.27ms
+step:1865/4150 train_time:321340ms step_avg:172.30ms
+step:1866/4150 train_time:321577ms step_avg:172.34ms
+step:1867/4150 train_time:321811ms step_avg:172.37ms
+step:1868/4150 train_time:322047ms step_avg:172.40ms
+step:1869/4150 train_time:322280ms step_avg:172.43ms
+step:1870/4150 train_time:322516ms step_avg:172.47ms
+step:1871/4150 train_time:322749ms step_avg:172.50ms
+step:1872/4150 train_time:322986ms step_avg:172.54ms
+step:1873/4150 train_time:323220ms step_avg:172.57ms
+step:1874/4150 train_time:323455ms step_avg:172.60ms
+step:1875/4150 train_time:323685ms step_avg:172.63ms
+step:1876/4150 train_time:323921ms step_avg:172.67ms
+step:1877/4150 train_time:324156ms step_avg:172.70ms
+step:1878/4150 train_time:324394ms step_avg:172.73ms
+step:1879/4150 train_time:324629ms step_avg:172.77ms
+step:1880/4150 train_time:324865ms step_avg:172.80ms
+step:1881/4150 train_time:325097ms step_avg:172.83ms
+step:1882/4150 train_time:325335ms step_avg:172.87ms
+step:1883/4150 train_time:325568ms step_avg:172.90ms
+step:1884/4150 train_time:325805ms step_avg:172.93ms
+step:1885/4150 train_time:326039ms step_avg:172.97ms
+step:1886/4150 train_time:326274ms step_avg:173.00ms
+step:1887/4150 train_time:326508ms step_avg:173.03ms
+step:1888/4150 train_time:326745ms step_avg:173.06ms
+step:1889/4150 train_time:326976ms step_avg:173.09ms
+step:1890/4150 train_time:327211ms step_avg:173.13ms
+step:1891/4150 train_time:327443ms step_avg:173.16ms
+step:1892/4150 train_time:327681ms step_avg:173.19ms
+step:1893/4150 train_time:327914ms step_avg:173.22ms
+step:1894/4150 train_time:328152ms step_avg:173.26ms
+step:1895/4150 train_time:328384ms step_avg:173.29ms
+step:1896/4150 train_time:328618ms step_avg:173.32ms
+step:1897/4150 train_time:328853ms step_avg:173.35ms
+step:1898/4150 train_time:329090ms step_avg:173.39ms
+step:1899/4150 train_time:329321ms step_avg:173.42ms
+step:1900/4150 train_time:329556ms step_avg:173.45ms
+step:1901/4150 train_time:329789ms step_avg:173.48ms
+step:1902/4150 train_time:330026ms step_avg:173.52ms
+step:1903/4150 train_time:330259ms step_avg:173.55ms
+step:1904/4150 train_time:330493ms step_avg:173.58ms
+step:1905/4150 train_time:330725ms step_avg:173.61ms
+step:1906/4150 train_time:330961ms step_avg:173.64ms
+step:1907/4150 train_time:331194ms step_avg:173.67ms
+step:1908/4150 train_time:331432ms step_avg:173.71ms
+step:1909/4150 train_time:331663ms step_avg:173.74ms
+step:1910/4150 train_time:331898ms step_avg:173.77ms
+step:1911/4150 train_time:332132ms step_avg:173.80ms
+step:1912/4150 train_time:332370ms step_avg:173.83ms
+step:1913/4150 train_time:332604ms step_avg:173.87ms
+step:1914/4150 train_time:332836ms step_avg:173.90ms
+step:1915/4150 train_time:333071ms step_avg:173.93ms
+step:1916/4150 train_time:333306ms step_avg:173.96ms
+step:1917/4150 train_time:333539ms step_avg:173.99ms
+step:1918/4150 train_time:333775ms step_avg:174.02ms
+step:1919/4150 train_time:334012ms step_avg:174.06ms
+step:1920/4150 train_time:334249ms step_avg:174.09ms
+step:1921/4150 train_time:334483ms step_avg:174.12ms
+step:1922/4150 train_time:334718ms step_avg:174.15ms
+step:1923/4150 train_time:334950ms step_avg:174.18ms
+step:1924/4150 train_time:335188ms step_avg:174.21ms
+step:1925/4150 train_time:335420ms step_avg:174.24ms
+step:1926/4150 train_time:335657ms step_avg:174.28ms
+step:1927/4150 train_time:335889ms step_avg:174.31ms
+step:1928/4150 train_time:336127ms step_avg:174.34ms
+step:1929/4150 train_time:336359ms step_avg:174.37ms
+step:1930/4150 train_time:336595ms step_avg:174.40ms
+step:1931/4150 train_time:336830ms step_avg:174.43ms
+step:1932/4150 train_time:337067ms step_avg:174.47ms
+step:1933/4150 train_time:337298ms step_avg:174.49ms
+step:1934/4150 train_time:337535ms step_avg:174.53ms
+step:1935/4150 train_time:337766ms step_avg:174.56ms
+step:1936/4150 train_time:338003ms step_avg:174.59ms
+step:1937/4150 train_time:338235ms step_avg:174.62ms
+step:1938/4150 train_time:338469ms step_avg:174.65ms
+step:1939/4150 train_time:338700ms step_avg:174.68ms
+step:1940/4150 train_time:338935ms step_avg:174.71ms
+step:1941/4150 train_time:339169ms step_avg:174.74ms
+step:1942/4150 train_time:339407ms step_avg:174.77ms
+step:1943/4150 train_time:339638ms step_avg:174.80ms
+step:1944/4150 train_time:339872ms step_avg:174.83ms
+step:1945/4150 train_time:340108ms step_avg:174.86ms
+step:1946/4150 train_time:340342ms step_avg:174.89ms
+step:1947/4150 train_time:340573ms step_avg:174.92ms
+step:1948/4150 train_time:340810ms step_avg:174.95ms
+step:1949/4150 train_time:341043ms step_avg:174.98ms
+step:1950/4150 train_time:341277ms step_avg:175.01ms
+step:1951/4150 train_time:341510ms step_avg:175.04ms
+step:1952/4150 train_time:341746ms step_avg:175.07ms
+step:1953/4150 train_time:341979ms step_avg:175.10ms
+step:1954/4150 train_time:342214ms step_avg:175.14ms
+step:1955/4150 train_time:342448ms step_avg:175.17ms
+step:1956/4150 train_time:342684ms step_avg:175.20ms
+step:1957/4150 train_time:342916ms step_avg:175.23ms
+step:1958/4150 train_time:343153ms step_avg:175.26ms
+step:1959/4150 train_time:343388ms step_avg:175.29ms
+step:1960/4150 train_time:343624ms step_avg:175.32ms
+step:1961/4150 train_time:343859ms step_avg:175.35ms
+step:1962/4150 train_time:344095ms step_avg:175.38ms
+step:1963/4150 train_time:344332ms step_avg:175.41ms
+step:1964/4150 train_time:344568ms step_avg:175.44ms
+step:1965/4150 train_time:344801ms step_avg:175.47ms
+step:1966/4150 train_time:345037ms step_avg:175.50ms
+step:1967/4150 train_time:345270ms step_avg:175.53ms
+step:1968/4150 train_time:345511ms step_avg:175.56ms
+step:1969/4150 train_time:345742ms step_avg:175.59ms
+step:1970/4150 train_time:345979ms step_avg:175.62ms
+step:1971/4150 train_time:346211ms step_avg:175.65ms
+step:1972/4150 train_time:346447ms step_avg:175.68ms
+step:1973/4150 train_time:346680ms step_avg:175.71ms
+step:1974/4150 train_time:346915ms step_avg:175.74ms
+step:1975/4150 train_time:347149ms step_avg:175.77ms
+step:1976/4150 train_time:347385ms step_avg:175.80ms
+step:1977/4150 train_time:347617ms step_avg:175.83ms
+step:1978/4150 train_time:347853ms step_avg:175.86ms
+step:1979/4150 train_time:348085ms step_avg:175.89ms
+step:1980/4150 train_time:348322ms step_avg:175.92ms
+step:1981/4150 train_time:348555ms step_avg:175.95ms
+step:1982/4150 train_time:348789ms step_avg:175.98ms
+step:1983/4150 train_time:349019ms step_avg:176.01ms
+step:1984/4150 train_time:349254ms step_avg:176.04ms
+step:1985/4150 train_time:349486ms step_avg:176.06ms
+step:1986/4150 train_time:349720ms step_avg:176.09ms
+step:1987/4150 train_time:349953ms step_avg:176.12ms
+step:1988/4150 train_time:350190ms step_avg:176.15ms
+step:1989/4150 train_time:350424ms step_avg:176.18ms
+step:1990/4150 train_time:350659ms step_avg:176.21ms
+step:1991/4150 train_time:350892ms step_avg:176.24ms
+step:1992/4150 train_time:351130ms step_avg:176.27ms
+step:1993/4150 train_time:351363ms step_avg:176.30ms
+step:1994/4150 train_time:351599ms step_avg:176.33ms
+step:1995/4150 train_time:351832ms step_avg:176.36ms
+step:1996/4150 train_time:352067ms step_avg:176.39ms
+step:1997/4150 train_time:352299ms step_avg:176.41ms
+step:1998/4150 train_time:352536ms step_avg:176.44ms
+step:1999/4150 train_time:352769ms step_avg:176.47ms
+step:2000/4150 train_time:353005ms step_avg:176.50ms
+step:2000/4150 val_loss:3.1819 train_time:353219ms step_avg:176.61ms
+step:2001/4150 train_time:353242ms step_avg:176.53ms
+step:2002/4150 train_time:353481ms step_avg:176.56ms
+step:2003/4150 train_time:353715ms step_avg:176.59ms
+step:2004/4150 train_time:353947ms step_avg:176.62ms
+step:2005/4150 train_time:354178ms step_avg:176.65ms
+step:2006/4150 train_time:354417ms step_avg:176.68ms
+step:2007/4150 train_time:354654ms step_avg:176.71ms
+step:2008/4150 train_time:354889ms step_avg:176.74ms
+step:2009/4150 train_time:355121ms step_avg:176.76ms
+step:2010/4150 train_time:355360ms step_avg:176.80ms
+step:2011/4150 train_time:355596ms step_avg:176.83ms
+step:2012/4150 train_time:355832ms step_avg:176.86ms
+step:2013/4150 train_time:356062ms step_avg:176.88ms
+step:2014/4150 train_time:356299ms step_avg:176.91ms
+step:2015/4150 train_time:356534ms step_avg:176.94ms
+step:2016/4150 train_time:356774ms step_avg:176.97ms
+step:2017/4150 train_time:357006ms step_avg:177.00ms
+step:2018/4150 train_time:357241ms step_avg:177.03ms
+step:2019/4150 train_time:357474ms step_avg:177.06ms
+step:2020/4150 train_time:357714ms step_avg:177.09ms
+step:2021/4150 train_time:357946ms step_avg:177.11ms
+step:2022/4150 train_time:358180ms step_avg:177.14ms
+step:2023/4150 train_time:358414ms step_avg:177.17ms
+step:2024/4150 train_time:358652ms step_avg:177.20ms
+step:2025/4150 train_time:358885ms step_avg:177.23ms
+step:2026/4150 train_time:359121ms step_avg:177.26ms
+step:2027/4150 train_time:359351ms step_avg:177.28ms
+step:2028/4150 train_time:359590ms step_avg:177.31ms
+step:2029/4150 train_time:359822ms step_avg:177.34ms
+step:2030/4150 train_time:360056ms step_avg:177.37ms
+step:2031/4150 train_time:360289ms step_avg:177.39ms
+step:2032/4150 train_time:360528ms step_avg:177.43ms
+step:2033/4150 train_time:360761ms step_avg:177.45ms
+step:2034/4150 train_time:361000ms step_avg:177.48ms
+step:2035/4150 train_time:361232ms step_avg:177.51ms
+step:2036/4150 train_time:361468ms step_avg:177.54ms
+step:2037/4150 train_time:361702ms step_avg:177.57ms
+step:2038/4150 train_time:361936ms step_avg:177.59ms
+step:2039/4150 train_time:362170ms step_avg:177.62ms
+step:2040/4150 train_time:362408ms step_avg:177.65ms
+step:2041/4150 train_time:362642ms step_avg:177.68ms
+step:2042/4150 train_time:362879ms step_avg:177.71ms
+step:2043/4150 train_time:363109ms step_avg:177.73ms
+step:2044/4150 train_time:363344ms step_avg:177.76ms
+step:2045/4150 train_time:363578ms step_avg:177.79ms
+step:2046/4150 train_time:363814ms step_avg:177.82ms
+step:2047/4150 train_time:364046ms step_avg:177.84ms
+step:2048/4150 train_time:364281ms step_avg:177.87ms
+step:2049/4150 train_time:364515ms step_avg:177.90ms
+step:2050/4150 train_time:364752ms step_avg:177.93ms
+step:2051/4150 train_time:364983ms step_avg:177.95ms
+step:2052/4150 train_time:365220ms step_avg:177.98ms
+step:2053/4150 train_time:365456ms step_avg:178.01ms
+step:2054/4150 train_time:365696ms step_avg:178.04ms
+step:2055/4150 train_time:365927ms step_avg:178.07ms
+step:2056/4150 train_time:366159ms step_avg:178.09ms
+step:2057/4150 train_time:366393ms step_avg:178.12ms
+step:2058/4150 train_time:366629ms step_avg:178.15ms
+step:2059/4150 train_time:366861ms step_avg:178.17ms
+step:2060/4150 train_time:367097ms step_avg:178.20ms
+step:2061/4150 train_time:367330ms step_avg:178.23ms
+step:2062/4150 train_time:367566ms step_avg:178.26ms
+step:2063/4150 train_time:367797ms step_avg:178.28ms
+step:2064/4150 train_time:368034ms step_avg:178.31ms
+step:2065/4150 train_time:368266ms step_avg:178.34ms
+step:2066/4150 train_time:368502ms step_avg:178.37ms
+step:2067/4150 train_time:368735ms step_avg:178.39ms
+step:2068/4150 train_time:368971ms step_avg:178.42ms
+step:2069/4150 train_time:369203ms step_avg:178.44ms
+step:2070/4150 train_time:369440ms step_avg:178.47ms
+step:2071/4150 train_time:369674ms step_avg:178.50ms
+step:2072/4150 train_time:369909ms step_avg:178.53ms
+step:2073/4150 train_time:370143ms step_avg:178.55ms
+step:2074/4150 train_time:370380ms step_avg:178.58ms
+step:2075/4150 train_time:370616ms step_avg:178.61ms
+step:2076/4150 train_time:370852ms step_avg:178.64ms
+step:2077/4150 train_time:371087ms step_avg:178.67ms
+step:2078/4150 train_time:371322ms step_avg:178.69ms
+step:2079/4150 train_time:371557ms step_avg:178.72ms
+step:2080/4150 train_time:371795ms step_avg:178.75ms
+step:2081/4150 train_time:372028ms step_avg:178.77ms
+step:2082/4150 train_time:372264ms step_avg:178.80ms
+step:2083/4150 train_time:372498ms step_avg:178.83ms
+step:2084/4150 train_time:372736ms step_avg:178.86ms
+step:2085/4150 train_time:372972ms step_avg:178.88ms
+step:2086/4150 train_time:373209ms step_avg:178.91ms
+step:2087/4150 train_time:373441ms step_avg:178.94ms
+step:2088/4150 train_time:373676ms step_avg:178.96ms
+step:2089/4150 train_time:373909ms step_avg:178.99ms
+step:2090/4150 train_time:374145ms step_avg:179.02ms
+step:2091/4150 train_time:374379ms step_avg:179.04ms
+step:2092/4150 train_time:374616ms step_avg:179.07ms
+step:2093/4150 train_time:374851ms step_avg:179.10ms
+step:2094/4150 train_time:375089ms step_avg:179.13ms
+step:2095/4150 train_time:375321ms step_avg:179.15ms
+step:2096/4150 train_time:375558ms step_avg:179.18ms
+step:2097/4150 train_time:375791ms step_avg:179.20ms
+step:2098/4150 train_time:376028ms step_avg:179.23ms
+step:2099/4150 train_time:376262ms step_avg:179.26ms
+step:2100/4150 train_time:376498ms step_avg:179.28ms
+step:2101/4150 train_time:376731ms step_avg:179.31ms
+step:2102/4150 train_time:376969ms step_avg:179.34ms
+step:2103/4150 train_time:377201ms step_avg:179.36ms
+step:2104/4150 train_time:377438ms step_avg:179.39ms
+step:2105/4150 train_time:377673ms step_avg:179.42ms
+step:2106/4150 train_time:377912ms step_avg:179.45ms
+step:2107/4150 train_time:378145ms step_avg:179.47ms
+step:2108/4150 train_time:378381ms step_avg:179.50ms
+step:2109/4150 train_time:378616ms step_avg:179.52ms
+step:2110/4150 train_time:378854ms step_avg:179.55ms
+step:2111/4150 train_time:379087ms step_avg:179.58ms
+step:2112/4150 train_time:379325ms step_avg:179.60ms
+step:2113/4150 train_time:379558ms step_avg:179.63ms
+step:2114/4150 train_time:379794ms step_avg:179.66ms
+step:2115/4150 train_time:380025ms step_avg:179.68ms
+step:2116/4150 train_time:380263ms step_avg:179.71ms
+step:2117/4150 train_time:380498ms step_avg:179.73ms
+step:2118/4150 train_time:380735ms step_avg:179.76ms
+step:2119/4150 train_time:380969ms step_avg:179.79ms
+step:2120/4150 train_time:381205ms step_avg:179.81ms
+step:2121/4150 train_time:381439ms step_avg:179.84ms
+step:2122/4150 train_time:381674ms step_avg:179.87ms
+step:2123/4150 train_time:381906ms step_avg:179.89ms
+step:2124/4150 train_time:382141ms step_avg:179.92ms
+step:2125/4150 train_time:382376ms step_avg:179.94ms
+step:2126/4150 train_time:382614ms step_avg:179.97ms
+step:2127/4150 train_time:382847ms step_avg:179.99ms
+step:2128/4150 train_time:383082ms step_avg:180.02ms
+step:2129/4150 train_time:383317ms step_avg:180.05ms
+step:2130/4150 train_time:383554ms step_avg:180.07ms
+step:2131/4150 train_time:383786ms step_avg:180.10ms
+step:2132/4150 train_time:384023ms step_avg:180.12ms
+step:2133/4150 train_time:384258ms step_avg:180.15ms
+step:2134/4150 train_time:384495ms step_avg:180.18ms
+step:2135/4150 train_time:384731ms step_avg:180.20ms
+step:2136/4150 train_time:384968ms step_avg:180.23ms
+step:2137/4150 train_time:385201ms step_avg:180.25ms
+step:2138/4150 train_time:385438ms step_avg:180.28ms
+step:2139/4150 train_time:385671ms step_avg:180.30ms
+step:2140/4150 train_time:385907ms step_avg:180.33ms
+step:2141/4150 train_time:386142ms step_avg:180.36ms
+step:2142/4150 train_time:386379ms step_avg:180.38ms
+step:2143/4150 train_time:386614ms step_avg:180.41ms
+step:2144/4150 train_time:386849ms step_avg:180.43ms
+step:2145/4150 train_time:387082ms step_avg:180.46ms
+step:2146/4150 train_time:387319ms step_avg:180.48ms
+step:2147/4150 train_time:387553ms step_avg:180.51ms
+step:2148/4150 train_time:387788ms step_avg:180.53ms
+step:2149/4150 train_time:388023ms step_avg:180.56ms
+step:2150/4150 train_time:388261ms step_avg:180.59ms
+step:2151/4150 train_time:388496ms step_avg:180.61ms
+step:2152/4150 train_time:388733ms step_avg:180.64ms
+step:2153/4150 train_time:388966ms step_avg:180.66ms
+step:2154/4150 train_time:389202ms step_avg:180.69ms
+step:2155/4150 train_time:389436ms step_avg:180.71ms
+step:2156/4150 train_time:389674ms step_avg:180.74ms
+step:2157/4150 train_time:389906ms step_avg:180.76ms
+step:2158/4150 train_time:390144ms step_avg:180.79ms
+step:2159/4150 train_time:390379ms step_avg:180.81ms
+step:2160/4150 train_time:390617ms step_avg:180.84ms
+step:2161/4150 train_time:390852ms step_avg:180.87ms
+step:2162/4150 train_time:391089ms step_avg:180.89ms
+step:2163/4150 train_time:391322ms step_avg:180.92ms
+step:2164/4150 train_time:391560ms step_avg:180.94ms
+step:2165/4150 train_time:391793ms step_avg:180.97ms
+step:2166/4150 train_time:392029ms step_avg:180.99ms
+step:2167/4150 train_time:392261ms step_avg:181.02ms
+step:2168/4150 train_time:392498ms step_avg:181.04ms
+step:2169/4150 train_time:392736ms step_avg:181.07ms
+step:2170/4150 train_time:392976ms step_avg:181.10ms
+step:2171/4150 train_time:393212ms step_avg:181.12ms
+step:2172/4150 train_time:393451ms step_avg:181.15ms
+step:2173/4150 train_time:393684ms step_avg:181.17ms
+step:2174/4150 train_time:393923ms step_avg:181.20ms
+step:2175/4150 train_time:394156ms step_avg:181.22ms
+step:2176/4150 train_time:394393ms step_avg:181.25ms
+step:2177/4150 train_time:394624ms step_avg:181.27ms
+step:2178/4150 train_time:394860ms step_avg:181.29ms
+step:2179/4150 train_time:395092ms step_avg:181.32ms
+step:2180/4150 train_time:395331ms step_avg:181.34ms
+step:2181/4150 train_time:395563ms step_avg:181.37ms
+step:2182/4150 train_time:395801ms step_avg:181.39ms
+step:2183/4150 train_time:396034ms step_avg:181.42ms
+step:2184/4150 train_time:396274ms step_avg:181.44ms
+step:2185/4150 train_time:396505ms step_avg:181.47ms
+step:2186/4150 train_time:396740ms step_avg:181.49ms
+step:2187/4150 train_time:396972ms step_avg:181.51ms
+step:2188/4150 train_time:397210ms step_avg:181.54ms
+step:2189/4150 train_time:397443ms step_avg:181.56ms
+step:2190/4150 train_time:397679ms step_avg:181.59ms
+step:2191/4150 train_time:397916ms step_avg:181.61ms
+step:2192/4150 train_time:398158ms step_avg:181.64ms
+step:2193/4150 train_time:398394ms step_avg:181.67ms
+step:2194/4150 train_time:398631ms step_avg:181.69ms
+step:2195/4150 train_time:398866ms step_avg:181.72ms
+step:2196/4150 train_time:399101ms step_avg:181.74ms
+step:2197/4150 train_time:399336ms step_avg:181.76ms
+step:2198/4150 train_time:399570ms step_avg:181.79ms
+step:2199/4150 train_time:399802ms step_avg:181.81ms
+step:2200/4150 train_time:400036ms step_avg:181.83ms
+step:2201/4150 train_time:400271ms step_avg:181.86ms
+step:2202/4150 train_time:400508ms step_avg:181.88ms
+step:2203/4150 train_time:400740ms step_avg:181.91ms
+step:2204/4150 train_time:400976ms step_avg:181.93ms
+step:2205/4150 train_time:401211ms step_avg:181.96ms
+step:2206/4150 train_time:401448ms step_avg:181.98ms
+step:2207/4150 train_time:401683ms step_avg:182.00ms
+step:2208/4150 train_time:401919ms step_avg:182.03ms
+step:2209/4150 train_time:402151ms step_avg:182.05ms
+step:2210/4150 train_time:402388ms step_avg:182.08ms
+step:2211/4150 train_time:402622ms step_avg:182.10ms
+step:2212/4150 train_time:402858ms step_avg:182.12ms
+step:2213/4150 train_time:403093ms step_avg:182.15ms
+step:2214/4150 train_time:403332ms step_avg:182.17ms
+step:2215/4150 train_time:403567ms step_avg:182.20ms
+step:2216/4150 train_time:403800ms step_avg:182.22ms
+step:2217/4150 train_time:404032ms step_avg:182.24ms
+step:2218/4150 train_time:404269ms step_avg:182.27ms
+step:2219/4150 train_time:404504ms step_avg:182.29ms
+step:2220/4150 train_time:404742ms step_avg:182.32ms
+step:2221/4150 train_time:404978ms step_avg:182.34ms
+step:2222/4150 train_time:405213ms step_avg:182.36ms
+step:2223/4150 train_time:405447ms step_avg:182.39ms
+step:2224/4150 train_time:405682ms step_avg:182.41ms
+step:2225/4150 train_time:405915ms step_avg:182.43ms
+step:2226/4150 train_time:406151ms step_avg:182.46ms
+step:2227/4150 train_time:406382ms step_avg:182.48ms
+step:2228/4150 train_time:406618ms step_avg:182.50ms
+step:2229/4150 train_time:406852ms step_avg:182.53ms
+step:2230/4150 train_time:407089ms step_avg:182.55ms
+step:2231/4150 train_time:407318ms step_avg:182.57ms
+step:2232/4150 train_time:407555ms step_avg:182.60ms
+step:2233/4150 train_time:407789ms step_avg:182.62ms
+step:2234/4150 train_time:408024ms step_avg:182.64ms
+step:2235/4150 train_time:408257ms step_avg:182.67ms
+step:2236/4150 train_time:408494ms step_avg:182.69ms
+step:2237/4150 train_time:408730ms step_avg:182.71ms
+step:2238/4150 train_time:408966ms step_avg:182.74ms
+step:2239/4150 train_time:409199ms step_avg:182.76ms
+step:2240/4150 train_time:409433ms step_avg:182.78ms
+step:2241/4150 train_time:409667ms step_avg:182.81ms
+step:2242/4150 train_time:409901ms step_avg:182.83ms
+step:2243/4150 train_time:410133ms step_avg:182.85ms
+step:2244/4150 train_time:410371ms step_avg:182.87ms
+step:2245/4150 train_time:410601ms step_avg:182.90ms
+step:2246/4150 train_time:410836ms step_avg:182.92ms
+step:2247/4150 train_time:411071ms step_avg:182.94ms
+step:2248/4150 train_time:411310ms step_avg:182.97ms
+step:2249/4150 train_time:411544ms step_avg:182.99ms
+step:2250/4150 train_time:411781ms step_avg:183.01ms
+step:2250/4150 val_loss:3.1423 train_time:411998ms step_avg:183.11ms
+step:2251/4150 train_time:412021ms step_avg:183.04ms
+step:2252/4150 train_time:412264ms step_avg:183.07ms
+step:2253/4150 train_time:412498ms step_avg:183.09ms
+step:2254/4150 train_time:412733ms step_avg:183.11ms
+step:2255/4150 train_time:412965ms step_avg:183.13ms
+step:2256/4150 train_time:413200ms step_avg:183.16ms
+step:2257/4150 train_time:413441ms step_avg:183.18ms
+step:2258/4150 train_time:413680ms step_avg:183.21ms
+step:2259/4150 train_time:413911ms step_avg:183.23ms
+step:2260/4150 train_time:414144ms step_avg:183.25ms
+step:2261/4150 train_time:414380ms step_avg:183.27ms
+step:2262/4150 train_time:414621ms step_avg:183.30ms
+step:2263/4150 train_time:414851ms step_avg:183.32ms
+step:2264/4150 train_time:415084ms step_avg:183.34ms
+step:2265/4150 train_time:415323ms step_avg:183.37ms
+step:2266/4150 train_time:415561ms step_avg:183.39ms
+step:2267/4150 train_time:415795ms step_avg:183.41ms
+step:2268/4150 train_time:416030ms step_avg:183.43ms
+step:2269/4150 train_time:416265ms step_avg:183.46ms
+step:2270/4150 train_time:416502ms step_avg:183.48ms
+step:2271/4150 train_time:416737ms step_avg:183.50ms
+step:2272/4150 train_time:416971ms step_avg:183.53ms
+step:2273/4150 train_time:417203ms step_avg:183.55ms
+step:2274/4150 train_time:417445ms step_avg:183.57ms
+step:2275/4150 train_time:417680ms step_avg:183.60ms
+step:2276/4150 train_time:417920ms step_avg:183.62ms
+step:2277/4150 train_time:418153ms step_avg:183.64ms
+step:2278/4150 train_time:418387ms step_avg:183.66ms
+step:2279/4150 train_time:418621ms step_avg:183.69ms
+step:2280/4150 train_time:418858ms step_avg:183.71ms
+step:2281/4150 train_time:419089ms step_avg:183.73ms
+step:2282/4150 train_time:419324ms step_avg:183.75ms
+step:2283/4150 train_time:419561ms step_avg:183.78ms
+step:2284/4150 train_time:419797ms step_avg:183.80ms
+step:2285/4150 train_time:420027ms step_avg:183.82ms
+step:2286/4150 train_time:420262ms step_avg:183.84ms
+step:2287/4150 train_time:420495ms step_avg:183.86ms
+step:2288/4150 train_time:420732ms step_avg:183.89ms
+step:2289/4150 train_time:420963ms step_avg:183.91ms
+step:2290/4150 train_time:421202ms step_avg:183.93ms
+step:2291/4150 train_time:421433ms step_avg:183.95ms
+step:2292/4150 train_time:421672ms step_avg:183.98ms
+step:2293/4150 train_time:421904ms step_avg:184.00ms
+step:2294/4150 train_time:422141ms step_avg:184.02ms
+step:2295/4150 train_time:422381ms step_avg:184.04ms
+step:2296/4150 train_time:422615ms step_avg:184.07ms
+step:2297/4150 train_time:422847ms step_avg:184.09ms
+step:2298/4150 train_time:423083ms step_avg:184.11ms
+step:2299/4150 train_time:423318ms step_avg:184.13ms
+step:2300/4150 train_time:423555ms step_avg:184.15ms
+step:2301/4150 train_time:423787ms step_avg:184.18ms
+step:2302/4150 train_time:424024ms step_avg:184.20ms
+step:2303/4150 train_time:424258ms step_avg:184.22ms
+step:2304/4150 train_time:424497ms step_avg:184.24ms
+step:2305/4150 train_time:424733ms step_avg:184.27ms
+step:2306/4150 train_time:424966ms step_avg:184.29ms
+step:2307/4150 train_time:425201ms step_avg:184.31ms
+step:2308/4150 train_time:425440ms step_avg:184.33ms
+step:2309/4150 train_time:425676ms step_avg:184.36ms
+step:2310/4150 train_time:425909ms step_avg:184.38ms
+step:2311/4150 train_time:426141ms step_avg:184.40ms
+step:2312/4150 train_time:426378ms step_avg:184.42ms
+step:2313/4150 train_time:426611ms step_avg:184.44ms
+step:2314/4150 train_time:426847ms step_avg:184.46ms
+step:2315/4150 train_time:427082ms step_avg:184.48ms
+step:2316/4150 train_time:427321ms step_avg:184.51ms
+step:2317/4150 train_time:427556ms step_avg:184.53ms
+step:2318/4150 train_time:427789ms step_avg:184.55ms
+step:2319/4150 train_time:428024ms step_avg:184.57ms
+step:2320/4150 train_time:428261ms step_avg:184.60ms
+step:2321/4150 train_time:428496ms step_avg:184.62ms
+step:2322/4150 train_time:428735ms step_avg:184.64ms
+step:2323/4150 train_time:428968ms step_avg:184.66ms
+step:2324/4150 train_time:429206ms step_avg:184.68ms
+step:2325/4150 train_time:429439ms step_avg:184.70ms
+step:2326/4150 train_time:429678ms step_avg:184.73ms
+step:2327/4150 train_time:429910ms step_avg:184.75ms
+step:2328/4150 train_time:430149ms step_avg:184.77ms
+step:2329/4150 train_time:430382ms step_avg:184.79ms
+step:2330/4150 train_time:430622ms step_avg:184.82ms
+step:2331/4150 train_time:430854ms step_avg:184.84ms
+step:2332/4150 train_time:431091ms step_avg:184.86ms
+step:2333/4150 train_time:431327ms step_avg:184.88ms
+step:2334/4150 train_time:431564ms step_avg:184.90ms
+step:2335/4150 train_time:431796ms step_avg:184.92ms
+step:2336/4150 train_time:432032ms step_avg:184.95ms
+step:2337/4150 train_time:432264ms step_avg:184.97ms
+step:2338/4150 train_time:432500ms step_avg:184.99ms
+step:2339/4150 train_time:432736ms step_avg:185.01ms
+step:2340/4150 train_time:432973ms step_avg:185.03ms
+step:2341/4150 train_time:433206ms step_avg:185.05ms
+step:2342/4150 train_time:433443ms step_avg:185.07ms
+step:2343/4150 train_time:433678ms step_avg:185.09ms
+step:2344/4150 train_time:433918ms step_avg:185.12ms
+step:2345/4150 train_time:434148ms step_avg:185.14ms
+step:2346/4150 train_time:434384ms step_avg:185.16ms
+step:2347/4150 train_time:434621ms step_avg:185.18ms
+step:2348/4150 train_time:434861ms step_avg:185.20ms
+step:2349/4150 train_time:435093ms step_avg:185.22ms
+step:2350/4150 train_time:435331ms step_avg:185.25ms
+step:2351/4150 train_time:435564ms step_avg:185.27ms
+step:2352/4150 train_time:435803ms step_avg:185.29ms
+step:2353/4150 train_time:436037ms step_avg:185.31ms
+step:2354/4150 train_time:436274ms step_avg:185.33ms
+step:2355/4150 train_time:436508ms step_avg:185.35ms
+step:2356/4150 train_time:436745ms step_avg:185.38ms
+step:2357/4150 train_time:436981ms step_avg:185.40ms
+step:2358/4150 train_time:437216ms step_avg:185.42ms
+step:2359/4150 train_time:437447ms step_avg:185.44ms
+step:2360/4150 train_time:437683ms step_avg:185.46ms
+step:2361/4150 train_time:437919ms step_avg:185.48ms
+step:2362/4150 train_time:438155ms step_avg:185.50ms
+step:2363/4150 train_time:438390ms step_avg:185.52ms
+step:2364/4150 train_time:438625ms step_avg:185.54ms
+step:2365/4150 train_time:438863ms step_avg:185.57ms
+step:2366/4150 train_time:439097ms step_avg:185.59ms
+step:2367/4150 train_time:439329ms step_avg:185.61ms
+step:2368/4150 train_time:439567ms step_avg:185.63ms
+step:2369/4150 train_time:439802ms step_avg:185.65ms
+step:2370/4150 train_time:440040ms step_avg:185.67ms
+step:2371/4150 train_time:440273ms step_avg:185.69ms
+step:2372/4150 train_time:440507ms step_avg:185.71ms
+step:2373/4150 train_time:440742ms step_avg:185.73ms
+step:2374/4150 train_time:440982ms step_avg:185.75ms
+step:2375/4150 train_time:441216ms step_avg:185.78ms
+step:2376/4150 train_time:441450ms step_avg:185.80ms
+step:2377/4150 train_time:441683ms step_avg:185.82ms
+step:2378/4150 train_time:441922ms step_avg:185.84ms
+step:2379/4150 train_time:442157ms step_avg:185.86ms
+step:2380/4150 train_time:442392ms step_avg:185.88ms
+step:2381/4150 train_time:442626ms step_avg:185.90ms
+step:2382/4150 train_time:442867ms step_avg:185.92ms
+step:2383/4150 train_time:443101ms step_avg:185.94ms
+step:2384/4150 train_time:443337ms step_avg:185.96ms
+step:2385/4150 train_time:443567ms step_avg:185.98ms
+step:2386/4150 train_time:443804ms step_avg:186.00ms
+step:2387/4150 train_time:444041ms step_avg:186.02ms
+step:2388/4150 train_time:444279ms step_avg:186.05ms
+step:2389/4150 train_time:444511ms step_avg:186.07ms
+step:2390/4150 train_time:444747ms step_avg:186.09ms
+step:2391/4150 train_time:444980ms step_avg:186.11ms
+step:2392/4150 train_time:445216ms step_avg:186.13ms
+step:2393/4150 train_time:445447ms step_avg:186.15ms
+step:2394/4150 train_time:445684ms step_avg:186.17ms
+step:2395/4150 train_time:445919ms step_avg:186.19ms
+step:2396/4150 train_time:446158ms step_avg:186.21ms
+step:2397/4150 train_time:446389ms step_avg:186.23ms
+step:2398/4150 train_time:446624ms step_avg:186.25ms
+step:2399/4150 train_time:446857ms step_avg:186.27ms
+step:2400/4150 train_time:447092ms step_avg:186.29ms
+step:2401/4150 train_time:447325ms step_avg:186.31ms
+step:2402/4150 train_time:447563ms step_avg:186.33ms
+step:2403/4150 train_time:447796ms step_avg:186.35ms
+step:2404/4150 train_time:448036ms step_avg:186.37ms
+step:2405/4150 train_time:448269ms step_avg:186.39ms
+step:2406/4150 train_time:448504ms step_avg:186.41ms
+step:2407/4150 train_time:448737ms step_avg:186.43ms
+step:2408/4150 train_time:448973ms step_avg:186.45ms
+step:2409/4150 train_time:449208ms step_avg:186.47ms
+step:2410/4150 train_time:449447ms step_avg:186.49ms
+step:2411/4150 train_time:449684ms step_avg:186.51ms
+step:2412/4150 train_time:449924ms step_avg:186.54ms
+step:2413/4150 train_time:450159ms step_avg:186.56ms
+step:2414/4150 train_time:450396ms step_avg:186.58ms
+step:2415/4150 train_time:450630ms step_avg:186.60ms
+step:2416/4150 train_time:450867ms step_avg:186.62ms
+step:2417/4150 train_time:451102ms step_avg:186.64ms
+step:2418/4150 train_time:451341ms step_avg:186.66ms
+step:2419/4150 train_time:451575ms step_avg:186.68ms
+step:2420/4150 train_time:451810ms step_avg:186.70ms
+step:2421/4150 train_time:452046ms step_avg:186.72ms
+step:2422/4150 train_time:452286ms step_avg:186.74ms
+step:2423/4150 train_time:452519ms step_avg:186.76ms
+step:2424/4150 train_time:452757ms step_avg:186.78ms
+step:2425/4150 train_time:452992ms step_avg:186.80ms
+step:2426/4150 train_time:453226ms step_avg:186.82ms
+step:2427/4150 train_time:453461ms step_avg:186.84ms
+step:2428/4150 train_time:453698ms step_avg:186.86ms
+step:2429/4150 train_time:453934ms step_avg:186.88ms
+step:2430/4150 train_time:454174ms step_avg:186.90ms
+step:2431/4150 train_time:454408ms step_avg:186.92ms
+step:2432/4150 train_time:454645ms step_avg:186.94ms
+step:2433/4150 train_time:454879ms step_avg:186.96ms
+step:2434/4150 train_time:455117ms step_avg:186.98ms
+step:2435/4150 train_time:455351ms step_avg:187.00ms
+step:2436/4150 train_time:455589ms step_avg:187.02ms
+step:2437/4150 train_time:455825ms step_avg:187.04ms
+step:2438/4150 train_time:456062ms step_avg:187.06ms
+step:2439/4150 train_time:456297ms step_avg:187.08ms
+step:2440/4150 train_time:456535ms step_avg:187.10ms
+step:2441/4150 train_time:456767ms step_avg:187.12ms
+step:2442/4150 train_time:457005ms step_avg:187.14ms
+step:2443/4150 train_time:457239ms step_avg:187.16ms
+step:2444/4150 train_time:457476ms step_avg:187.18ms
+step:2445/4150 train_time:457707ms step_avg:187.20ms
+step:2446/4150 train_time:457942ms step_avg:187.22ms
+step:2447/4150 train_time:458176ms step_avg:187.24ms
+step:2448/4150 train_time:458415ms step_avg:187.26ms
+step:2449/4150 train_time:458648ms step_avg:187.28ms
+step:2450/4150 train_time:458887ms step_avg:187.30ms
+step:2451/4150 train_time:459123ms step_avg:187.32ms
+step:2452/4150 train_time:459361ms step_avg:187.34ms
+step:2453/4150 train_time:459594ms step_avg:187.36ms
+step:2454/4150 train_time:459834ms step_avg:187.38ms
+step:2455/4150 train_time:460068ms step_avg:187.40ms
+step:2456/4150 train_time:460307ms step_avg:187.42ms
+step:2457/4150 train_time:460541ms step_avg:187.44ms
+step:2458/4150 train_time:460777ms step_avg:187.46ms
+step:2459/4150 train_time:461009ms step_avg:187.48ms
+step:2460/4150 train_time:461245ms step_avg:187.50ms
+step:2461/4150 train_time:461479ms step_avg:187.52ms
+step:2462/4150 train_time:461720ms step_avg:187.54ms
+step:2463/4150 train_time:461958ms step_avg:187.56ms
+step:2464/4150 train_time:462193ms step_avg:187.58ms
+step:2465/4150 train_time:462427ms step_avg:187.60ms
+step:2466/4150 train_time:462666ms step_avg:187.62ms
+step:2467/4150 train_time:462900ms step_avg:187.64ms
+step:2468/4150 train_time:463137ms step_avg:187.66ms
+step:2469/4150 train_time:463371ms step_avg:187.68ms
+step:2470/4150 train_time:463608ms step_avg:187.70ms
+step:2471/4150 train_time:463847ms step_avg:187.72ms
+step:2472/4150 train_time:464082ms step_avg:187.74ms
+step:2473/4150 train_time:464316ms step_avg:187.75ms
+step:2474/4150 train_time:464551ms step_avg:187.77ms
+step:2475/4150 train_time:464786ms step_avg:187.79ms
+step:2476/4150 train_time:465028ms step_avg:187.81ms
+step:2477/4150 train_time:465263ms step_avg:187.83ms
+step:2478/4150 train_time:465499ms step_avg:187.85ms
+step:2479/4150 train_time:465731ms step_avg:187.87ms
+step:2480/4150 train_time:465967ms step_avg:187.89ms
+step:2481/4150 train_time:466199ms step_avg:187.91ms
+step:2482/4150 train_time:466436ms step_avg:187.93ms
+step:2483/4150 train_time:466670ms step_avg:187.95ms
+step:2484/4150 train_time:466906ms step_avg:187.97ms
+step:2485/4150 train_time:467142ms step_avg:187.98ms
+step:2486/4150 train_time:467379ms step_avg:188.00ms
+step:2487/4150 train_time:467613ms step_avg:188.02ms
+step:2488/4150 train_time:467855ms step_avg:188.04ms
+step:2489/4150 train_time:468086ms step_avg:188.06ms
+step:2490/4150 train_time:468323ms step_avg:188.08ms
+step:2491/4150 train_time:468558ms step_avg:188.10ms
+step:2492/4150 train_time:468794ms step_avg:188.12ms
+step:2493/4150 train_time:469028ms step_avg:188.14ms
+step:2494/4150 train_time:469267ms step_avg:188.16ms
+step:2495/4150 train_time:469501ms step_avg:188.18ms
+step:2496/4150 train_time:469737ms step_avg:188.20ms
+step:2497/4150 train_time:469967ms step_avg:188.21ms
+step:2498/4150 train_time:470204ms step_avg:188.23ms
+step:2499/4150 train_time:470438ms step_avg:188.25ms
+step:2500/4150 train_time:470676ms step_avg:188.27ms
+step:2500/4150 val_loss:3.1058 train_time:470891ms step_avg:188.36ms
+step:2501/4150 train_time:470914ms step_avg:188.29ms
+step:2502/4150 train_time:471154ms step_avg:188.31ms
+step:2503/4150 train_time:471392ms step_avg:188.33ms
+step:2504/4150 train_time:471627ms step_avg:188.35ms
+step:2505/4150 train_time:471858ms step_avg:188.37ms
+step:2506/4150 train_time:472095ms step_avg:188.39ms
+step:2507/4150 train_time:472330ms step_avg:188.40ms
+step:2508/4150 train_time:472570ms step_avg:188.42ms
+step:2509/4150 train_time:472802ms step_avg:188.44ms
+step:2510/4150 train_time:473037ms step_avg:188.46ms
+step:2511/4150 train_time:473272ms step_avg:188.48ms
+step:2512/4150 train_time:473511ms step_avg:188.50ms
+step:2513/4150 train_time:473743ms step_avg:188.52ms
+step:2514/4150 train_time:473979ms step_avg:188.54ms
+step:2515/4150 train_time:474216ms step_avg:188.56ms
+step:2516/4150 train_time:474454ms step_avg:188.57ms
+step:2517/4150 train_time:474687ms step_avg:188.59ms
+step:2518/4150 train_time:474924ms step_avg:188.61ms
+step:2519/4150 train_time:475159ms step_avg:188.63ms
+step:2520/4150 train_time:475399ms step_avg:188.65ms
+step:2521/4150 train_time:475633ms step_avg:188.67ms
+step:2522/4150 train_time:475868ms step_avg:188.69ms
+step:2523/4150 train_time:476101ms step_avg:188.70ms
+step:2524/4150 train_time:476340ms step_avg:188.72ms
+step:2525/4150 train_time:476575ms step_avg:188.74ms
+step:2526/4150 train_time:476812ms step_avg:188.76ms
+step:2527/4150 train_time:477043ms step_avg:188.78ms
+step:2528/4150 train_time:477280ms step_avg:188.80ms
+step:2529/4150 train_time:477515ms step_avg:188.82ms
+step:2530/4150 train_time:477757ms step_avg:188.84ms
+step:2531/4150 train_time:477989ms step_avg:188.85ms
+step:2532/4150 train_time:478225ms step_avg:188.87ms
+step:2533/4150 train_time:478460ms step_avg:188.89ms
+step:2534/4150 train_time:478698ms step_avg:188.91ms
+step:2535/4150 train_time:478935ms step_avg:188.93ms
+step:2536/4150 train_time:479171ms step_avg:188.95ms
+step:2537/4150 train_time:479404ms step_avg:188.96ms
+step:2538/4150 train_time:479641ms step_avg:188.98ms
+step:2539/4150 train_time:479875ms step_avg:189.00ms
+step:2540/4150 train_time:480113ms step_avg:189.02ms
+step:2541/4150 train_time:480347ms step_avg:189.04ms
+step:2542/4150 train_time:480582ms step_avg:189.06ms
+step:2543/4150 train_time:480818ms step_avg:189.07ms
+step:2544/4150 train_time:481054ms step_avg:189.09ms
+step:2545/4150 train_time:481287ms step_avg:189.11ms
+step:2546/4150 train_time:481524ms step_avg:189.13ms
+step:2547/4150 train_time:481760ms step_avg:189.15ms
+step:2548/4150 train_time:481998ms step_avg:189.17ms
+step:2549/4150 train_time:482234ms step_avg:189.19ms
+step:2550/4150 train_time:482469ms step_avg:189.20ms
+step:2551/4150 train_time:482703ms step_avg:189.22ms
+step:2552/4150 train_time:482941ms step_avg:189.24ms
+step:2553/4150 train_time:483177ms step_avg:189.26ms
+step:2554/4150 train_time:483414ms step_avg:189.28ms
+step:2555/4150 train_time:483647ms step_avg:189.29ms
+step:2556/4150 train_time:483884ms step_avg:189.31ms
+step:2557/4150 train_time:484118ms step_avg:189.33ms
+step:2558/4150 train_time:484357ms step_avg:189.35ms
+step:2559/4150 train_time:484593ms step_avg:189.37ms
+step:2560/4150 train_time:484830ms step_avg:189.39ms
+step:2561/4150 train_time:485064ms step_avg:189.40ms
+step:2562/4150 train_time:485299ms step_avg:189.42ms
+step:2563/4150 train_time:485533ms step_avg:189.44ms
+step:2564/4150 train_time:485773ms step_avg:189.46ms
+step:2565/4150 train_time:486007ms step_avg:189.48ms
+step:2566/4150 train_time:486243ms step_avg:189.49ms
+step:2567/4150 train_time:486479ms step_avg:189.51ms
+step:2568/4150 train_time:486717ms step_avg:189.53ms
+step:2569/4150 train_time:486953ms step_avg:189.55ms
+step:2570/4150 train_time:487189ms step_avg:189.57ms
+step:2571/4150 train_time:487422ms step_avg:189.58ms
+step:2572/4150 train_time:487658ms step_avg:189.60ms
+step:2573/4150 train_time:487890ms step_avg:189.62ms
+step:2574/4150 train_time:488128ms step_avg:189.64ms
+step:2575/4150 train_time:488363ms step_avg:189.66ms
+step:2576/4150 train_time:488602ms step_avg:189.67ms
+step:2577/4150 train_time:488837ms step_avg:189.69ms
+step:2578/4150 train_time:489075ms step_avg:189.71ms
+step:2579/4150 train_time:489307ms step_avg:189.73ms
+step:2580/4150 train_time:489541ms step_avg:189.74ms
+step:2581/4150 train_time:489779ms step_avg:189.76ms
+step:2582/4150 train_time:490017ms step_avg:189.78ms
+step:2583/4150 train_time:490249ms step_avg:189.80ms
+step:2584/4150 train_time:490485ms step_avg:189.82ms
+step:2585/4150 train_time:490718ms step_avg:189.83ms
+step:2586/4150 train_time:490957ms step_avg:189.85ms
+step:2587/4150 train_time:491192ms step_avg:189.87ms
+step:2588/4150 train_time:491429ms step_avg:189.89ms
+step:2589/4150 train_time:491664ms step_avg:189.90ms
+step:2590/4150 train_time:491902ms step_avg:189.92ms
+step:2591/4150 train_time:492137ms step_avg:189.94ms
+step:2592/4150 train_time:492374ms step_avg:189.96ms
+step:2593/4150 train_time:492610ms step_avg:189.98ms
+step:2594/4150 train_time:492847ms step_avg:189.99ms
+step:2595/4150 train_time:493083ms step_avg:190.01ms
+step:2596/4150 train_time:493322ms step_avg:190.03ms
+step:2597/4150 train_time:493559ms step_avg:190.05ms
+step:2598/4150 train_time:493794ms step_avg:190.07ms
+step:2599/4150 train_time:494026ms step_avg:190.08ms
+step:2600/4150 train_time:494266ms step_avg:190.10ms
+step:2601/4150 train_time:494500ms step_avg:190.12ms
+step:2602/4150 train_time:494736ms step_avg:190.14ms
+step:2603/4150 train_time:494971ms step_avg:190.15ms
+step:2604/4150 train_time:495209ms step_avg:190.17ms
+step:2605/4150 train_time:495443ms step_avg:190.19ms
+step:2606/4150 train_time:495680ms step_avg:190.21ms
+step:2607/4150 train_time:495915ms step_avg:190.22ms
+step:2608/4150 train_time:496151ms step_avg:190.24ms
+step:2609/4150 train_time:496385ms step_avg:190.26ms
+step:2610/4150 train_time:496621ms step_avg:190.28ms
+step:2611/4150 train_time:496854ms step_avg:190.29ms
+step:2612/4150 train_time:497091ms step_avg:190.31ms
+step:2613/4150 train_time:497324ms step_avg:190.33ms
+step:2614/4150 train_time:497560ms step_avg:190.34ms
+step:2615/4150 train_time:497794ms step_avg:190.36ms
+step:2616/4150 train_time:498029ms step_avg:190.38ms
+step:2617/4150 train_time:498262ms step_avg:190.39ms
+step:2618/4150 train_time:498501ms step_avg:190.41ms
+step:2619/4150 train_time:498736ms step_avg:190.43ms
+step:2620/4150 train_time:498975ms step_avg:190.45ms
+step:2621/4150 train_time:499208ms step_avg:190.46ms
+step:2622/4150 train_time:499445ms step_avg:190.48ms
+step:2623/4150 train_time:499679ms step_avg:190.50ms
+step:2624/4150 train_time:499921ms step_avg:190.52ms
+step:2625/4150 train_time:500158ms step_avg:190.54ms
+step:2626/4150 train_time:500395ms step_avg:190.55ms
+step:2627/4150 train_time:500632ms step_avg:190.57ms
+step:2628/4150 train_time:500868ms step_avg:190.59ms
+step:2629/4150 train_time:501101ms step_avg:190.61ms
+step:2630/4150 train_time:501337ms step_avg:190.62ms
+step:2631/4150 train_time:501571ms step_avg:190.64ms
+step:2632/4150 train_time:501811ms step_avg:190.66ms
+step:2633/4150 train_time:502042ms step_avg:190.67ms
+step:2634/4150 train_time:502277ms step_avg:190.69ms
+step:2635/4150 train_time:502512ms step_avg:190.71ms
+step:2636/4150 train_time:502752ms step_avg:190.73ms
+step:2637/4150 train_time:502982ms step_avg:190.74ms
+step:2638/4150 train_time:503221ms step_avg:190.76ms
+step:2639/4150 train_time:503454ms step_avg:190.77ms
+step:2640/4150 train_time:503697ms step_avg:190.79ms
+step:2641/4150 train_time:503931ms step_avg:190.81ms
+step:2642/4150 train_time:504168ms step_avg:190.83ms
+step:2643/4150 train_time:504401ms step_avg:190.84ms
+step:2644/4150 train_time:504639ms step_avg:190.86ms
+step:2645/4150 train_time:504874ms step_avg:190.88ms
+step:2646/4150 train_time:505112ms step_avg:190.90ms
+step:2647/4150 train_time:505347ms step_avg:190.91ms
+step:2648/4150 train_time:505583ms step_avg:190.93ms
+step:2649/4150 train_time:505818ms step_avg:190.95ms
+step:2650/4150 train_time:506055ms step_avg:190.96ms
+step:2651/4150 train_time:506290ms step_avg:190.98ms
+step:2652/4150 train_time:506527ms step_avg:191.00ms
+step:2653/4150 train_time:506765ms step_avg:191.02ms
+step:2654/4150 train_time:507002ms step_avg:191.03ms
+step:2655/4150 train_time:507236ms step_avg:191.05ms
+step:2656/4150 train_time:507471ms step_avg:191.07ms
+step:2657/4150 train_time:507707ms step_avg:191.08ms
+step:2658/4150 train_time:507944ms step_avg:191.10ms
+step:2659/4150 train_time:508176ms step_avg:191.12ms
+step:2660/4150 train_time:508412ms step_avg:191.13ms
+step:2661/4150 train_time:508647ms step_avg:191.15ms
+step:2662/4150 train_time:508885ms step_avg:191.17ms
+step:2663/4150 train_time:509118ms step_avg:191.18ms
+step:2664/4150 train_time:509356ms step_avg:191.20ms
+step:2665/4150 train_time:509588ms step_avg:191.21ms
+step:2666/4150 train_time:509825ms step_avg:191.23ms
+step:2667/4150 train_time:510059ms step_avg:191.25ms
+step:2668/4150 train_time:510297ms step_avg:191.27ms
+step:2669/4150 train_time:510533ms step_avg:191.28ms
+step:2670/4150 train_time:510770ms step_avg:191.30ms
+step:2671/4150 train_time:511002ms step_avg:191.31ms
+step:2672/4150 train_time:511240ms step_avg:191.33ms
+step:2673/4150 train_time:511477ms step_avg:191.35ms
+step:2674/4150 train_time:511715ms step_avg:191.37ms
+step:2675/4150 train_time:511945ms step_avg:191.38ms
+step:2676/4150 train_time:512181ms step_avg:191.40ms
+step:2677/4150 train_time:512415ms step_avg:191.41ms
+step:2678/4150 train_time:512652ms step_avg:191.43ms
+step:2679/4150 train_time:512883ms step_avg:191.45ms
+step:2680/4150 train_time:513122ms step_avg:191.46ms
+step:2681/4150 train_time:513358ms step_avg:191.48ms
+step:2682/4150 train_time:513594ms step_avg:191.50ms
+step:2683/4150 train_time:513825ms step_avg:191.51ms
+step:2684/4150 train_time:514063ms step_avg:191.53ms
+step:2685/4150 train_time:514297ms step_avg:191.54ms
+step:2686/4150 train_time:514535ms step_avg:191.56ms
+step:2687/4150 train_time:514769ms step_avg:191.58ms
+step:2688/4150 train_time:515004ms step_avg:191.59ms
+step:2689/4150 train_time:515242ms step_avg:191.61ms
+step:2690/4150 train_time:515480ms step_avg:191.63ms
+step:2691/4150 train_time:515715ms step_avg:191.64ms
+step:2692/4150 train_time:515952ms step_avg:191.66ms
+step:2693/4150 train_time:516184ms step_avg:191.68ms
+step:2694/4150 train_time:516423ms step_avg:191.69ms
+step:2695/4150 train_time:516660ms step_avg:191.71ms
+step:2696/4150 train_time:516895ms step_avg:191.73ms
+step:2697/4150 train_time:517131ms step_avg:191.74ms
+step:2698/4150 train_time:517371ms step_avg:191.76ms
+step:2699/4150 train_time:517608ms step_avg:191.78ms
+step:2700/4150 train_time:517843ms step_avg:191.79ms
+step:2701/4150 train_time:518074ms step_avg:191.81ms
+step:2702/4150 train_time:518315ms step_avg:191.83ms
+step:2703/4150 train_time:518551ms step_avg:191.84ms
+step:2704/4150 train_time:518787ms step_avg:191.86ms
+step:2705/4150 train_time:519020ms step_avg:191.87ms
+step:2706/4150 train_time:519257ms step_avg:191.89ms
+step:2707/4150 train_time:519493ms step_avg:191.91ms
+step:2708/4150 train_time:519730ms step_avg:191.92ms
+step:2709/4150 train_time:519962ms step_avg:191.94ms
+step:2710/4150 train_time:520199ms step_avg:191.96ms
+step:2711/4150 train_time:520432ms step_avg:191.97ms
+step:2712/4150 train_time:520667ms step_avg:191.99ms
+step:2713/4150 train_time:520901ms step_avg:192.00ms
+step:2714/4150 train_time:521138ms step_avg:192.02ms
+step:2715/4150 train_time:521372ms step_avg:192.03ms
+step:2716/4150 train_time:521611ms step_avg:192.05ms
+step:2717/4150 train_time:521843ms step_avg:192.07ms
+step:2718/4150 train_time:522079ms step_avg:192.08ms
+step:2719/4150 train_time:522313ms step_avg:192.10ms
+step:2720/4150 train_time:522552ms step_avg:192.11ms
+step:2721/4150 train_time:522784ms step_avg:192.13ms
+step:2722/4150 train_time:523021ms step_avg:192.15ms
+step:2723/4150 train_time:523254ms step_avg:192.16ms
+step:2724/4150 train_time:523494ms step_avg:192.18ms
+step:2725/4150 train_time:523729ms step_avg:192.19ms
+step:2726/4150 train_time:523964ms step_avg:192.21ms
+step:2727/4150 train_time:524200ms step_avg:192.23ms
+step:2728/4150 train_time:524436ms step_avg:192.24ms
+step:2729/4150 train_time:524672ms step_avg:192.26ms
+step:2730/4150 train_time:524913ms step_avg:192.28ms
+step:2731/4150 train_time:525146ms step_avg:192.29ms
+step:2732/4150 train_time:525383ms step_avg:192.31ms
+step:2733/4150 train_time:525619ms step_avg:192.32ms
+step:2734/4150 train_time:525856ms step_avg:192.34ms
+step:2735/4150 train_time:526089ms step_avg:192.35ms
+step:2736/4150 train_time:526323ms step_avg:192.37ms
+step:2737/4150 train_time:526556ms step_avg:192.38ms
+step:2738/4150 train_time:526795ms step_avg:192.40ms
+step:2739/4150 train_time:527033ms step_avg:192.42ms
+step:2740/4150 train_time:527274ms step_avg:192.44ms
+step:2741/4150 train_time:527507ms step_avg:192.45ms
+step:2742/4150 train_time:527741ms step_avg:192.47ms
+step:2743/4150 train_time:527979ms step_avg:192.48ms
+step:2744/4150 train_time:528215ms step_avg:192.50ms
+step:2745/4150 train_time:528447ms step_avg:192.51ms
+step:2746/4150 train_time:528682ms step_avg:192.53ms
+step:2747/4150 train_time:528917ms step_avg:192.54ms
+step:2748/4150 train_time:529155ms step_avg:192.56ms
+step:2749/4150 train_time:529390ms step_avg:192.58ms
+step:2750/4150 train_time:529628ms step_avg:192.59ms
+step:2750/4150 val_loss:3.0727 train_time:529848ms step_avg:192.67ms
+step:2751/4150 train_time:529874ms step_avg:192.61ms
+step:2752/4150 train_time:530111ms step_avg:192.63ms
+step:2753/4150 train_time:530346ms step_avg:192.64ms
+step:2754/4150 train_time:530580ms step_avg:192.66ms
+step:2755/4150 train_time:530812ms step_avg:192.67ms
+step:2756/4150 train_time:531049ms step_avg:192.69ms
+step:2757/4150 train_time:531286ms step_avg:192.70ms
+step:2758/4150 train_time:531521ms step_avg:192.72ms
+step:2759/4150 train_time:531755ms step_avg:192.73ms
+step:2760/4150 train_time:531994ms step_avg:192.75ms
+step:2761/4150 train_time:532230ms step_avg:192.77ms
+step:2762/4150 train_time:532469ms step_avg:192.78ms
+step:2763/4150 train_time:532699ms step_avg:192.80ms
+step:2764/4150 train_time:532936ms step_avg:192.81ms
+step:2765/4150 train_time:533175ms step_avg:192.83ms
+step:2766/4150 train_time:533415ms step_avg:192.85ms
+step:2767/4150 train_time:533648ms step_avg:192.86ms
+step:2768/4150 train_time:533882ms step_avg:192.88ms
+step:2769/4150 train_time:534118ms step_avg:192.89ms
+step:2770/4150 train_time:534356ms step_avg:192.91ms
+step:2771/4150 train_time:534590ms step_avg:192.92ms
+step:2772/4150 train_time:534825ms step_avg:192.94ms
+step:2773/4150 train_time:535058ms step_avg:192.95ms
+step:2774/4150 train_time:535296ms step_avg:192.97ms
+step:2775/4150 train_time:535531ms step_avg:192.98ms
+step:2776/4150 train_time:535771ms step_avg:193.00ms
+step:2777/4150 train_time:536004ms step_avg:193.02ms
+step:2778/4150 train_time:536241ms step_avg:193.03ms
+step:2779/4150 train_time:536479ms step_avg:193.05ms
+step:2780/4150 train_time:536717ms step_avg:193.06ms
+step:2781/4150 train_time:536951ms step_avg:193.08ms
+step:2782/4150 train_time:537186ms step_avg:193.09ms
+step:2783/4150 train_time:537421ms step_avg:193.11ms
+step:2784/4150 train_time:537660ms step_avg:193.12ms
+step:2785/4150 train_time:537894ms step_avg:193.14ms
+step:2786/4150 train_time:538131ms step_avg:193.16ms
+step:2787/4150 train_time:538364ms step_avg:193.17ms
+step:2788/4150 train_time:538605ms step_avg:193.19ms
+step:2789/4150 train_time:538841ms step_avg:193.20ms
+step:2790/4150 train_time:539078ms step_avg:193.22ms
+step:2791/4150 train_time:539313ms step_avg:193.23ms
+step:2792/4150 train_time:539550ms step_avg:193.25ms
+step:2793/4150 train_time:539784ms step_avg:193.26ms
+step:2794/4150 train_time:540018ms step_avg:193.28ms
+step:2795/4150 train_time:540256ms step_avg:193.29ms
+step:2796/4150 train_time:540493ms step_avg:193.31ms
+step:2797/4150 train_time:540726ms step_avg:193.32ms
+step:2798/4150 train_time:540960ms step_avg:193.34ms
+step:2799/4150 train_time:541199ms step_avg:193.35ms
+step:2800/4150 train_time:541436ms step_avg:193.37ms
+step:2801/4150 train_time:541671ms step_avg:193.38ms
+step:2802/4150 train_time:541907ms step_avg:193.40ms
+step:2803/4150 train_time:542141ms step_avg:193.41ms
+step:2804/4150 train_time:542376ms step_avg:193.43ms
+step:2805/4150 train_time:542611ms step_avg:193.44ms
+step:2806/4150 train_time:542848ms step_avg:193.46ms
+step:2807/4150 train_time:543079ms step_avg:193.47ms
+step:2808/4150 train_time:543319ms step_avg:193.49ms
+step:2809/4150 train_time:543554ms step_avg:193.50ms
+step:2810/4150 train_time:543796ms step_avg:193.52ms
+step:2811/4150 train_time:544029ms step_avg:193.54ms
+step:2812/4150 train_time:544265ms step_avg:193.55ms
+step:2813/4150 train_time:544497ms step_avg:193.56ms
+step:2814/4150 train_time:544737ms step_avg:193.58ms
+step:2815/4150 train_time:544979ms step_avg:193.60ms
+step:2816/4150 train_time:545219ms step_avg:193.61ms
+step:2817/4150 train_time:545456ms step_avg:193.63ms
+step:2818/4150 train_time:545694ms step_avg:193.65ms
+step:2819/4150 train_time:545930ms step_avg:193.66ms
+step:2820/4150 train_time:546168ms step_avg:193.68ms
+step:2821/4150 train_time:546402ms step_avg:193.69ms
+step:2822/4150 train_time:546639ms step_avg:193.71ms
+step:2823/4150 train_time:546871ms step_avg:193.72ms
+step:2824/4150 train_time:547107ms step_avg:193.73ms
+step:2825/4150 train_time:547345ms step_avg:193.75ms
+step:2826/4150 train_time:547579ms step_avg:193.76ms
+step:2827/4150 train_time:547813ms step_avg:193.78ms
+step:2828/4150 train_time:548050ms step_avg:193.79ms
+step:2829/4150 train_time:548282ms step_avg:193.81ms
+step:2830/4150 train_time:548520ms step_avg:193.82ms
+step:2831/4150 train_time:548757ms step_avg:193.84ms
+step:2832/4150 train_time:548997ms step_avg:193.85ms
+step:2833/4150 train_time:549233ms step_avg:193.87ms
+step:2834/4150 train_time:549471ms step_avg:193.89ms
+step:2835/4150 train_time:549705ms step_avg:193.90ms
+step:2836/4150 train_time:549941ms step_avg:193.91ms
+step:2837/4150 train_time:550177ms step_avg:193.93ms
+step:2838/4150 train_time:550416ms step_avg:193.95ms
+step:2839/4150 train_time:550650ms step_avg:193.96ms
+step:2840/4150 train_time:550886ms step_avg:193.97ms
+step:2841/4150 train_time:551120ms step_avg:193.99ms
+step:2842/4150 train_time:551356ms step_avg:194.00ms
+step:2843/4150 train_time:551594ms step_avg:194.02ms
+step:2844/4150 train_time:551834ms step_avg:194.03ms
+step:2845/4150 train_time:552070ms step_avg:194.05ms
+step:2846/4150 train_time:552305ms step_avg:194.06ms
+step:2847/4150 train_time:552539ms step_avg:194.08ms
+step:2848/4150 train_time:552778ms step_avg:194.09ms
+step:2849/4150 train_time:553012ms step_avg:194.11ms
+step:2850/4150 train_time:553250ms step_avg:194.12ms
+step:2851/4150 train_time:553482ms step_avg:194.14ms
+step:2852/4150 train_time:553718ms step_avg:194.15ms
+step:2853/4150 train_time:553954ms step_avg:194.17ms
+step:2854/4150 train_time:554191ms step_avg:194.18ms
+step:2855/4150 train_time:554425ms step_avg:194.19ms
+step:2856/4150 train_time:554662ms step_avg:194.21ms
+step:2857/4150 train_time:554899ms step_avg:194.22ms
+step:2858/4150 train_time:555135ms step_avg:194.24ms
+step:2859/4150 train_time:555370ms step_avg:194.25ms
+step:2860/4150 train_time:555607ms step_avg:194.27ms
+step:2861/4150 train_time:555843ms step_avg:194.28ms
+step:2862/4150 train_time:556082ms step_avg:194.30ms
+step:2863/4150 train_time:556317ms step_avg:194.31ms
+step:2864/4150 train_time:556553ms step_avg:194.33ms
+step:2865/4150 train_time:556788ms step_avg:194.34ms
+step:2866/4150 train_time:557025ms step_avg:194.36ms
+step:2867/4150 train_time:557258ms step_avg:194.37ms
+step:2868/4150 train_time:557494ms step_avg:194.38ms
+step:2869/4150 train_time:557730ms step_avg:194.40ms
+step:2870/4150 train_time:557969ms step_avg:194.41ms
+step:2871/4150 train_time:558203ms step_avg:194.43ms
+step:2872/4150 train_time:558442ms step_avg:194.44ms
+step:2873/4150 train_time:558677ms step_avg:194.46ms
+step:2874/4150 train_time:558915ms step_avg:194.47ms
+step:2875/4150 train_time:559149ms step_avg:194.49ms
+step:2876/4150 train_time:559384ms step_avg:194.50ms
+step:2877/4150 train_time:559621ms step_avg:194.52ms
+step:2878/4150 train_time:559862ms step_avg:194.53ms
+step:2879/4150 train_time:560096ms step_avg:194.55ms
+step:2880/4150 train_time:560336ms step_avg:194.56ms
+step:2881/4150 train_time:560571ms step_avg:194.58ms
+step:2882/4150 train_time:560810ms step_avg:194.59ms
+step:2883/4150 train_time:561045ms step_avg:194.60ms
+step:2884/4150 train_time:561281ms step_avg:194.62ms
+step:2885/4150 train_time:561514ms step_avg:194.63ms
+step:2886/4150 train_time:561754ms step_avg:194.65ms
+step:2887/4150 train_time:561991ms step_avg:194.66ms
+step:2888/4150 train_time:562228ms step_avg:194.68ms
+step:2889/4150 train_time:562459ms step_avg:194.69ms
+step:2890/4150 train_time:562697ms step_avg:194.70ms
+step:2891/4150 train_time:562932ms step_avg:194.72ms
+step:2892/4150 train_time:563170ms step_avg:194.73ms
+step:2893/4150 train_time:563402ms step_avg:194.75ms
+step:2894/4150 train_time:563640ms step_avg:194.76ms
+step:2895/4150 train_time:563875ms step_avg:194.78ms
+step:2896/4150 train_time:564114ms step_avg:194.79ms
+step:2897/4150 train_time:564349ms step_avg:194.80ms
+step:2898/4150 train_time:564584ms step_avg:194.82ms
+step:2899/4150 train_time:564820ms step_avg:194.83ms
+step:2900/4150 train_time:565057ms step_avg:194.85ms
+step:2901/4150 train_time:565292ms step_avg:194.86ms
+step:2902/4150 train_time:565530ms step_avg:194.88ms
+step:2903/4150 train_time:565762ms step_avg:194.89ms
+step:2904/4150 train_time:566000ms step_avg:194.90ms
+step:2905/4150 train_time:566236ms step_avg:194.92ms
+step:2906/4150 train_time:566473ms step_avg:194.93ms
+step:2907/4150 train_time:566704ms step_avg:194.94ms
+step:2908/4150 train_time:566941ms step_avg:194.96ms
+step:2909/4150 train_time:567180ms step_avg:194.97ms
+step:2910/4150 train_time:567417ms step_avg:194.99ms
+step:2911/4150 train_time:567654ms step_avg:195.00ms
+step:2912/4150 train_time:567889ms step_avg:195.02ms
+step:2913/4150 train_time:568121ms step_avg:195.03ms
+step:2914/4150 train_time:568361ms step_avg:195.04ms
+step:2915/4150 train_time:568596ms step_avg:195.06ms
+step:2916/4150 train_time:568835ms step_avg:195.07ms
+step:2917/4150 train_time:569068ms step_avg:195.09ms
+step:2918/4150 train_time:569305ms step_avg:195.10ms
+step:2919/4150 train_time:569541ms step_avg:195.11ms
+step:2920/4150 train_time:569776ms step_avg:195.13ms
+step:2921/4150 train_time:570010ms step_avg:195.14ms
+step:2922/4150 train_time:570249ms step_avg:195.16ms
+step:2923/4150 train_time:570481ms step_avg:195.17ms
+step:2924/4150 train_time:570719ms step_avg:195.18ms
+step:2925/4150 train_time:570954ms step_avg:195.20ms
+step:2926/4150 train_time:571192ms step_avg:195.21ms
+step:2927/4150 train_time:571423ms step_avg:195.22ms
+step:2928/4150 train_time:571660ms step_avg:195.24ms
+step:2929/4150 train_time:571896ms step_avg:195.25ms
+step:2930/4150 train_time:572134ms step_avg:195.27ms
+step:2931/4150 train_time:572369ms step_avg:195.28ms
+step:2932/4150 train_time:572607ms step_avg:195.30ms
+step:2933/4150 train_time:572841ms step_avg:195.31ms
+step:2934/4150 train_time:573080ms step_avg:195.32ms
+step:2935/4150 train_time:573316ms step_avg:195.34ms
+step:2936/4150 train_time:573556ms step_avg:195.35ms
+step:2937/4150 train_time:573790ms step_avg:195.37ms
+step:2938/4150 train_time:574026ms step_avg:195.38ms
+step:2939/4150 train_time:574263ms step_avg:195.39ms
+step:2940/4150 train_time:574501ms step_avg:195.41ms
+step:2941/4150 train_time:574737ms step_avg:195.42ms
+step:2942/4150 train_time:574976ms step_avg:195.44ms
+step:2943/4150 train_time:575211ms step_avg:195.45ms
+step:2944/4150 train_time:575449ms step_avg:195.47ms
+step:2945/4150 train_time:575682ms step_avg:195.48ms
+step:2946/4150 train_time:575920ms step_avg:195.49ms
+step:2947/4150 train_time:576156ms step_avg:195.51ms
+step:2948/4150 train_time:576392ms step_avg:195.52ms
+step:2949/4150 train_time:576624ms step_avg:195.53ms
+step:2950/4150 train_time:576862ms step_avg:195.55ms
+step:2951/4150 train_time:577095ms step_avg:195.56ms
+step:2952/4150 train_time:577333ms step_avg:195.57ms
+step:2953/4150 train_time:577567ms step_avg:195.59ms
+step:2954/4150 train_time:577806ms step_avg:195.60ms
+step:2955/4150 train_time:578042ms step_avg:195.61ms
+step:2956/4150 train_time:578278ms step_avg:195.63ms
+step:2957/4150 train_time:578515ms step_avg:195.64ms
+step:2958/4150 train_time:578751ms step_avg:195.66ms
+step:2959/4150 train_time:578988ms step_avg:195.67ms
+step:2960/4150 train_time:579224ms step_avg:195.68ms
+step:2961/4150 train_time:579459ms step_avg:195.70ms
+step:2962/4150 train_time:579699ms step_avg:195.71ms
+step:2963/4150 train_time:579932ms step_avg:195.72ms
+step:2964/4150 train_time:580171ms step_avg:195.74ms
+step:2965/4150 train_time:580404ms step_avg:195.75ms
+step:2966/4150 train_time:580640ms step_avg:195.77ms
+step:2967/4150 train_time:580877ms step_avg:195.78ms
+step:2968/4150 train_time:581115ms step_avg:195.79ms
+step:2969/4150 train_time:581352ms step_avg:195.81ms
+step:2970/4150 train_time:581593ms step_avg:195.82ms
+step:2971/4150 train_time:581824ms step_avg:195.83ms
+step:2972/4150 train_time:582060ms step_avg:195.85ms
+step:2973/4150 train_time:582297ms step_avg:195.86ms
+step:2974/4150 train_time:582532ms step_avg:195.87ms
+step:2975/4150 train_time:582766ms step_avg:195.89ms
+step:2976/4150 train_time:583003ms step_avg:195.90ms
+step:2977/4150 train_time:583238ms step_avg:195.91ms
+step:2978/4150 train_time:583473ms step_avg:195.93ms
+step:2979/4150 train_time:583708ms step_avg:195.94ms
+step:2980/4150 train_time:583946ms step_avg:195.96ms
+step:2981/4150 train_time:584181ms step_avg:195.97ms
+step:2982/4150 train_time:584419ms step_avg:195.98ms
+step:2983/4150 train_time:584654ms step_avg:196.00ms
+step:2984/4150 train_time:584896ms step_avg:196.01ms
+step:2985/4150 train_time:585133ms step_avg:196.02ms
+step:2986/4150 train_time:585371ms step_avg:196.04ms
+step:2987/4150 train_time:585604ms step_avg:196.05ms
+step:2988/4150 train_time:585843ms step_avg:196.07ms
+step:2989/4150 train_time:586076ms step_avg:196.08ms
+step:2990/4150 train_time:586314ms step_avg:196.09ms
+step:2991/4150 train_time:586550ms step_avg:196.10ms
+step:2992/4150 train_time:586787ms step_avg:196.12ms
+step:2993/4150 train_time:587020ms step_avg:196.13ms
+step:2994/4150 train_time:587258ms step_avg:196.15ms
+step:2995/4150 train_time:587494ms step_avg:196.16ms
+step:2996/4150 train_time:587730ms step_avg:196.17ms
+step:2997/4150 train_time:587964ms step_avg:196.18ms
+step:2998/4150 train_time:588200ms step_avg:196.20ms
+step:2999/4150 train_time:588437ms step_avg:196.21ms
+step:3000/4150 train_time:588675ms step_avg:196.22ms
+step:3000/4150 val_loss:3.0411 train_time:588891ms step_avg:196.30ms
+step:3001/4150 train_time:588915ms step_avg:196.24ms
+step:3002/4150 train_time:589152ms step_avg:196.25ms
+step:3003/4150 train_time:589387ms step_avg:196.27ms
+step:3004/4150 train_time:589623ms step_avg:196.28ms
+step:3005/4150 train_time:589855ms step_avg:196.29ms
+step:3006/4150 train_time:590093ms step_avg:196.30ms
+step:3007/4150 train_time:590331ms step_avg:196.32ms
+step:3008/4150 train_time:590571ms step_avg:196.33ms
+step:3009/4150 train_time:590804ms step_avg:196.35ms
+step:3010/4150 train_time:591041ms step_avg:196.36ms
+step:3011/4150 train_time:591276ms step_avg:196.37ms
+step:3012/4150 train_time:591513ms step_avg:196.39ms
+step:3013/4150 train_time:591748ms step_avg:196.40ms
+step:3014/4150 train_time:591986ms step_avg:196.41ms
+step:3015/4150 train_time:592223ms step_avg:196.43ms
+step:3016/4150 train_time:592459ms step_avg:196.44ms
+step:3017/4150 train_time:592694ms step_avg:196.45ms
+step:3018/4150 train_time:592929ms step_avg:196.46ms
+step:3019/4150 train_time:593168ms step_avg:196.48ms
+step:3020/4150 train_time:593407ms step_avg:196.49ms
+step:3021/4150 train_time:593641ms step_avg:196.50ms
+step:3022/4150 train_time:593877ms step_avg:196.52ms
+step:3023/4150 train_time:594115ms step_avg:196.53ms
+step:3024/4150 train_time:594352ms step_avg:196.55ms
+step:3025/4150 train_time:594585ms step_avg:196.56ms
+step:3026/4150 train_time:594821ms step_avg:196.57ms
+step:3027/4150 train_time:595054ms step_avg:196.58ms
+step:3028/4150 train_time:595290ms step_avg:196.60ms
+step:3029/4150 train_time:595524ms step_avg:196.61ms
+step:3030/4150 train_time:595762ms step_avg:196.62ms
+step:3031/4150 train_time:595995ms step_avg:196.63ms
+step:3032/4150 train_time:596231ms step_avg:196.65ms
+step:3033/4150 train_time:596464ms step_avg:196.66ms
+step:3034/4150 train_time:596705ms step_avg:196.67ms
+step:3035/4150 train_time:596938ms step_avg:196.68ms
+step:3036/4150 train_time:597173ms step_avg:196.70ms
+step:3037/4150 train_time:597408ms step_avg:196.71ms
+step:3038/4150 train_time:597647ms step_avg:196.72ms
+step:3039/4150 train_time:597880ms step_avg:196.74ms
+step:3040/4150 train_time:598118ms step_avg:196.75ms
+step:3041/4150 train_time:598354ms step_avg:196.76ms
+step:3042/4150 train_time:598590ms step_avg:196.78ms
+step:3043/4150 train_time:598824ms step_avg:196.79ms
+step:3044/4150 train_time:599059ms step_avg:196.80ms
+step:3045/4150 train_time:599294ms step_avg:196.81ms
+step:3046/4150 train_time:599532ms step_avg:196.83ms
+step:3047/4150 train_time:599768ms step_avg:196.84ms
+step:3048/4150 train_time:600008ms step_avg:196.85ms
+step:3049/4150 train_time:600243ms step_avg:196.87ms
+step:3050/4150 train_time:600481ms step_avg:196.88ms
+step:3051/4150 train_time:600713ms step_avg:196.89ms
+step:3052/4150 train_time:600952ms step_avg:196.90ms
+step:3053/4150 train_time:601186ms step_avg:196.92ms
+step:3054/4150 train_time:601423ms step_avg:196.93ms
+step:3055/4150 train_time:601657ms step_avg:196.94ms
+step:3056/4150 train_time:601893ms step_avg:196.95ms
+step:3057/4150 train_time:602130ms step_avg:196.97ms
+step:3058/4150 train_time:602367ms step_avg:196.98ms
+step:3059/4150 train_time:602603ms step_avg:196.99ms
+step:3060/4150 train_time:602843ms step_avg:197.01ms
+step:3061/4150 train_time:603076ms step_avg:197.02ms
+step:3062/4150 train_time:603315ms step_avg:197.03ms
+step:3063/4150 train_time:603552ms step_avg:197.05ms
+step:3064/4150 train_time:603792ms step_avg:197.06ms
+step:3065/4150 train_time:604026ms step_avg:197.07ms
+step:3066/4150 train_time:604267ms step_avg:197.09ms
+step:3067/4150 train_time:604500ms step_avg:197.10ms
+step:3068/4150 train_time:604736ms step_avg:197.11ms
+step:3069/4150 train_time:604966ms step_avg:197.12ms
+step:3070/4150 train_time:605204ms step_avg:197.13ms
+step:3071/4150 train_time:605438ms step_avg:197.15ms
+step:3072/4150 train_time:605674ms step_avg:197.16ms
+step:3073/4150 train_time:605907ms step_avg:197.17ms
+step:3074/4150 train_time:606146ms step_avg:197.18ms
+step:3075/4150 train_time:606383ms step_avg:197.20ms
+step:3076/4150 train_time:606620ms step_avg:197.21ms
+step:3077/4150 train_time:606853ms step_avg:197.22ms
+step:3078/4150 train_time:607092ms step_avg:197.24ms
+step:3079/4150 train_time:607327ms step_avg:197.25ms
+step:3080/4150 train_time:607564ms step_avg:197.26ms
+step:3081/4150 train_time:607798ms step_avg:197.27ms
+step:3082/4150 train_time:608036ms step_avg:197.29ms
+step:3083/4150 train_time:608270ms step_avg:197.30ms
+step:3084/4150 train_time:608509ms step_avg:197.31ms
+step:3085/4150 train_time:608744ms step_avg:197.32ms
+step:3086/4150 train_time:608981ms step_avg:197.34ms
+step:3087/4150 train_time:609214ms step_avg:197.35ms
+step:3088/4150 train_time:609453ms step_avg:197.36ms
+step:3089/4150 train_time:609688ms step_avg:197.37ms
+step:3090/4150 train_time:609926ms step_avg:197.39ms
+step:3091/4150 train_time:610160ms step_avg:197.40ms
+step:3092/4150 train_time:610399ms step_avg:197.41ms
+step:3093/4150 train_time:610634ms step_avg:197.42ms
+step:3094/4150 train_time:610871ms step_avg:197.44ms
+step:3095/4150 train_time:611105ms step_avg:197.45ms
+step:3096/4150 train_time:611342ms step_avg:197.46ms
+step:3097/4150 train_time:611575ms step_avg:197.47ms
+step:3098/4150 train_time:611812ms step_avg:197.49ms
+step:3099/4150 train_time:612050ms step_avg:197.50ms
+step:3100/4150 train_time:612284ms step_avg:197.51ms
+step:3101/4150 train_time:612520ms step_avg:197.52ms
+step:3102/4150 train_time:612756ms step_avg:197.54ms
+step:3103/4150 train_time:612990ms step_avg:197.55ms
+step:3104/4150 train_time:613229ms step_avg:197.56ms
+step:3105/4150 train_time:613466ms step_avg:197.57ms
+step:3106/4150 train_time:613703ms step_avg:197.59ms
+step:3107/4150 train_time:613938ms step_avg:197.60ms
+step:3108/4150 train_time:614179ms step_avg:197.61ms
+step:3109/4150 train_time:614415ms step_avg:197.62ms
+step:3110/4150 train_time:614653ms step_avg:197.64ms
+step:3111/4150 train_time:614887ms step_avg:197.65ms
+step:3112/4150 train_time:615126ms step_avg:197.66ms
+step:3113/4150 train_time:615363ms step_avg:197.68ms
+step:3114/4150 train_time:615602ms step_avg:197.69ms
+step:3115/4150 train_time:615836ms step_avg:197.70ms
+step:3116/4150 train_time:616073ms step_avg:197.71ms
+step:3117/4150 train_time:616308ms step_avg:197.72ms
+step:3118/4150 train_time:616547ms step_avg:197.74ms
+step:3119/4150 train_time:616781ms step_avg:197.75ms
+step:3120/4150 train_time:617024ms step_avg:197.76ms
+step:3121/4150 train_time:617262ms step_avg:197.78ms
+step:3122/4150 train_time:617499ms step_avg:197.79ms
+step:3123/4150 train_time:617733ms step_avg:197.80ms
+step:3124/4150 train_time:617969ms step_avg:197.81ms
+step:3125/4150 train_time:618204ms step_avg:197.83ms
+step:3126/4150 train_time:618441ms step_avg:197.84ms
+step:3127/4150 train_time:618675ms step_avg:197.85ms
+step:3128/4150 train_time:618911ms step_avg:197.86ms
+step:3129/4150 train_time:619143ms step_avg:197.87ms
+step:3130/4150 train_time:619384ms step_avg:197.89ms
+step:3131/4150 train_time:619617ms step_avg:197.90ms
+step:3132/4150 train_time:619853ms step_avg:197.91ms
+step:3133/4150 train_time:620091ms step_avg:197.92ms
+step:3134/4150 train_time:620329ms step_avg:197.94ms
+step:3135/4150 train_time:620564ms step_avg:197.95ms
+step:3136/4150 train_time:620804ms step_avg:197.96ms
+step:3137/4150 train_time:621041ms step_avg:197.97ms
+step:3138/4150 train_time:621279ms step_avg:197.99ms
+step:3139/4150 train_time:621514ms step_avg:198.00ms
+step:3140/4150 train_time:621752ms step_avg:198.01ms
+step:3141/4150 train_time:621988ms step_avg:198.02ms
+step:3142/4150 train_time:622227ms step_avg:198.04ms
+step:3143/4150 train_time:622460ms step_avg:198.05ms
+step:3144/4150 train_time:622699ms step_avg:198.06ms
+step:3145/4150 train_time:622935ms step_avg:198.07ms
+step:3146/4150 train_time:623171ms step_avg:198.08ms
+step:3147/4150 train_time:623404ms step_avg:198.09ms
+step:3148/4150 train_time:623639ms step_avg:198.11ms
+step:3149/4150 train_time:623873ms step_avg:198.12ms
+step:3150/4150 train_time:624113ms step_avg:198.13ms
+step:3151/4150 train_time:624348ms step_avg:198.14ms
+step:3152/4150 train_time:624586ms step_avg:198.16ms
+step:3153/4150 train_time:624823ms step_avg:198.17ms
+step:3154/4150 train_time:625061ms step_avg:198.18ms
+step:3155/4150 train_time:625297ms step_avg:198.19ms
+step:3156/4150 train_time:625533ms step_avg:198.20ms
+step:3157/4150 train_time:625770ms step_avg:198.22ms
+step:3158/4150 train_time:626009ms step_avg:198.23ms
+step:3159/4150 train_time:626247ms step_avg:198.24ms
+step:3160/4150 train_time:626488ms step_avg:198.26ms
+step:3161/4150 train_time:626723ms step_avg:198.27ms
+step:3162/4150 train_time:626960ms step_avg:198.28ms
+step:3163/4150 train_time:627195ms step_avg:198.29ms
+step:3164/4150 train_time:627434ms step_avg:198.30ms
+step:3165/4150 train_time:627668ms step_avg:198.32ms
+step:3166/4150 train_time:627903ms step_avg:198.33ms
+step:3167/4150 train_time:628138ms step_avg:198.34ms
+step:3168/4150 train_time:628377ms step_avg:198.35ms
+step:3169/4150 train_time:628610ms step_avg:198.36ms
+step:3170/4150 train_time:628848ms step_avg:198.37ms
+step:3171/4150 train_time:629080ms step_avg:198.39ms
+step:3172/4150 train_time:629318ms step_avg:198.40ms
+step:3173/4150 train_time:629554ms step_avg:198.41ms
+step:3174/4150 train_time:629792ms step_avg:198.42ms
+step:3175/4150 train_time:630028ms step_avg:198.43ms
+step:3176/4150 train_time:630267ms step_avg:198.45ms
+step:3177/4150 train_time:630502ms step_avg:198.46ms
+step:3178/4150 train_time:630739ms step_avg:198.47ms
+step:3179/4150 train_time:630974ms step_avg:198.48ms
+step:3180/4150 train_time:631211ms step_avg:198.49ms
+step:3181/4150 train_time:631447ms step_avg:198.51ms
+step:3182/4150 train_time:631685ms step_avg:198.52ms
+step:3183/4150 train_time:631920ms step_avg:198.53ms
+step:3184/4150 train_time:632157ms step_avg:198.54ms
+step:3185/4150 train_time:632391ms step_avg:198.55ms
+step:3186/4150 train_time:632631ms step_avg:198.57ms
+step:3187/4150 train_time:632864ms step_avg:198.58ms
+step:3188/4150 train_time:633104ms step_avg:198.59ms
+step:3189/4150 train_time:633339ms step_avg:198.60ms
+step:3190/4150 train_time:633575ms step_avg:198.61ms
+step:3191/4150 train_time:633810ms step_avg:198.62ms
+step:3192/4150 train_time:634047ms step_avg:198.64ms
+step:3193/4150 train_time:634279ms step_avg:198.65ms
+step:3194/4150 train_time:634517ms step_avg:198.66ms
+step:3195/4150 train_time:634754ms step_avg:198.67ms
+step:3196/4150 train_time:634989ms step_avg:198.68ms
+step:3197/4150 train_time:635221ms step_avg:198.69ms
+step:3198/4150 train_time:635460ms step_avg:198.71ms
+step:3199/4150 train_time:635697ms step_avg:198.72ms
+step:3200/4150 train_time:635931ms step_avg:198.73ms
+step:3201/4150 train_time:636167ms step_avg:198.74ms
+step:3202/4150 train_time:636405ms step_avg:198.75ms
+step:3203/4150 train_time:636637ms step_avg:198.76ms
+step:3204/4150 train_time:636873ms step_avg:198.77ms
+step:3205/4150 train_time:637109ms step_avg:198.79ms
+step:3206/4150 train_time:637352ms step_avg:198.80ms
+step:3207/4150 train_time:637584ms step_avg:198.81ms
+step:3208/4150 train_time:637822ms step_avg:198.82ms
+step:3209/4150 train_time:638055ms step_avg:198.83ms
+step:3210/4150 train_time:638291ms step_avg:198.84ms
+step:3211/4150 train_time:638528ms step_avg:198.86ms
+step:3212/4150 train_time:638766ms step_avg:198.87ms
+step:3213/4150 train_time:638999ms step_avg:198.88ms
+step:3214/4150 train_time:639237ms step_avg:198.89ms
+step:3215/4150 train_time:639471ms step_avg:198.90ms
+step:3216/4150 train_time:639706ms step_avg:198.91ms
+step:3217/4150 train_time:639941ms step_avg:198.92ms
+step:3218/4150 train_time:640178ms step_avg:198.94ms
+step:3219/4150 train_time:640415ms step_avg:198.95ms
+step:3220/4150 train_time:640652ms step_avg:198.96ms
+step:3221/4150 train_time:640884ms step_avg:198.97ms
+step:3222/4150 train_time:641121ms step_avg:198.98ms
+step:3223/4150 train_time:641354ms step_avg:198.99ms
+step:3224/4150 train_time:641592ms step_avg:199.00ms
+step:3225/4150 train_time:641826ms step_avg:199.02ms
+step:3226/4150 train_time:642066ms step_avg:199.03ms
+step:3227/4150 train_time:642300ms step_avg:199.04ms
+step:3228/4150 train_time:642536ms step_avg:199.05ms
+step:3229/4150 train_time:642769ms step_avg:199.06ms
+step:3230/4150 train_time:643007ms step_avg:199.07ms
+step:3231/4150 train_time:643242ms step_avg:199.08ms
+step:3232/4150 train_time:643481ms step_avg:199.10ms
+step:3233/4150 train_time:643713ms step_avg:199.11ms
+step:3234/4150 train_time:643951ms step_avg:199.12ms
+step:3235/4150 train_time:644184ms step_avg:199.13ms
+step:3236/4150 train_time:644422ms step_avg:199.14ms
+step:3237/4150 train_time:644655ms step_avg:199.15ms
+step:3238/4150 train_time:644892ms step_avg:199.16ms
+step:3239/4150 train_time:645130ms step_avg:199.18ms
+step:3240/4150 train_time:645366ms step_avg:199.19ms
+step:3241/4150 train_time:645601ms step_avg:199.20ms
+step:3242/4150 train_time:645843ms step_avg:199.21ms
+step:3243/4150 train_time:646077ms step_avg:199.22ms
+step:3244/4150 train_time:646313ms step_avg:199.23ms
+step:3245/4150 train_time:646550ms step_avg:199.24ms
+step:3246/4150 train_time:646787ms step_avg:199.26ms
+step:3247/4150 train_time:647023ms step_avg:199.27ms
+step:3248/4150 train_time:647261ms step_avg:199.28ms
+step:3249/4150 train_time:647496ms step_avg:199.29ms
+step:3250/4150 train_time:647733ms step_avg:199.30ms
+step:3250/4150 val_loss:3.0096 train_time:647950ms step_avg:199.37ms
+step:3251/4150 train_time:647973ms step_avg:199.31ms
+step:3252/4150 train_time:648214ms step_avg:199.33ms
+step:3253/4150 train_time:648449ms step_avg:199.34ms
+step:3254/4150 train_time:648683ms step_avg:199.35ms
+step:3255/4150 train_time:648914ms step_avg:199.36ms
+step:3256/4150 train_time:649153ms step_avg:199.37ms
+step:3257/4150 train_time:649391ms step_avg:199.38ms
+step:3258/4150 train_time:649626ms step_avg:199.39ms
+step:3259/4150 train_time:649857ms step_avg:199.40ms
+step:3260/4150 train_time:650094ms step_avg:199.42ms
+step:3261/4150 train_time:650332ms step_avg:199.43ms
+step:3262/4150 train_time:650569ms step_avg:199.44ms
+step:3263/4150 train_time:650803ms step_avg:199.45ms
+step:3264/4150 train_time:651042ms step_avg:199.46ms
+step:3265/4150 train_time:651279ms step_avg:199.47ms
+step:3266/4150 train_time:651520ms step_avg:199.49ms
+step:3267/4150 train_time:651753ms step_avg:199.50ms
+step:3268/4150 train_time:651988ms step_avg:199.51ms
+step:3269/4150 train_time:652222ms step_avg:199.52ms
+step:3270/4150 train_time:652461ms step_avg:199.53ms
+step:3271/4150 train_time:652698ms step_avg:199.54ms
+step:3272/4150 train_time:652937ms step_avg:199.55ms
+step:3273/4150 train_time:653169ms step_avg:199.56ms
+step:3274/4150 train_time:653406ms step_avg:199.57ms
+step:3275/4150 train_time:653641ms step_avg:199.58ms
+step:3276/4150 train_time:653884ms step_avg:199.60ms
+step:3277/4150 train_time:654119ms step_avg:199.61ms
+step:3278/4150 train_time:654355ms step_avg:199.62ms
+step:3279/4150 train_time:654590ms step_avg:199.63ms
+step:3280/4150 train_time:654828ms step_avg:199.64ms
+step:3281/4150 train_time:655064ms step_avg:199.65ms
+step:3282/4150 train_time:655302ms step_avg:199.67ms
+step:3283/4150 train_time:655537ms step_avg:199.68ms
+step:3284/4150 train_time:655776ms step_avg:199.69ms
+step:3285/4150 train_time:656010ms step_avg:199.70ms
+step:3286/4150 train_time:656246ms step_avg:199.71ms
+step:3287/4150 train_time:656480ms step_avg:199.72ms
+step:3288/4150 train_time:656719ms step_avg:199.73ms
+step:3289/4150 train_time:656952ms step_avg:199.74ms
+step:3290/4150 train_time:657187ms step_avg:199.75ms
+step:3291/4150 train_time:657424ms step_avg:199.76ms
+step:3292/4150 train_time:657662ms step_avg:199.78ms
+step:3293/4150 train_time:657898ms step_avg:199.79ms
+step:3294/4150 train_time:658137ms step_avg:199.80ms
+step:3295/4150 train_time:658373ms step_avg:199.81ms
+step:3296/4150 train_time:658608ms step_avg:199.82ms
+step:3297/4150 train_time:658844ms step_avg:199.83ms
+step:3298/4150 train_time:659082ms step_avg:199.84ms
+step:3299/4150 train_time:659315ms step_avg:199.85ms
+step:3300/4150 train_time:659552ms step_avg:199.86ms
+step:3301/4150 train_time:659786ms step_avg:199.87ms
+step:3302/4150 train_time:660022ms step_avg:199.89ms
+step:3303/4150 train_time:660255ms step_avg:199.90ms
+step:3304/4150 train_time:660495ms step_avg:199.91ms
+step:3305/4150 train_time:660728ms step_avg:199.92ms
+step:3306/4150 train_time:660966ms step_avg:199.93ms
+step:3307/4150 train_time:661200ms step_avg:199.94ms
+step:3308/4150 train_time:661438ms step_avg:199.95ms
+step:3309/4150 train_time:661673ms step_avg:199.96ms
+step:3310/4150 train_time:661907ms step_avg:199.97ms
+step:3311/4150 train_time:662144ms step_avg:199.98ms
+step:3312/4150 train_time:662379ms step_avg:199.99ms
+step:3313/4150 train_time:662613ms step_avg:200.00ms
+step:3314/4150 train_time:662850ms step_avg:200.02ms
+step:3315/4150 train_time:663088ms step_avg:200.03ms
+step:3316/4150 train_time:663327ms step_avg:200.04ms
+step:3317/4150 train_time:663564ms step_avg:200.05ms
+step:3318/4150 train_time:663802ms step_avg:200.06ms
+step:3319/4150 train_time:664040ms step_avg:200.07ms
+step:3320/4150 train_time:664281ms step_avg:200.08ms
+step:3321/4150 train_time:664519ms step_avg:200.10ms
+step:3322/4150 train_time:664753ms step_avg:200.11ms
+step:3323/4150 train_time:664986ms step_avg:200.12ms
+step:3324/4150 train_time:665224ms step_avg:200.13ms
+step:3325/4150 train_time:665460ms step_avg:200.14ms
+step:3326/4150 train_time:665696ms step_avg:200.15ms
+step:3327/4150 train_time:665931ms step_avg:200.16ms
+step:3328/4150 train_time:666166ms step_avg:200.17ms
+step:3329/4150 train_time:666405ms step_avg:200.18ms
+step:3330/4150 train_time:666642ms step_avg:200.19ms
+step:3331/4150 train_time:666875ms step_avg:200.20ms
+step:3332/4150 train_time:667115ms step_avg:200.21ms
+step:3333/4150 train_time:667352ms step_avg:200.23ms
+step:3334/4150 train_time:667588ms step_avg:200.24ms
+step:3335/4150 train_time:667824ms step_avg:200.25ms
+step:3336/4150 train_time:668060ms step_avg:200.26ms
+step:3337/4150 train_time:668294ms step_avg:200.27ms
+step:3338/4150 train_time:668530ms step_avg:200.28ms
+step:3339/4150 train_time:668765ms step_avg:200.29ms
+step:3340/4150 train_time:669001ms step_avg:200.30ms
+step:3341/4150 train_time:669239ms step_avg:200.31ms
+step:3342/4150 train_time:669479ms step_avg:200.32ms
+step:3343/4150 train_time:669714ms step_avg:200.33ms
+step:3344/4150 train_time:669950ms step_avg:200.34ms
+step:3345/4150 train_time:670184ms step_avg:200.35ms
+step:3346/4150 train_time:670425ms step_avg:200.37ms
+step:3347/4150 train_time:670660ms step_avg:200.38ms
+step:3348/4150 train_time:670897ms step_avg:200.39ms
+step:3349/4150 train_time:671131ms step_avg:200.40ms
+step:3350/4150 train_time:671369ms step_avg:200.41ms
+step:3351/4150 train_time:671603ms step_avg:200.42ms
+step:3352/4150 train_time:671840ms step_avg:200.43ms
+step:3353/4150 train_time:672073ms step_avg:200.44ms
+step:3354/4150 train_time:672308ms step_avg:200.45ms
+step:3355/4150 train_time:672546ms step_avg:200.46ms
+step:3356/4150 train_time:672787ms step_avg:200.47ms
+step:3357/4150 train_time:673022ms step_avg:200.48ms
+step:3358/4150 train_time:673258ms step_avg:200.49ms
+step:3359/4150 train_time:673494ms step_avg:200.50ms
+step:3360/4150 train_time:673731ms step_avg:200.52ms
+step:3361/4150 train_time:673967ms step_avg:200.53ms
+step:3362/4150 train_time:674207ms step_avg:200.54ms
+step:3363/4150 train_time:674445ms step_avg:200.55ms
+step:3364/4150 train_time:674684ms step_avg:200.56ms
+step:3365/4150 train_time:674921ms step_avg:200.57ms
+step:3366/4150 train_time:675160ms step_avg:200.58ms
+step:3367/4150 train_time:675393ms step_avg:200.59ms
+step:3368/4150 train_time:675630ms step_avg:200.60ms
+step:3369/4150 train_time:675867ms step_avg:200.61ms
+step:3370/4150 train_time:676105ms step_avg:200.62ms
+step:3371/4150 train_time:676338ms step_avg:200.63ms
+step:3372/4150 train_time:676574ms step_avg:200.64ms
+step:3373/4150 train_time:676808ms step_avg:200.65ms
+step:3374/4150 train_time:677048ms step_avg:200.67ms
+step:3375/4150 train_time:677283ms step_avg:200.68ms
+step:3376/4150 train_time:677524ms step_avg:200.69ms
+step:3377/4150 train_time:677758ms step_avg:200.70ms
+step:3378/4150 train_time:677998ms step_avg:200.71ms
+step:3379/4150 train_time:678235ms step_avg:200.72ms
+step:3380/4150 train_time:678471ms step_avg:200.73ms
+step:3381/4150 train_time:678705ms step_avg:200.74ms
+step:3382/4150 train_time:678944ms step_avg:200.75ms
+step:3383/4150 train_time:679178ms step_avg:200.76ms
+step:3384/4150 train_time:679414ms step_avg:200.77ms
+step:3385/4150 train_time:679653ms step_avg:200.78ms
+step:3386/4150 train_time:679890ms step_avg:200.79ms
+step:3387/4150 train_time:680124ms step_avg:200.80ms
+step:3388/4150 train_time:680364ms step_avg:200.82ms
+step:3389/4150 train_time:680600ms step_avg:200.83ms
+step:3390/4150 train_time:680836ms step_avg:200.84ms
+step:3391/4150 train_time:681069ms step_avg:200.85ms
+step:3392/4150 train_time:681308ms step_avg:200.86ms
+step:3393/4150 train_time:681545ms step_avg:200.87ms
+step:3394/4150 train_time:681784ms step_avg:200.88ms
+step:3395/4150 train_time:682020ms step_avg:200.89ms
+step:3396/4150 train_time:682259ms step_avg:200.90ms
+step:3397/4150 train_time:682493ms step_avg:200.91ms
+step:3398/4150 train_time:682730ms step_avg:200.92ms
+step:3399/4150 train_time:682962ms step_avg:200.93ms
+step:3400/4150 train_time:683204ms step_avg:200.94ms
+step:3401/4150 train_time:683439ms step_avg:200.95ms
+step:3402/4150 train_time:683681ms step_avg:200.96ms
+step:3403/4150 train_time:683914ms step_avg:200.97ms
+step:3404/4150 train_time:684152ms step_avg:200.98ms
+step:3405/4150 train_time:684385ms step_avg:200.99ms
+step:3406/4150 train_time:684623ms step_avg:201.01ms
+step:3407/4150 train_time:684857ms step_avg:201.01ms
+step:3408/4150 train_time:685093ms step_avg:201.03ms
+step:3409/4150 train_time:685328ms step_avg:201.03ms
+step:3410/4150 train_time:685570ms step_avg:201.05ms
+step:3411/4150 train_time:685803ms step_avg:201.06ms
+step:3412/4150 train_time:686043ms step_avg:201.07ms
+step:3413/4150 train_time:686277ms step_avg:201.08ms
+step:3414/4150 train_time:686515ms step_avg:201.09ms
+step:3415/4150 train_time:686749ms step_avg:201.10ms
+step:3416/4150 train_time:686987ms step_avg:201.11ms
+step:3417/4150 train_time:687222ms step_avg:201.12ms
+step:3418/4150 train_time:687461ms step_avg:201.13ms
+step:3419/4150 train_time:687697ms step_avg:201.14ms
+step:3420/4150 train_time:687933ms step_avg:201.15ms
+step:3421/4150 train_time:688170ms step_avg:201.16ms
+step:3422/4150 train_time:688407ms step_avg:201.17ms
+step:3423/4150 train_time:688641ms step_avg:201.18ms
+step:3424/4150 train_time:688878ms step_avg:201.19ms
+step:3425/4150 train_time:689110ms step_avg:201.20ms
+step:3426/4150 train_time:689345ms step_avg:201.21ms
+step:3427/4150 train_time:689582ms step_avg:201.22ms
+step:3428/4150 train_time:689821ms step_avg:201.23ms
+step:3429/4150 train_time:690054ms step_avg:201.24ms
+step:3430/4150 train_time:690292ms step_avg:201.25ms
+step:3431/4150 train_time:690532ms step_avg:201.26ms
+step:3432/4150 train_time:690768ms step_avg:201.27ms
+step:3433/4150 train_time:691006ms step_avg:201.28ms
+step:3434/4150 train_time:691243ms step_avg:201.29ms
+step:3435/4150 train_time:691477ms step_avg:201.30ms
+step:3436/4150 train_time:691716ms step_avg:201.31ms
+step:3437/4150 train_time:691952ms step_avg:201.32ms
+step:3438/4150 train_time:692189ms step_avg:201.33ms
+step:3439/4150 train_time:692423ms step_avg:201.34ms
+step:3440/4150 train_time:692665ms step_avg:201.36ms
+step:3441/4150 train_time:692902ms step_avg:201.37ms
+step:3442/4150 train_time:693138ms step_avg:201.38ms
+step:3443/4150 train_time:693369ms step_avg:201.39ms
+step:3444/4150 train_time:693607ms step_avg:201.40ms
+step:3445/4150 train_time:693846ms step_avg:201.41ms
+step:3446/4150 train_time:694082ms step_avg:201.42ms
+step:3447/4150 train_time:694316ms step_avg:201.43ms
+step:3448/4150 train_time:694551ms step_avg:201.44ms
+step:3449/4150 train_time:694788ms step_avg:201.45ms
+step:3450/4150 train_time:695025ms step_avg:201.46ms
+step:3451/4150 train_time:695257ms step_avg:201.47ms
+step:3452/4150 train_time:695494ms step_avg:201.48ms
+step:3453/4150 train_time:695730ms step_avg:201.49ms
+step:3454/4150 train_time:695967ms step_avg:201.50ms
+step:3455/4150 train_time:696204ms step_avg:201.51ms
+step:3456/4150 train_time:696442ms step_avg:201.52ms
+step:3457/4150 train_time:696676ms step_avg:201.53ms
+step:3458/4150 train_time:696914ms step_avg:201.54ms
+step:3459/4150 train_time:697151ms step_avg:201.55ms
+step:3460/4150 train_time:697387ms step_avg:201.56ms
+step:3461/4150 train_time:697619ms step_avg:201.57ms
+step:3462/4150 train_time:697859ms step_avg:201.58ms
+step:3463/4150 train_time:698091ms step_avg:201.59ms
+step:3464/4150 train_time:698330ms step_avg:201.60ms
+step:3465/4150 train_time:698565ms step_avg:201.61ms
+step:3466/4150 train_time:698804ms step_avg:201.62ms
+step:3467/4150 train_time:699041ms step_avg:201.63ms
+step:3468/4150 train_time:699280ms step_avg:201.64ms
+step:3469/4150 train_time:699512ms step_avg:201.65ms
+step:3470/4150 train_time:699748ms step_avg:201.66ms
+step:3471/4150 train_time:699983ms step_avg:201.67ms
+step:3472/4150 train_time:700221ms step_avg:201.68ms
+step:3473/4150 train_time:700453ms step_avg:201.69ms
+step:3474/4150 train_time:700688ms step_avg:201.70ms
+step:3475/4150 train_time:700924ms step_avg:201.70ms
+step:3476/4150 train_time:701161ms step_avg:201.71ms
+step:3477/4150 train_time:701396ms step_avg:201.72ms
+step:3478/4150 train_time:701632ms step_avg:201.73ms
+step:3479/4150 train_time:701864ms step_avg:201.74ms
+step:3480/4150 train_time:702104ms step_avg:201.75ms
+step:3481/4150 train_time:702339ms step_avg:201.76ms
+step:3482/4150 train_time:702577ms step_avg:201.77ms
+step:3483/4150 train_time:702808ms step_avg:201.78ms
+step:3484/4150 train_time:703044ms step_avg:201.79ms
+step:3485/4150 train_time:703279ms step_avg:201.80ms
+step:3486/4150 train_time:703522ms step_avg:201.81ms
+step:3487/4150 train_time:703758ms step_avg:201.82ms
+step:3488/4150 train_time:703994ms step_avg:201.83ms
+step:3489/4150 train_time:704229ms step_avg:201.84ms
+step:3490/4150 train_time:704466ms step_avg:201.85ms
+step:3491/4150 train_time:704703ms step_avg:201.86ms
+step:3492/4150 train_time:704937ms step_avg:201.87ms
+step:3493/4150 train_time:705168ms step_avg:201.88ms
+step:3494/4150 train_time:705407ms step_avg:201.89ms
+step:3495/4150 train_time:705645ms step_avg:201.90ms
+step:3496/4150 train_time:705884ms step_avg:201.91ms
+step:3497/4150 train_time:706118ms step_avg:201.92ms
+step:3498/4150 train_time:706354ms step_avg:201.93ms
+step:3499/4150 train_time:706590ms step_avg:201.94ms
+step:3500/4150 train_time:706827ms step_avg:201.95ms
+step:3500/4150 val_loss:2.9787 train_time:707043ms step_avg:202.01ms
+step:3501/4150 train_time:707066ms step_avg:201.96ms
+step:3502/4150 train_time:707306ms step_avg:201.97ms
+step:3503/4150 train_time:707541ms step_avg:201.98ms
+step:3504/4150 train_time:707776ms step_avg:201.99ms
+step:3505/4150 train_time:708006ms step_avg:202.00ms
+step:3506/4150 train_time:708247ms step_avg:202.01ms
+step:3507/4150 train_time:708482ms step_avg:202.02ms
+step:3508/4150 train_time:708720ms step_avg:202.03ms
+step:3509/4150 train_time:708952ms step_avg:202.04ms
+step:3510/4150 train_time:709193ms step_avg:202.05ms
+step:3511/4150 train_time:709428ms step_avg:202.06ms
+step:3512/4150 train_time:709664ms step_avg:202.07ms
+step:3513/4150 train_time:709898ms step_avg:202.08ms
+step:3514/4150 train_time:710136ms step_avg:202.09ms
+step:3515/4150 train_time:710372ms step_avg:202.10ms
+step:3516/4150 train_time:710611ms step_avg:202.11ms
+step:3517/4150 train_time:710845ms step_avg:202.12ms
+step:3518/4150 train_time:711082ms step_avg:202.13ms
+step:3519/4150 train_time:711318ms step_avg:202.14ms
+step:3520/4150 train_time:711554ms step_avg:202.15ms
+step:3521/4150 train_time:711787ms step_avg:202.15ms
+step:3522/4150 train_time:712023ms step_avg:202.16ms
+step:3523/4150 train_time:712262ms step_avg:202.17ms
+step:3524/4150 train_time:712498ms step_avg:202.18ms
+step:3525/4150 train_time:712730ms step_avg:202.19ms
+step:3526/4150 train_time:712967ms step_avg:202.20ms
+step:3527/4150 train_time:713201ms step_avg:202.21ms
+step:3528/4150 train_time:713438ms step_avg:202.22ms
+step:3529/4150 train_time:713673ms step_avg:202.23ms
+step:3530/4150 train_time:713908ms step_avg:202.24ms
+step:3531/4150 train_time:714140ms step_avg:202.25ms
+step:3532/4150 train_time:714378ms step_avg:202.26ms
+step:3533/4150 train_time:714614ms step_avg:202.27ms
+step:3534/4150 train_time:714854ms step_avg:202.28ms
+step:3535/4150 train_time:715087ms step_avg:202.29ms
+step:3536/4150 train_time:715325ms step_avg:202.30ms
+step:3537/4150 train_time:715558ms step_avg:202.31ms
+step:3538/4150 train_time:715799ms step_avg:202.32ms
+step:3539/4150 train_time:716035ms step_avg:202.33ms
+step:3540/4150 train_time:716272ms step_avg:202.34ms
+step:3541/4150 train_time:716506ms step_avg:202.35ms
+step:3542/4150 train_time:716742ms step_avg:202.36ms
+step:3543/4150 train_time:716981ms step_avg:202.37ms
+step:3544/4150 train_time:717217ms step_avg:202.37ms
+step:3545/4150 train_time:717452ms step_avg:202.38ms
+step:3546/4150 train_time:717689ms step_avg:202.39ms
+step:3547/4150 train_time:717924ms step_avg:202.40ms
+step:3548/4150 train_time:718161ms step_avg:202.41ms
+step:3549/4150 train_time:718395ms step_avg:202.42ms
+step:3550/4150 train_time:718632ms step_avg:202.43ms
+step:3551/4150 train_time:718866ms step_avg:202.44ms
+step:3552/4150 train_time:719101ms step_avg:202.45ms
+step:3553/4150 train_time:719337ms step_avg:202.46ms
+step:3554/4150 train_time:719576ms step_avg:202.47ms
+step:3555/4150 train_time:719811ms step_avg:202.48ms
+step:3556/4150 train_time:720050ms step_avg:202.49ms
+step:3557/4150 train_time:720280ms step_avg:202.50ms
+step:3558/4150 train_time:720519ms step_avg:202.51ms
+step:3559/4150 train_time:720757ms step_avg:202.52ms
+step:3560/4150 train_time:720995ms step_avg:202.53ms
+step:3561/4150 train_time:721229ms step_avg:202.54ms
+step:3562/4150 train_time:721469ms step_avg:202.55ms
+step:3563/4150 train_time:721703ms step_avg:202.55ms
+step:3564/4150 train_time:721941ms step_avg:202.56ms
+step:3565/4150 train_time:722177ms step_avg:202.57ms
+step:3566/4150 train_time:722414ms step_avg:202.58ms
+step:3567/4150 train_time:722651ms step_avg:202.59ms
+step:3568/4150 train_time:722889ms step_avg:202.60ms
+step:3569/4150 train_time:723123ms step_avg:202.61ms
+step:3570/4150 train_time:723360ms step_avg:202.62ms
+step:3571/4150 train_time:723595ms step_avg:202.63ms
+step:3572/4150 train_time:723830ms step_avg:202.64ms
+step:3573/4150 train_time:724066ms step_avg:202.65ms
+step:3574/4150 train_time:724301ms step_avg:202.66ms
+step:3575/4150 train_time:724535ms step_avg:202.67ms
+step:3576/4150 train_time:724771ms step_avg:202.68ms
+step:3577/4150 train_time:725007ms step_avg:202.69ms
+step:3578/4150 train_time:725244ms step_avg:202.70ms
+step:3579/4150 train_time:725479ms step_avg:202.70ms
+step:3580/4150 train_time:725719ms step_avg:202.71ms
+step:3581/4150 train_time:725958ms step_avg:202.72ms
+step:3582/4150 train_time:726193ms step_avg:202.73ms
+step:3583/4150 train_time:726428ms step_avg:202.74ms
+step:3584/4150 train_time:726666ms step_avg:202.75ms
+step:3585/4150 train_time:726903ms step_avg:202.76ms
+step:3586/4150 train_time:727137ms step_avg:202.77ms
+step:3587/4150 train_time:727370ms step_avg:202.78ms
+step:3588/4150 train_time:727608ms step_avg:202.79ms
+step:3589/4150 train_time:727846ms step_avg:202.80ms
+step:3590/4150 train_time:728083ms step_avg:202.81ms
+step:3591/4150 train_time:728318ms step_avg:202.82ms
+step:3592/4150 train_time:728558ms step_avg:202.83ms
+step:3593/4150 train_time:728795ms step_avg:202.84ms
+step:3594/4150 train_time:729033ms step_avg:202.85ms
+step:3595/4150 train_time:729266ms step_avg:202.86ms
+step:3596/4150 train_time:729503ms step_avg:202.87ms
+step:3597/4150 train_time:729739ms step_avg:202.87ms
+step:3598/4150 train_time:729977ms step_avg:202.88ms
+step:3599/4150 train_time:730210ms step_avg:202.89ms
+step:3600/4150 train_time:730446ms step_avg:202.90ms
+step:3601/4150 train_time:730682ms step_avg:202.91ms
+step:3602/4150 train_time:730921ms step_avg:202.92ms
+step:3603/4150 train_time:731157ms step_avg:202.93ms
+step:3604/4150 train_time:731397ms step_avg:202.94ms
+step:3605/4150 train_time:731630ms step_avg:202.95ms
+step:3606/4150 train_time:731867ms step_avg:202.96ms
+step:3607/4150 train_time:732101ms step_avg:202.97ms
+step:3608/4150 train_time:732341ms step_avg:202.98ms
+step:3609/4150 train_time:732575ms step_avg:202.99ms
+step:3610/4150 train_time:732815ms step_avg:203.00ms
+step:3611/4150 train_time:733050ms step_avg:203.00ms
+step:3612/4150 train_time:733287ms step_avg:203.01ms
+step:3613/4150 train_time:733519ms step_avg:203.02ms
+step:3614/4150 train_time:733759ms step_avg:203.03ms
+step:3615/4150 train_time:733991ms step_avg:203.04ms
+step:3616/4150 train_time:734230ms step_avg:203.05ms
+step:3617/4150 train_time:734465ms step_avg:203.06ms
+step:3618/4150 train_time:734701ms step_avg:203.07ms
+step:3619/4150 train_time:734936ms step_avg:203.08ms
+step:3620/4150 train_time:735171ms step_avg:203.09ms
+step:3621/4150 train_time:735406ms step_avg:203.09ms
+step:3622/4150 train_time:735645ms step_avg:203.10ms
+step:3623/4150 train_time:735879ms step_avg:203.11ms
+step:3624/4150 train_time:736116ms step_avg:203.12ms
+step:3625/4150 train_time:736350ms step_avg:203.13ms
+step:3626/4150 train_time:736585ms step_avg:203.14ms
+step:3627/4150 train_time:736821ms step_avg:203.15ms
+step:3628/4150 train_time:737056ms step_avg:203.16ms
+step:3629/4150 train_time:737292ms step_avg:203.17ms
+step:3630/4150 train_time:737530ms step_avg:203.18ms
+step:3631/4150 train_time:737763ms step_avg:203.18ms
+step:3632/4150 train_time:737998ms step_avg:203.19ms
+step:3633/4150 train_time:738231ms step_avg:203.20ms
+step:3634/4150 train_time:738470ms step_avg:203.21ms
+step:3635/4150 train_time:738703ms step_avg:203.22ms
+step:3636/4150 train_time:738940ms step_avg:203.23ms
+step:3637/4150 train_time:739173ms step_avg:203.24ms
+step:3638/4150 train_time:739413ms step_avg:203.25ms
+step:3639/4150 train_time:739648ms step_avg:203.26ms
+step:3640/4150 train_time:739888ms step_avg:203.27ms
+step:3641/4150 train_time:740119ms step_avg:203.27ms
+step:3642/4150 train_time:740358ms step_avg:203.28ms
+step:3643/4150 train_time:740591ms step_avg:203.29ms
+step:3644/4150 train_time:740833ms step_avg:203.30ms
+step:3645/4150 train_time:741068ms step_avg:203.31ms
+step:3646/4150 train_time:741306ms step_avg:203.32ms
+step:3647/4150 train_time:741541ms step_avg:203.33ms
+step:3648/4150 train_time:741777ms step_avg:203.34ms
+step:3649/4150 train_time:742010ms step_avg:203.35ms
+step:3650/4150 train_time:742248ms step_avg:203.36ms
+step:3651/4150 train_time:742482ms step_avg:203.36ms
+step:3652/4150 train_time:742721ms step_avg:203.37ms
+step:3653/4150 train_time:742956ms step_avg:203.38ms
+step:3654/4150 train_time:743194ms step_avg:203.39ms
+step:3655/4150 train_time:743429ms step_avg:203.40ms
+step:3656/4150 train_time:743667ms step_avg:203.41ms
+step:3657/4150 train_time:743903ms step_avg:203.42ms
+step:3658/4150 train_time:744139ms step_avg:203.43ms
+step:3659/4150 train_time:744373ms step_avg:203.44ms
+step:3660/4150 train_time:744612ms step_avg:203.45ms
+step:3661/4150 train_time:744844ms step_avg:203.45ms
+step:3662/4150 train_time:745080ms step_avg:203.46ms
+step:3663/4150 train_time:745314ms step_avg:203.47ms
+step:3664/4150 train_time:745557ms step_avg:203.48ms
+step:3665/4150 train_time:745790ms step_avg:203.49ms
+step:3666/4150 train_time:746027ms step_avg:203.50ms
+step:3667/4150 train_time:746261ms step_avg:203.51ms
+step:3668/4150 train_time:746499ms step_avg:203.52ms
+step:3669/4150 train_time:746738ms step_avg:203.53ms
+step:3670/4150 train_time:746976ms step_avg:203.54ms
+step:3671/4150 train_time:747210ms step_avg:203.54ms
+step:3672/4150 train_time:747447ms step_avg:203.55ms
+step:3673/4150 train_time:747681ms step_avg:203.56ms
+step:3674/4150 train_time:747921ms step_avg:203.57ms
+step:3675/4150 train_time:748156ms step_avg:203.58ms
+step:3676/4150 train_time:748395ms step_avg:203.59ms
+step:3677/4150 train_time:748634ms step_avg:203.60ms
+step:3678/4150 train_time:748873ms step_avg:203.61ms
+step:3679/4150 train_time:749111ms step_avg:203.62ms
+step:3680/4150 train_time:749347ms step_avg:203.63ms
+step:3681/4150 train_time:749580ms step_avg:203.63ms
+step:3682/4150 train_time:749819ms step_avg:203.64ms
+step:3683/4150 train_time:750056ms step_avg:203.65ms
+step:3684/4150 train_time:750294ms step_avg:203.66ms
+step:3685/4150 train_time:750528ms step_avg:203.67ms
+step:3686/4150 train_time:750763ms step_avg:203.68ms
+step:3687/4150 train_time:750996ms step_avg:203.69ms
+step:3688/4150 train_time:751235ms step_avg:203.70ms
+step:3689/4150 train_time:751469ms step_avg:203.71ms
+step:3690/4150 train_time:751708ms step_avg:203.71ms
+step:3691/4150 train_time:751943ms step_avg:203.72ms
+step:3692/4150 train_time:752178ms step_avg:203.73ms
+step:3693/4150 train_time:752415ms step_avg:203.74ms
+step:3694/4150 train_time:752651ms step_avg:203.75ms
+step:3695/4150 train_time:752882ms step_avg:203.76ms
+step:3696/4150 train_time:753120ms step_avg:203.77ms
+step:3697/4150 train_time:753353ms step_avg:203.77ms
+step:3698/4150 train_time:753594ms step_avg:203.78ms
+step:3699/4150 train_time:753827ms step_avg:203.79ms
+step:3700/4150 train_time:754065ms step_avg:203.80ms
+step:3701/4150 train_time:754301ms step_avg:203.81ms
+step:3702/4150 train_time:754538ms step_avg:203.82ms
+step:3703/4150 train_time:754772ms step_avg:203.83ms
+step:3704/4150 train_time:755011ms step_avg:203.84ms
+step:3705/4150 train_time:755245ms step_avg:203.84ms
+step:3706/4150 train_time:755483ms step_avg:203.85ms
+step:3707/4150 train_time:755716ms step_avg:203.86ms
+step:3708/4150 train_time:755954ms step_avg:203.87ms
+step:3709/4150 train_time:756187ms step_avg:203.88ms
+step:3710/4150 train_time:756424ms step_avg:203.89ms
+step:3711/4150 train_time:756659ms step_avg:203.90ms
+step:3712/4150 train_time:756899ms step_avg:203.91ms
+step:3713/4150 train_time:757133ms step_avg:203.91ms
+step:3714/4150 train_time:757369ms step_avg:203.92ms
+step:3715/4150 train_time:757607ms step_avg:203.93ms
+step:3716/4150 train_time:757845ms step_avg:203.94ms
+step:3717/4150 train_time:758079ms step_avg:203.95ms
+step:3718/4150 train_time:758315ms step_avg:203.96ms
+step:3719/4150 train_time:758552ms step_avg:203.97ms
+step:3720/4150 train_time:758792ms step_avg:203.98ms
+step:3721/4150 train_time:759028ms step_avg:203.98ms
+step:3722/4150 train_time:759266ms step_avg:203.99ms
+step:3723/4150 train_time:759501ms step_avg:204.00ms
+step:3724/4150 train_time:759739ms step_avg:204.01ms
+step:3725/4150 train_time:759976ms step_avg:204.02ms
+step:3726/4150 train_time:760211ms step_avg:204.03ms
+step:3727/4150 train_time:760449ms step_avg:204.04ms
+step:3728/4150 train_time:760689ms step_avg:204.05ms
+step:3729/4150 train_time:760925ms step_avg:204.06ms
+step:3730/4150 train_time:761160ms step_avg:204.06ms
+step:3731/4150 train_time:761396ms step_avg:204.07ms
+step:3732/4150 train_time:761635ms step_avg:204.08ms
+step:3733/4150 train_time:761871ms step_avg:204.09ms
+step:3734/4150 train_time:762109ms step_avg:204.10ms
+step:3735/4150 train_time:762344ms step_avg:204.11ms
+step:3736/4150 train_time:762582ms step_avg:204.12ms
+step:3737/4150 train_time:762815ms step_avg:204.13ms
+step:3738/4150 train_time:763059ms step_avg:204.14ms
+step:3739/4150 train_time:763296ms step_avg:204.14ms
+step:3740/4150 train_time:763535ms step_avg:204.15ms
+step:3741/4150 train_time:763774ms step_avg:204.16ms
+step:3742/4150 train_time:764010ms step_avg:204.17ms
+step:3743/4150 train_time:764244ms step_avg:204.18ms
+step:3744/4150 train_time:764481ms step_avg:204.19ms
+step:3745/4150 train_time:764718ms step_avg:204.20ms
+step:3746/4150 train_time:764954ms step_avg:204.21ms
+step:3747/4150 train_time:765189ms step_avg:204.21ms
+step:3748/4150 train_time:765426ms step_avg:204.22ms
+step:3749/4150 train_time:765663ms step_avg:204.23ms
+step:3750/4150 train_time:765900ms step_avg:204.24ms
+step:3750/4150 val_loss:2.9511 train_time:766117ms step_avg:204.30ms
+step:3751/4150 train_time:766142ms step_avg:204.25ms
+step:3752/4150 train_time:766382ms step_avg:204.26ms
+step:3753/4150 train_time:766616ms step_avg:204.27ms
+step:3754/4150 train_time:766850ms step_avg:204.28ms
+step:3755/4150 train_time:767084ms step_avg:204.28ms
+step:3756/4150 train_time:767325ms step_avg:204.29ms
+step:3757/4150 train_time:767564ms step_avg:204.30ms
+step:3758/4150 train_time:767800ms step_avg:204.31ms
+step:3759/4150 train_time:768031ms step_avg:204.32ms
+step:3760/4150 train_time:768274ms step_avg:204.33ms
+step:3761/4150 train_time:768512ms step_avg:204.34ms
+step:3762/4150 train_time:768748ms step_avg:204.35ms
+step:3763/4150 train_time:768981ms step_avg:204.35ms
+step:3764/4150 train_time:769214ms step_avg:204.36ms
+step:3765/4150 train_time:769452ms step_avg:204.37ms
+step:3766/4150 train_time:769691ms step_avg:204.38ms
+step:3767/4150 train_time:769929ms step_avg:204.39ms
+step:3768/4150 train_time:770166ms step_avg:204.40ms
+step:3769/4150 train_time:770401ms step_avg:204.40ms
+step:3770/4150 train_time:770636ms step_avg:204.41ms
+step:3771/4150 train_time:770868ms step_avg:204.42ms
+step:3772/4150 train_time:771105ms step_avg:204.43ms
+step:3773/4150 train_time:771339ms step_avg:204.44ms
+step:3774/4150 train_time:771579ms step_avg:204.45ms
+step:3775/4150 train_time:771818ms step_avg:204.46ms
+step:3776/4150 train_time:772057ms step_avg:204.46ms
+step:3777/4150 train_time:772293ms step_avg:204.47ms
+step:3778/4150 train_time:772534ms step_avg:204.48ms
+step:3779/4150 train_time:772768ms step_avg:204.49ms
+step:3780/4150 train_time:773006ms step_avg:204.50ms
+step:3781/4150 train_time:773238ms step_avg:204.51ms
+step:3782/4150 train_time:773476ms step_avg:204.52ms
+step:3783/4150 train_time:773708ms step_avg:204.52ms
+step:3784/4150 train_time:773946ms step_avg:204.53ms
+step:3785/4150 train_time:774179ms step_avg:204.54ms
+step:3786/4150 train_time:774417ms step_avg:204.55ms
+step:3787/4150 train_time:774653ms step_avg:204.56ms
+step:3788/4150 train_time:774890ms step_avg:204.56ms
+step:3789/4150 train_time:775123ms step_avg:204.57ms
+step:3790/4150 train_time:775362ms step_avg:204.58ms
+step:3791/4150 train_time:775596ms step_avg:204.59ms
+step:3792/4150 train_time:775835ms step_avg:204.60ms
+step:3793/4150 train_time:776067ms step_avg:204.61ms
+step:3794/4150 train_time:776305ms step_avg:204.61ms
+step:3795/4150 train_time:776539ms step_avg:204.62ms
+step:3796/4150 train_time:776778ms step_avg:204.63ms
+step:3797/4150 train_time:777011ms step_avg:204.64ms
+step:3798/4150 train_time:777249ms step_avg:204.65ms
+step:3799/4150 train_time:777484ms step_avg:204.65ms
+step:3800/4150 train_time:777721ms step_avg:204.66ms
+step:3801/4150 train_time:777953ms step_avg:204.67ms
+step:3802/4150 train_time:778192ms step_avg:204.68ms
+step:3803/4150 train_time:778427ms step_avg:204.69ms
+step:3804/4150 train_time:778665ms step_avg:204.70ms
+step:3805/4150 train_time:778899ms step_avg:204.70ms
+step:3806/4150 train_time:779135ms step_avg:204.71ms
+step:3807/4150 train_time:779370ms step_avg:204.72ms
+step:3808/4150 train_time:779609ms step_avg:204.73ms
+step:3809/4150 train_time:779843ms step_avg:204.74ms
+step:3810/4150 train_time:780080ms step_avg:204.75ms
+step:3811/4150 train_time:780314ms step_avg:204.75ms
+step:3812/4150 train_time:780551ms step_avg:204.76ms
+step:3813/4150 train_time:780788ms step_avg:204.77ms
+step:3814/4150 train_time:781024ms step_avg:204.78ms
+step:3815/4150 train_time:781259ms step_avg:204.79ms
+step:3816/4150 train_time:781495ms step_avg:204.79ms
+step:3817/4150 train_time:781731ms step_avg:204.80ms
+step:3818/4150 train_time:781972ms step_avg:204.81ms
+step:3819/4150 train_time:782205ms step_avg:204.82ms
+step:3820/4150 train_time:782440ms step_avg:204.83ms
+step:3821/4150 train_time:782672ms step_avg:204.83ms
+step:3822/4150 train_time:782910ms step_avg:204.84ms
+step:3823/4150 train_time:783147ms step_avg:204.85ms
+step:3824/4150 train_time:783383ms step_avg:204.86ms
+step:3825/4150 train_time:783618ms step_avg:204.87ms
+step:3826/4150 train_time:783856ms step_avg:204.88ms
+step:3827/4150 train_time:784092ms step_avg:204.88ms
+step:3828/4150 train_time:784327ms step_avg:204.89ms
+step:3829/4150 train_time:784564ms step_avg:204.90ms
+step:3830/4150 train_time:784803ms step_avg:204.91ms
+step:3831/4150 train_time:785039ms step_avg:204.92ms
+step:3832/4150 train_time:785277ms step_avg:204.93ms
+step:3833/4150 train_time:785511ms step_avg:204.93ms
+step:3834/4150 train_time:785747ms step_avg:204.94ms
+step:3835/4150 train_time:785980ms step_avg:204.95ms
+step:3836/4150 train_time:786217ms step_avg:204.96ms
+step:3837/4150 train_time:786453ms step_avg:204.97ms
+step:3838/4150 train_time:786692ms step_avg:204.97ms
+step:3839/4150 train_time:786931ms step_avg:204.98ms
+step:3840/4150 train_time:787169ms step_avg:204.99ms
+step:3841/4150 train_time:787403ms step_avg:205.00ms
+step:3842/4150 train_time:787638ms step_avg:205.01ms
+step:3843/4150 train_time:787874ms step_avg:205.02ms
+step:3844/4150 train_time:788110ms step_avg:205.02ms
+step:3845/4150 train_time:788348ms step_avg:205.03ms
+step:3846/4150 train_time:788587ms step_avg:205.04ms
+step:3847/4150 train_time:788821ms step_avg:205.05ms
+step:3848/4150 train_time:789057ms step_avg:205.06ms
+step:3849/4150 train_time:789290ms step_avg:205.06ms
+step:3850/4150 train_time:789527ms step_avg:205.07ms
+step:3851/4150 train_time:789762ms step_avg:205.08ms
+step:3852/4150 train_time:789999ms step_avg:205.09ms
+step:3853/4150 train_time:790238ms step_avg:205.10ms
+step:3854/4150 train_time:790477ms step_avg:205.11ms
+step:3855/4150 train_time:790712ms step_avg:205.11ms
+step:3856/4150 train_time:790950ms step_avg:205.12ms
+step:3857/4150 train_time:791186ms step_avg:205.13ms
+step:3858/4150 train_time:791429ms step_avg:205.14ms
+step:3859/4150 train_time:791660ms step_avg:205.15ms
+step:3860/4150 train_time:791899ms step_avg:205.16ms
+step:3861/4150 train_time:792131ms step_avg:205.16ms
+step:3862/4150 train_time:792369ms step_avg:205.17ms
+step:3863/4150 train_time:792602ms step_avg:205.18ms
+step:3864/4150 train_time:792840ms step_avg:205.19ms
+step:3865/4150 train_time:793077ms step_avg:205.19ms
+step:3866/4150 train_time:793315ms step_avg:205.20ms
+step:3867/4150 train_time:793549ms step_avg:205.21ms
+step:3868/4150 train_time:793792ms step_avg:205.22ms
+step:3869/4150 train_time:794024ms step_avg:205.23ms
+step:3870/4150 train_time:794261ms step_avg:205.24ms
+step:3871/4150 train_time:794496ms step_avg:205.24ms
+step:3872/4150 train_time:794733ms step_avg:205.25ms
+step:3873/4150 train_time:794968ms step_avg:205.26ms
+step:3874/4150 train_time:795204ms step_avg:205.27ms
+step:3875/4150 train_time:795439ms step_avg:205.27ms
+step:3876/4150 train_time:795677ms step_avg:205.28ms
+step:3877/4150 train_time:795913ms step_avg:205.29ms
+step:3878/4150 train_time:796149ms step_avg:205.30ms
+step:3879/4150 train_time:796385ms step_avg:205.31ms
+step:3880/4150 train_time:796623ms step_avg:205.32ms
+step:3881/4150 train_time:796857ms step_avg:205.32ms
+step:3882/4150 train_time:797092ms step_avg:205.33ms
+step:3883/4150 train_time:797329ms step_avg:205.34ms
+step:3884/4150 train_time:797566ms step_avg:205.35ms
+step:3885/4150 train_time:797801ms step_avg:205.35ms
+step:3886/4150 train_time:798041ms step_avg:205.36ms
+step:3887/4150 train_time:798273ms step_avg:205.37ms
+step:3888/4150 train_time:798509ms step_avg:205.38ms
+step:3889/4150 train_time:798743ms step_avg:205.39ms
+step:3890/4150 train_time:798981ms step_avg:205.39ms
+step:3891/4150 train_time:799215ms step_avg:205.40ms
+step:3892/4150 train_time:799452ms step_avg:205.41ms
+step:3893/4150 train_time:799690ms step_avg:205.42ms
+step:3894/4150 train_time:799928ms step_avg:205.43ms
+step:3895/4150 train_time:800164ms step_avg:205.43ms
+step:3896/4150 train_time:800403ms step_avg:205.44ms
+step:3897/4150 train_time:800636ms step_avg:205.45ms
+step:3898/4150 train_time:800873ms step_avg:205.46ms
+step:3899/4150 train_time:801109ms step_avg:205.47ms
+step:3900/4150 train_time:801347ms step_avg:205.47ms
+step:3901/4150 train_time:801580ms step_avg:205.48ms
+step:3902/4150 train_time:801819ms step_avg:205.49ms
+step:3903/4150 train_time:802054ms step_avg:205.50ms
+step:3904/4150 train_time:802291ms step_avg:205.50ms
+step:3905/4150 train_time:802527ms step_avg:205.51ms
+step:3906/4150 train_time:802763ms step_avg:205.52ms
+step:3907/4150 train_time:802996ms step_avg:205.53ms
+step:3908/4150 train_time:803233ms step_avg:205.54ms
+step:3909/4150 train_time:803469ms step_avg:205.54ms
+step:3910/4150 train_time:803706ms step_avg:205.55ms
+step:3911/4150 train_time:803945ms step_avg:205.56ms
+step:3912/4150 train_time:804182ms step_avg:205.57ms
+step:3913/4150 train_time:804415ms step_avg:205.57ms
+step:3914/4150 train_time:804653ms step_avg:205.58ms
+step:3915/4150 train_time:804890ms step_avg:205.59ms
+step:3916/4150 train_time:805128ms step_avg:205.60ms
+step:3917/4150 train_time:805365ms step_avg:205.61ms
+step:3918/4150 train_time:805601ms step_avg:205.62ms
+step:3919/4150 train_time:805833ms step_avg:205.62ms
+step:3920/4150 train_time:806072ms step_avg:205.63ms
+step:3921/4150 train_time:806310ms step_avg:205.64ms
+step:3922/4150 train_time:806549ms step_avg:205.65ms
+step:3923/4150 train_time:806781ms step_avg:205.65ms
+step:3924/4150 train_time:807021ms step_avg:205.66ms
+step:3925/4150 train_time:807256ms step_avg:205.67ms
+step:3926/4150 train_time:807492ms step_avg:205.68ms
+step:3927/4150 train_time:807730ms step_avg:205.69ms
+step:3928/4150 train_time:807968ms step_avg:205.69ms
+step:3929/4150 train_time:808204ms step_avg:205.70ms
+step:3930/4150 train_time:808444ms step_avg:205.71ms
+step:3931/4150 train_time:808678ms step_avg:205.72ms
+step:3932/4150 train_time:808913ms step_avg:205.73ms
+step:3933/4150 train_time:809146ms step_avg:205.73ms
+step:3934/4150 train_time:809384ms step_avg:205.74ms
+step:3935/4150 train_time:809616ms step_avg:205.75ms
+step:3936/4150 train_time:809856ms step_avg:205.76ms
+step:3937/4150 train_time:810092ms step_avg:205.76ms
+step:3938/4150 train_time:810331ms step_avg:205.77ms
+step:3939/4150 train_time:810566ms step_avg:205.78ms
+step:3940/4150 train_time:810807ms step_avg:205.79ms
+step:3941/4150 train_time:811044ms step_avg:205.80ms
+step:3942/4150 train_time:811280ms step_avg:205.80ms
+step:3943/4150 train_time:811514ms step_avg:205.81ms
+step:3944/4150 train_time:811751ms step_avg:205.82ms
+step:3945/4150 train_time:811987ms step_avg:205.83ms
+step:3946/4150 train_time:812223ms step_avg:205.83ms
+step:3947/4150 train_time:812456ms step_avg:205.84ms
+step:3948/4150 train_time:812696ms step_avg:205.85ms
+step:3949/4150 train_time:812930ms step_avg:205.86ms
+step:3950/4150 train_time:813172ms step_avg:205.87ms
+step:3951/4150 train_time:813409ms step_avg:205.87ms
+step:3952/4150 train_time:813645ms step_avg:205.88ms
+step:3953/4150 train_time:813877ms step_avg:205.89ms
+step:3954/4150 train_time:814117ms step_avg:205.90ms
+step:3955/4150 train_time:814350ms step_avg:205.90ms
+step:3956/4150 train_time:814584ms step_avg:205.91ms
+step:3957/4150 train_time:814819ms step_avg:205.92ms
+step:3958/4150 train_time:815057ms step_avg:205.93ms
+step:3959/4150 train_time:815290ms step_avg:205.93ms
+step:3960/4150 train_time:815527ms step_avg:205.94ms
+step:3961/4150 train_time:815762ms step_avg:205.95ms
+step:3962/4150 train_time:815999ms step_avg:205.96ms
+step:3963/4150 train_time:816233ms step_avg:205.96ms
+step:3964/4150 train_time:816470ms step_avg:205.97ms
+step:3965/4150 train_time:816705ms step_avg:205.98ms
+step:3966/4150 train_time:816942ms step_avg:205.99ms
+step:3967/4150 train_time:817177ms step_avg:205.99ms
+step:3968/4150 train_time:817414ms step_avg:206.00ms
+step:3969/4150 train_time:817647ms step_avg:206.01ms
+step:3970/4150 train_time:817889ms step_avg:206.02ms
+step:3971/4150 train_time:818123ms step_avg:206.02ms
+step:3972/4150 train_time:818361ms step_avg:206.03ms
+step:3973/4150 train_time:818593ms step_avg:206.04ms
+step:3974/4150 train_time:818831ms step_avg:206.05ms
+step:3975/4150 train_time:819064ms step_avg:206.05ms
+step:3976/4150 train_time:819303ms step_avg:206.06ms
+step:3977/4150 train_time:819536ms step_avg:206.07ms
+step:3978/4150 train_time:819773ms step_avg:206.08ms
+step:3979/4150 train_time:820009ms step_avg:206.08ms
+step:3980/4150 train_time:820245ms step_avg:206.09ms
+step:3981/4150 train_time:820479ms step_avg:206.10ms
+step:3982/4150 train_time:820716ms step_avg:206.11ms
+step:3983/4150 train_time:820953ms step_avg:206.11ms
+step:3984/4150 train_time:821188ms step_avg:206.12ms
+step:3985/4150 train_time:821422ms step_avg:206.13ms
+step:3986/4150 train_time:821658ms step_avg:206.14ms
+step:3987/4150 train_time:821894ms step_avg:206.14ms
+step:3988/4150 train_time:822132ms step_avg:206.15ms
+step:3989/4150 train_time:822366ms step_avg:206.16ms
+step:3990/4150 train_time:822604ms step_avg:206.17ms
+step:3991/4150 train_time:822839ms step_avg:206.17ms
+step:3992/4150 train_time:823075ms step_avg:206.18ms
+step:3993/4150 train_time:823309ms step_avg:206.19ms
+step:3994/4150 train_time:823550ms step_avg:206.20ms
+step:3995/4150 train_time:823784ms step_avg:206.20ms
+step:3996/4150 train_time:824024ms step_avg:206.21ms
+step:3997/4150 train_time:824257ms step_avg:206.22ms
+step:3998/4150 train_time:824494ms step_avg:206.23ms
+step:3999/4150 train_time:824730ms step_avg:206.23ms
+step:4000/4150 train_time:824970ms step_avg:206.24ms
+step:4000/4150 val_loss:2.9281 train_time:825184ms step_avg:206.30ms
+step:4001/4150 train_time:825208ms step_avg:206.25ms
+step:4002/4150 train_time:825450ms step_avg:206.26ms
+step:4003/4150 train_time:825684ms step_avg:206.27ms
+step:4004/4150 train_time:825919ms step_avg:206.27ms
+step:4005/4150 train_time:826153ms step_avg:206.28ms
+step:4006/4150 train_time:826397ms step_avg:206.29ms
+step:4007/4150 train_time:826633ms step_avg:206.30ms
+step:4008/4150 train_time:826866ms step_avg:206.30ms
+step:4009/4150 train_time:827097ms step_avg:206.31ms
+step:4010/4150 train_time:827335ms step_avg:206.32ms
+step:4011/4150 train_time:827571ms step_avg:206.33ms
+step:4012/4150 train_time:827808ms step_avg:206.33ms
+step:4013/4150 train_time:828041ms step_avg:206.34ms
+step:4014/4150 train_time:828277ms step_avg:206.35ms
+step:4015/4150 train_time:828512ms step_avg:206.35ms
+step:4016/4150 train_time:828749ms step_avg:206.36ms
+step:4017/4150 train_time:828980ms step_avg:206.37ms
+step:4018/4150 train_time:829218ms step_avg:206.38ms
+step:4019/4150 train_time:829456ms step_avg:206.38ms
+step:4020/4150 train_time:829693ms step_avg:206.39ms
+step:4021/4150 train_time:829926ms step_avg:206.40ms
+step:4022/4150 train_time:830163ms step_avg:206.41ms
+step:4023/4150 train_time:830398ms step_avg:206.41ms
+step:4024/4150 train_time:830641ms step_avg:206.42ms
+step:4025/4150 train_time:830874ms step_avg:206.43ms
+step:4026/4150 train_time:831110ms step_avg:206.44ms
+step:4027/4150 train_time:831342ms step_avg:206.44ms
+step:4028/4150 train_time:831582ms step_avg:206.45ms
+step:4029/4150 train_time:831817ms step_avg:206.46ms
+step:4030/4150 train_time:832054ms step_avg:206.47ms
+step:4031/4150 train_time:832288ms step_avg:206.47ms
+step:4032/4150 train_time:832527ms step_avg:206.48ms
+step:4033/4150 train_time:832764ms step_avg:206.49ms
+step:4034/4150 train_time:833001ms step_avg:206.49ms
+step:4035/4150 train_time:833233ms step_avg:206.50ms
+step:4036/4150 train_time:833468ms step_avg:206.51ms
+step:4037/4150 train_time:833705ms step_avg:206.52ms
+step:4038/4150 train_time:833945ms step_avg:206.52ms
+step:4039/4150 train_time:834179ms step_avg:206.53ms
+step:4040/4150 train_time:834418ms step_avg:206.54ms
+step:4041/4150 train_time:834654ms step_avg:206.55ms
+step:4042/4150 train_time:834890ms step_avg:206.55ms
+step:4043/4150 train_time:835122ms step_avg:206.56ms
+step:4044/4150 train_time:835360ms step_avg:206.57ms
+step:4045/4150 train_time:835597ms step_avg:206.58ms
+step:4046/4150 train_time:835832ms step_avg:206.58ms
+step:4047/4150 train_time:836064ms step_avg:206.59ms
+step:4048/4150 train_time:836301ms step_avg:206.60ms
+step:4049/4150 train_time:836538ms step_avg:206.60ms
+step:4050/4150 train_time:836779ms step_avg:206.61ms
+step:4051/4150 train_time:837015ms step_avg:206.62ms
+step:4052/4150 train_time:837249ms step_avg:206.63ms
+step:4053/4150 train_time:837486ms step_avg:206.63ms
+step:4054/4150 train_time:837724ms step_avg:206.64ms
+step:4055/4150 train_time:837957ms step_avg:206.65ms
+step:4056/4150 train_time:838195ms step_avg:206.66ms
+step:4057/4150 train_time:838428ms step_avg:206.66ms
+step:4058/4150 train_time:838664ms step_avg:206.67ms
+step:4059/4150 train_time:838901ms step_avg:206.68ms
+step:4060/4150 train_time:839139ms step_avg:206.68ms
+step:4061/4150 train_time:839373ms step_avg:206.69ms
+step:4062/4150 train_time:839612ms step_avg:206.70ms
+step:4063/4150 train_time:839845ms step_avg:206.71ms
+step:4064/4150 train_time:840082ms step_avg:206.71ms
+step:4065/4150 train_time:840320ms step_avg:206.72ms
+step:4066/4150 train_time:840555ms step_avg:206.73ms
+step:4067/4150 train_time:840791ms step_avg:206.73ms
+step:4068/4150 train_time:841029ms step_avg:206.74ms
+step:4069/4150 train_time:841268ms step_avg:206.75ms
+step:4070/4150 train_time:841505ms step_avg:206.76ms
+step:4071/4150 train_time:841740ms step_avg:206.76ms
+step:4072/4150 train_time:841976ms step_avg:206.77ms
+step:4073/4150 train_time:842212ms step_avg:206.78ms
+step:4074/4150 train_time:842449ms step_avg:206.79ms
+step:4075/4150 train_time:842684ms step_avg:206.79ms
+step:4076/4150 train_time:842922ms step_avg:206.80ms
+step:4077/4150 train_time:843157ms step_avg:206.81ms
+step:4078/4150 train_time:843394ms step_avg:206.82ms
+step:4079/4150 train_time:843625ms step_avg:206.82ms
+step:4080/4150 train_time:843862ms step_avg:206.83ms
+step:4081/4150 train_time:844096ms step_avg:206.84ms
+step:4082/4150 train_time:844336ms step_avg:206.84ms
+step:4083/4150 train_time:844570ms step_avg:206.85ms
+step:4084/4150 train_time:844808ms step_avg:206.86ms
+step:4085/4150 train_time:845043ms step_avg:206.86ms
+step:4086/4150 train_time:845281ms step_avg:206.87ms
+step:4087/4150 train_time:845514ms step_avg:206.88ms
+step:4088/4150 train_time:845750ms step_avg:206.89ms
+step:4089/4150 train_time:845986ms step_avg:206.89ms
+step:4090/4150 train_time:846227ms step_avg:206.90ms
+step:4091/4150 train_time:846464ms step_avg:206.91ms
+step:4092/4150 train_time:846703ms step_avg:206.92ms
+step:4093/4150 train_time:846935ms step_avg:206.92ms
+step:4094/4150 train_time:847173ms step_avg:206.93ms
+step:4095/4150 train_time:847407ms step_avg:206.94ms
+step:4096/4150 train_time:847645ms step_avg:206.94ms
+step:4097/4150 train_time:847878ms step_avg:206.95ms
+step:4098/4150 train_time:848116ms step_avg:206.96ms
+step:4099/4150 train_time:848350ms step_avg:206.97ms
+step:4100/4150 train_time:848588ms step_avg:206.97ms
+step:4101/4150 train_time:848827ms step_avg:206.98ms
+step:4102/4150 train_time:849064ms step_avg:206.99ms
+step:4103/4150 train_time:849298ms step_avg:206.99ms
+step:4104/4150 train_time:849537ms step_avg:207.00ms
+step:4105/4150 train_time:849771ms step_avg:207.01ms
+step:4106/4150 train_time:850007ms step_avg:207.02ms
+step:4107/4150 train_time:850241ms step_avg:207.02ms
+step:4108/4150 train_time:850480ms step_avg:207.03ms
+step:4109/4150 train_time:850716ms step_avg:207.04ms
+step:4110/4150 train_time:850953ms step_avg:207.04ms
+step:4111/4150 train_time:851186ms step_avg:207.05ms
+step:4112/4150 train_time:851423ms step_avg:207.06ms
+step:4113/4150 train_time:851657ms step_avg:207.06ms
+step:4114/4150 train_time:851896ms step_avg:207.07ms
+step:4115/4150 train_time:852130ms step_avg:207.08ms
+step:4116/4150 train_time:852365ms step_avg:207.09ms
+step:4117/4150 train_time:852601ms step_avg:207.09ms
+step:4118/4150 train_time:852839ms step_avg:207.10ms
+step:4119/4150 train_time:853073ms step_avg:207.11ms
+step:4120/4150 train_time:853312ms step_avg:207.11ms
+step:4121/4150 train_time:853546ms step_avg:207.12ms
+step:4122/4150 train_time:853783ms step_avg:207.13ms
+step:4123/4150 train_time:854020ms step_avg:207.14ms
+step:4124/4150 train_time:854258ms step_avg:207.14ms
+step:4125/4150 train_time:854491ms step_avg:207.15ms
+step:4126/4150 train_time:854728ms step_avg:207.16ms
+step:4127/4150 train_time:854960ms step_avg:207.16ms
+step:4128/4150 train_time:855201ms step_avg:207.17ms
+step:4129/4150 train_time:855436ms step_avg:207.18ms
+step:4130/4150 train_time:855673ms step_avg:207.18ms
+step:4131/4150 train_time:855909ms step_avg:207.19ms
+step:4132/4150 train_time:856146ms step_avg:207.20ms
+step:4133/4150 train_time:856384ms step_avg:207.21ms
+step:4134/4150 train_time:856624ms step_avg:207.21ms
+step:4135/4150 train_time:856860ms step_avg:207.22ms
+step:4136/4150 train_time:857095ms step_avg:207.23ms
+step:4137/4150 train_time:857331ms step_avg:207.23ms
+step:4138/4150 train_time:857567ms step_avg:207.24ms
+step:4139/4150 train_time:857805ms step_avg:207.25ms
+step:4140/4150 train_time:858044ms step_avg:207.26ms
+step:4141/4150 train_time:858278ms step_avg:207.26ms
+step:4142/4150 train_time:858516ms step_avg:207.27ms
+step:4143/4150 train_time:858747ms step_avg:207.28ms
+step:4144/4150 train_time:858985ms step_avg:207.28ms
+step:4145/4150 train_time:859220ms step_avg:207.29ms
+step:4146/4150 train_time:859457ms step_avg:207.30ms
+step:4147/4150 train_time:859690ms step_avg:207.30ms
+step:4148/4150 train_time:859927ms step_avg:207.31ms
+step:4149/4150 train_time:860162ms step_avg:207.32ms
+step:4150/4150 train_time:860399ms step_avg:207.33ms
+step:4150/4150 val_loss:2.9171 train_time:860614ms step_avg:207.38ms
+peak memory allocated: 59977 MiB reserved: 60424 MiB

--- a/train_gpt_medium.py
+++ b/train_gpt_medium.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from itertools import accumulate
 from pathlib import Path
 import gc
+import numpy as np
 
 os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 import torch
@@ -25,11 +26,12 @@ import torch._dynamo as dynamo
 import torch.distributed as dist
 import torch.nn.functional as F
 
-# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+# torch._inductor.config.coordinate_descent_tuning = True # allowed on medium track, ~30+ min extra compile time
 import triton
 import triton.language as tl
 from kernels import get_kernel
 from torch import Tensor, nn
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
 
 dynamo.config.recompile_limit = 64
 
@@ -115,255 +117,105 @@ def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
 
 mm_op.register_autograd(backward, setup_context=setup_context)
 
-# -----------------------------------------------------------------------------
-# Triton kernel for symmetric matrix multiplication by @byronxu99
+# Transposed FP8 matmul custom ops (for CastedLinearT lm_head)
 
-def _get_autotune_configs():
-    return [
-        triton.Config(
-            {
-                "BLOCK_SIZE_M": bm,
-                "BLOCK_SIZE_N": bn,
-                "BLOCK_SIZE_K": bk,
-                "GROUP_SIZE_M": 8,
-                "LOWER_UPPER": 1,
-            },
-            num_stages=stages,
-            num_warps=warps,
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
         )
-        for bm in [64, 128]
-        for bn in [64, 128, 256]
-        for bk in [64, 128]
-        for stages, warps in [(3, 4), (3, 8), (4, 4)]
-        if bm // bn <= 2 and bn // bm <= 2
-    ]
+        return out, x_f8, w_f8
 
-@triton.jit
-def _pid_to_block(
-    pid,
-    M,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-):
-    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
-    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
-    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+    return impl(x, w)
 
-    # Map PID to a single matrix in batch
-    batch_idx = pid // (num_pid_m * num_pid_n)
-    pid = pid % (num_pid_m * num_pid_n)
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
 
-    # Map PID to 2D grid of blocks
-    pid_m = pid // num_pid_n
-    pid_n = pid % num_pid_n
-    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
 
-    m_idx = pid_m * BLOCK_SIZE_M
-    n_idx = pid_n * BLOCK_SIZE_N
-    return batch_idx, m_idx, n_idx
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
 
-@triton.autotune(
-    configs=_get_autotune_configs(),
-    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
-)
-@triton.jit
-def XXT_kernel(
-    A_ptr, C_ptr,
-    M, K,
-    a_stride_b, a_stride_r, a_stride_c,
-    c_stride_b, c_stride_r, c_stride_c,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    LOWER_UPPER: tl.constexpr,
-):
-    pid = tl.program_id(axis=0)
-    batch_idx, m_idx, n_idx = _pid_to_block(
-        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
     )
+    return grad_x, grad_w, None, None, None
 
-    # Skip blocks that don't need to be computed
-    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
-    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
-    if skip_block_below_diag or skip_block_above_diag:
-        return
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
 
-    # Index into one matrix of batch
-    A_ptr += batch_idx * a_stride_b
-    C_ptr += batch_idx * c_stride_b
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
 
-    # Create pointer arrays for A and A.T
-    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
-    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
-    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+# XXT, XTX, and ba_plus_cAA kernels imported from triton_kernels.py (hardcoded configs, no autotune)
 
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-
-    # Accumulate over blocks of K
-    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
-        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
-        accumulator = tl.dot(a, at, accumulator)
-        a_ptrs += BLOCK_SIZE_K * a_stride_c
-        at_ptrs += BLOCK_SIZE_K * a_stride_c
-
-    out_dtype = C_ptr.dtype.element_ty
-    output = accumulator.to(out_dtype)
-
-    # Store block of C
-    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
-    tl.store(c_ptrs, output, mask=c_mask)
-
-    # Store block of C mirrored across the diagonal
-    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
-    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
-    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
-
-def XXT(A: torch.Tensor, out: torch.Tensor):
-    """
-    Launch Triton kernel to compute C = A @ A.T
-    """
-    assert A.ndim == 2 or A.ndim == 3
-    M, K = A.shape[-2:]
-    assert out.size(-2) == M, "Output matrix has incorrect shape"
-    assert out.size(-1) == M, "Output matrix has incorrect shape"
-
-    batch_size = A.size(0) if A.ndim == 3 else 1
-    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
-    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
-
-    grid = lambda meta: (
-        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
-    )
-    XXT_kernel[grid](
-        A_ptr=A,
-        C_ptr=out,
-        M=M,
-        K=K,
-        a_stride_b=input_batch_stride,
-        a_stride_r=A.stride(-2),
-        a_stride_c=A.stride(-1),
-        c_stride_b=output_batch_stride,
-        c_stride_r=out.stride(-2),
-        c_stride_c=out.stride(-1),
-    )
-    return out
-
-@triton.autotune(
-    configs=_get_autotune_configs(),
-    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
-)
-@triton.jit
-def ba_plus_cAA_kernel(
-    A_ptr, C_ptr,
-    M,
-    a_stride_b, a_stride_r, a_stride_c,
-    c_stride_b, c_stride_r, c_stride_c,
-    alpha, beta,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    LOWER_UPPER: tl.constexpr,
-):
-    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
-    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
-    pid = tl.program_id(axis=0)
-    batch_idx, m_idx, n_idx = _pid_to_block(
-        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
-    )
-
-    # Skip blocks that don't need to be computed
-    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
-    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
-    if skip_block_below_diag or skip_block_above_diag:
-        return
-
-    # Index into one matrix of batch
-    A_ptr += batch_idx * a_stride_b
-    C_ptr += batch_idx * c_stride_b
-
-    # Create pointer arrays for A and A.T
-    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
-    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
-    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
-
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-
-    # Accumulate over blocks of K
-    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
-        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
-        accumulator = tl.dot(a, at, accumulator)
-        a_ptrs += BLOCK_SIZE_K * a_stride_c
-        at_ptrs += BLOCK_SIZE_K * a_stride_c
-
-    # Load block of A to add (corresponds to the current block of C)
-    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
-    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
-    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
-    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
-    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
-
-    # Apply alpha and beta
-    accumulator *= alpha
-    accumulator += a_add * beta
-
-    out_dtype = C_ptr.dtype.element_ty
-    output = accumulator.to(out_dtype)
-
-    # Store block of C
-    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
-    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
-    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
-    tl.store(c_ptrs, output, mask=c_mask)
-
-    # Store block of C mirrored across the diagonal
-    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
-    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
-    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
-
-def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
-    """
-    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
-    """
-    assert A.ndim == 2 or A.ndim == 3
-    M, K = A.shape[-2:]
-    assert M == K, "Input matrix must be square"
-    assert out.size(-2) == M
-    assert out.size(-1) == M
-
-    batch_size = A.size(0) if A.ndim == 3 else 1
-    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
-    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
-
-    grid = lambda meta: (
-        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
-    )
-    ba_plus_cAA_kernel[grid](
-        A_ptr=A,
-        C_ptr=out,
-        M=M,
-        a_stride_b=input_batch_stride,
-        a_stride_r=A.stride(-2),
-        a_stride_c=A.stride(-1),
-        c_stride_b=output_batch_stride,
-        c_stride_r=out.stride(-2),
-        c_stride_c=out.stride(-1),
-        alpha=alpha,
-        beta=beta,
-    )
-    return out
+# FusedSoftcappedCrossEntropy is now imported from triton_kernels.py (with FP8 matmul support)
 
 # Computed for num_iters=5, safety_factor=2e-2, cushion=2
 polar_express_coeffs = [
@@ -375,463 +227,762 @@ polar_express_coeffs = [
 ]
 
 @torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
-def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
     """
-    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
     by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
     """
-    X = G.bfloat16()
-    if G.size(-2) > G.size(-1):
-        X = X.mT
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
 
     # Ensure spectral norm is at most 1
     X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
 
-    # Allocate buffers
     X = X.contiguous()
-    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
-    B = torch.empty_like(A)
-    C = torch.empty_like(X)
 
-    # Select batched vs unbatched
-    if split_baddbmm:
-        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
-    else:
-        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
 
-    # Perform the iterations
-    for a, b, c in polar_express_coeffs:
-        XXT(X, out=A)  # A = X @ X.mT
-        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
-
-        # Referencing X twice causes pytorch to make a defensive copy,
-        # resulting in a cudaMemcpyAsync in baddbmm.
-        # For large matrices (i.e., the mlp weights), it's faster to split
-        # the operation into two kernels to avoid this.
+        # Select batched vs unbatched
         if split_baddbmm:
-            BX_matmul(B, X, out=C)  # C = B @ X
-            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
         else:
-            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
 
-        X, C = C, X  # Swap references to avoid unnecessary copies
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
 
-    if G.size(-2) > G.size(-1):
-        X = X.mT
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
     return X
 
 
 # -----------------------------------------------------------------------------
-# Compiled helpers for NorMuon by @chrisjmccormick
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
 
-@torch.compile(dynamic=False, fullgraph=True)
-def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
-    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
-    mask = (v * p) >= 0
-    wd_factor = wd_tensor.to(p.dtype)
-    lr_factor = lr_tensor.to(p.dtype)
-    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
 
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
 
-@torch.compile(dynamic=False, fullgraph=True)
-def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
-    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
-    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
-    red_dim_size = v_chunk.size(red_dim)
-    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
-    v_norm = v_norm_sq.sqrt_()
-    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
-    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
-    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
-    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
-    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
-    return v_chunk.mul_(final_scale.type_as(v_chunk))
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
 
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
 
 # -----------------------------------------------------------------------------
-# NorMuon optimizer
+# Combined NorMuon + Adam Optimizer
 
-class NorMuon(torch.optim.Optimizer):
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
     """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
     Muon - MomentUm Orthogonalized by Newton-schulz
 
     https://kellerjordan.github.io/posts/muon/
 
     Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
     processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
-    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
-    the advantage that it can be stably run in bfloat16 on the GPU.
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
 
-    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
-    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
 
     Differences from standard Muon:
     - Newton-Shulz is replaced with Polar Express for the orthogonalization step
     - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
-    - small 1D parameters handled here instead of in Adam
     - Cautious weight decay, a gated version of decoupled weight decay
-    - Custom distributed sizing:
-    The model stores all attn and mlp weights in the same shape, and then updates the view as
-    needed on the forward pass. This enables attn and mlp weights to be contained within the same
-    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
-    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
-    The scheduling is:
-        1. reduce scatter attn_gate (10 params 6 padding params)
-        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
-        3. reduce scatter attn/mlp round 2 (16 mlp params)
-        4. wait on step 1, then compute update of 1 and schedule all gather
-        5. wait on step 2, then compute update of 2 and schedule all gather
-        6. wait on step 3, then compute update of 3 and schedule all gather
-            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
-            GPUs that receive params of type attn reshape before computing update
-        7. wait on 4, then compute update of 4 and schedule all gather
-        8. wait for each all gather to complete and update params
-    Empirically, leading with small params provides an additional 0.2s improvement.
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
     """
-    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
-        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
         self.world_size = dist.get_world_size() if dist.is_initialized() else 1
-        # custom sizing requires 8 GPUs
-        if custom_sizing and dist.get_world_size()==8:
-            param_groups = self.generate_custom_param_groups(params)
-        else:
-            param_groups = self.generate_standard_param_groups(params)
-        super().__init__(param_groups, defaults)
 
-    def reset(self):
-        # expose a reset for clearing buffers
-        for group in self.param_groups:
-            if "momentum_buffer" in group:
-                group["momentum_buffer"].zero_()
-                group["second_momentum_buffer"].zero_()
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
 
-    def generate_standard_param_groups(self, params):
-        """
-        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
-        Creates one param group per module.
-        """
-        groups = defaultdict(list)
-        for param in params:
-            groups[param.label].append(param)
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table, f"param {name} has label={label}, not in param_table"
+            assert label not in self._param_by_label, f"duplicate label {label}"
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
 
-        param_groups = []
-        for module_name, group_params in groups.items():
-            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
-            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
 
-        return param_groups
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
 
-    def generate_custom_param_groups(self, params):
-        """
-        Implementation requires that a single GPU does not receive both attn
-        and mlp params when a param group is split across GPUs.
-        """
-        params_list = list(params)
-        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp'] # 16, 10, 16, 32
-        group_sizes = [16, 10, 16, 16, 16]
-        params_list.sort(key=lambda x: module_group_order.index(x.label))
-        print0(len(params_list), console=True)
-        idx = 0
-        assert len(params_list) == sum(group_sizes)
-        param_groups = []
-        for size in group_sizes:
-            chunk_size = (size + self.world_size - 1) // self.world_size
-            group_params = params_list[idx: idx + size]
-            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
-            idx += size
+        # Initialize state for all params
+        self._init_state()
 
-        return param_groups
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
 
-    @torch.no_grad()
-    def step(self):
-        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
-        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
-        rank = dist.get_rank()
-        group_infos = []
-        for group in self.param_groups:
-            params: list[Tensor] = group["params"]
-            if not params:
-                continue
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, dict] = {}
 
-            chunk_size = group["chunk_size"]
-            padded_num_params = chunk_size * self.world_size
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
 
-            stacked_grads = torch.empty(
-                (padded_num_params, *params[0].shape),
-                dtype=params[0].dtype,
-                device=params[0].device
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
             )
-            for i, p in enumerate(params):
-                stacked_grads[i].copy_(p.grad, non_blocking=True)
-            if len(params) < padded_num_params:
-                stacked_grads[len(params):].zero_()
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
 
-            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
 
-            reduce_future = dist.reduce_scatter_tensor(
-                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
-            ).get_future()
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
 
-            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
 
-        all_gather_infos = []
-        # Second pass: wait for gradients, compute updates for the local shard of parameters,
-        # and launch all async all_gather operations.
-        for group, info in zip(self.param_groups, group_infos):
-            info["reduce_future"].wait()
+        self.param_cfgs[param] = p_cfg
 
-            params = group["params"]
-            grad_chunk = info["grad_chunk"]
-            chunk_size = group["chunk_size"]
-            padded_num_params = chunk_size * self.world_size
-
-            start_idx = rank * chunk_size
-            module_idx = start_idx if start_idx < len(params) else 0
-
-            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
-
-            if "momentum_buffer" not in group:
-                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
-            momentum_buffer = group["momentum_buffer"]
-            # Apply momentum update to the persistent momentum buffer in-place
-            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
-            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
-
-            grad_shape = updated_grads.shape
-            if params[module_idx].label == 'attn':
-
-                for p in params[module_idx:module_idx + num_params]:
-                    assert p.label == 'attn'
-
-                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
-
-            ref_param = params[module_idx]
-            param_shape = ref_param.shape
-
-            # The below shape-based heuristic assumes that matrices have their input along the
-            # row dimension and their output along the columns. Gates are an exception.
-            is_gate = 'gate' in ref_param.label
-
-            if "second_momentum_buffer" not in group:
-                if is_gate:
-                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
                 else:
-                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
-                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
-                    )
-            second_momentum_buffer = group["second_momentum_buffer"]
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
 
-            if "param_lr_cpu" not in group:
-                # Define multipliers for ALL params in this group (global, not per-shard)
-                lr_mults = []
-                wd_mults = []
-                for p in params:
-                    # Increase learning rate for modules with larger inputs than outputs.
-                    # This shape check also assumes rows=input, columns=output, so take care
-                    # when changing memory layouts. @chrisjmccormick
-                    shape = p.shape
-                    if len(shape) >= 2:
-                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
-                    else:
-                        shape_mult = 1.0
-                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
-                    wd_mults.append(getattr(p, "wd_mul", 1.0))
-                # Define as cpu tensors to enable Inductor constant folding
-                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
-                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
 
-            eff_lr_all = group["param_lr_cpu"] * group["lr"]
-            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
-
-            # Slice the portion corresponding to this rank's shard
-            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
-            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
-
-            # Compute zeropower for the entire chunk in a single, batched call.
-            if num_params == 0:
-                v_chunk = updated_grads
-            else:
-                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
-
-            # Note that the head orientation in O is transposed relative to QKV, so red_dim
-            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
-            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
-
-            v_chunk = apply_normuon_variance_reduction(
-                v_chunk, second_momentum_buffer, group["beta2"], red_dim
-            )
-
-            v_chunk = v_chunk.view(grad_shape)
-
-            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
-            updated_params = torch.empty_like(grad_chunk)
-            if num_params > 0:
-                # Work on a stacked copy to avoid touching original params
-                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
-
-                for local_idx in range(num_params):
-                    cautious_wd_and_update_inplace(
-                        param_chunk[local_idx],
-                        v_chunk[local_idx],
-                        eff_wd_cpu[local_idx],
-                        eff_lr_cpu[local_idx],
-                    )
-            else:
-                param_chunk = torch.zeros_like(v_chunk)
-
-            updated_params[:num_params].copy_(param_chunk)
-            if num_params < chunk_size:
-                updated_params[num_params:].zero_()
-
-            stacked_params = torch.empty(
-                (padded_num_params, *param_shape),
-                dtype=updated_params.dtype,
-                device=updated_params.device,
-            )
-
-            gather_future = dist.all_gather_into_tensor(
-                stacked_params, updated_params, async_op=True
-            ).get_future()
-
-            all_gather_infos.append(
-                {
-                    "gather_future": gather_future,
-                    "stacked_params": stacked_params,
-                    "orig_params": params,
-                }
-            )
-
-        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
-        for info in all_gather_infos:
-            info["gather_future"].wait()
-            stacked_params = info["stacked_params"]
-            orig_params = info["orig_params"]
-
-            unstacked_params = torch.unbind(stacked_params)
-            for i, p in enumerate(orig_params):
-                p.copy_(unstacked_params[i], non_blocking=True)
-
-
-class DistAdam(torch.optim.Optimizer):
-    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
-        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
-        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
-        params = list(params)
-        # Group by label, with explicit ordering for execution control.
-        params_by_label = defaultdict(list)
-        for p in params:
-            params_by_label[getattr(p, 'label', None)].append(p)
-        param_groups = []
-        for label in label_order:
-            if label in params_by_label:
-                param_groups.append(dict(params=params_by_label[label]))
-        # include any unlabeled params at the end (processed last)
-        if None in params_by_label:
-            param_groups.append(dict(params=params_by_label[None]))
-        super().__init__(param_groups, defaults)
-        # init state: small params (numel < 1024) use full-sized state, others use sharded
-        for p in params:
-            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
-            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
-            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
-        # DistributedAdam implementation by @vagrawal, @akash5474
-        self.should_sync = False
-        self._reduce_scatter_hooks = []
-        self._reduce_scatter_futures = {}
-        self.register_backward_hooks()
-
-    def register_backward_hooks(self):
-        for group in self.param_groups:
-            for param in group["params"]:
-                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
-
-    @torch.no_grad()
-    def _sync_gradient(self, param):
-        if not self.should_sync:
-            return
-
-        grad = param.grad
-        if param.numel() < 1024:
-            # Small params: use all_reduce (no scatter/gather needed)
-            self._reduce_scatter_futures[param] = (
-                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
-                grad
-            )
-        else:
-            rank_size = grad.shape[0] // self.world_size
-            if grad is not None:
-                grad_slice = torch.empty_like(grad[:rank_size])
-                self._reduce_scatter_futures[param] = (
-                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
-                    grad_slice
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
                 )
 
-    def copy_lm_to_embed(self):
-        # run at 1/6 of training
-        lm_head = self.param_groups[0]['params'][0]
-        embed = self.param_groups[-1]['params'][0]
-        lm_head_state = self.state[lm_head]
-        embed_state = self.state[embed]
-        embed_state['step'] = lm_head_state['step']
-        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
-        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
-        embed.data.copy_(lm_head.data)
-
-    @torch.compile
-    @torch.no_grad()
-    def step(self):
-        rank = dist.get_rank()
-        all_gather_futures: list[torch.Future] = []
-
-        for group in self.param_groups:
-            beta1, beta2 = group['betas']
-            eps = group['eps']
-            wd = group['weight_decay']
-            for param in group['params']:
-                if param not in self._reduce_scatter_futures:
-                    continue
-
-                fut, g_slice = self._reduce_scatter_futures[param]
-                fut.wait()
-
-                is_small = param.numel() < 1024
-                if is_small:
-                    # Small params: g_slice is actually full grad, p_slice is full param
-                    p_slice = param
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
                 else:
-                    rank_size = param.shape[0] // self.world_size
-                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
 
-                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
-                state = self.state[param]
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
 
-                exp_avg = state["exp_avg"]
-                exp_avg_sq = state["exp_avg_sq"]
-                state["step"] += 1
-                t = state["step"]
-                # update running averages
-                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
-                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
-                # bias corrections
-                bias1 = 1 - beta1 ** t
-                bias2 = 1 - beta2 ** t
-                # compute step
-                denom = exp_avg_sq.sqrt().add_(eps)
-                step_size = lr * (bias2 ** 0.5 / bias1)
-                update = exp_avg.div(denom).mul_(step_size)
-                # cautious weight decay
-                mask = (update * p_slice) > 0
-                # lr as weight decay schedule
-                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
-                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
 
-                p_slice.add_(other=update, alpha=-1.0)
+    # -----------------------------------
+    # Reduce/Gather operations
 
-                if not is_small:
-                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
 
-        self._reduce_scatter_futures.clear()
-        torch.futures.collect_all(all_gather_futures).wait()
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (1024, 50304) is sharded to (128, 50304) per rank (along model_dim)
+        - embed (50304, 1024) is sharded to (6288, 1024) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size
+            embed_chunk_size = embed_cfg.chunk_size
+
+            # All-gather lm_head momentum to get full (1024, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (128, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, self.world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
 
 # -----------------------------------------------------------------------------
 # PyTorch nn.Module definitions for the model
@@ -858,6 +1009,36 @@ class CastedLinear(nn.Linear):
             return out.reshape(*x.shape[:-1], -1)
         else:
             return F.linear(x, self.weight.type_as(x))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
 
 
 # -----------------------------------------------------------------------------
@@ -919,43 +1100,26 @@ class AttnArgs:
     sin: torch.Tensor
     attn_scale: float
     key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    precomputed_ve_gate: torch.Tensor | None = None
 
 flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
 
 class CausalSelfAttention(nn.Module):
-    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
         super().__init__()
         self.num_heads = num_heads
         self.head_dim = head_dim
         self.dim = dim
         self.hdim = num_heads * head_dim
-
         assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
-        std = self.dim ** -0.5
-        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
-        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
-        # https://x.com/hi_tysam/status/1879699187107033311
-        # Simplified layout by @chrisjmccormick
-        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
-        # label all modules for explicit optimizer grouping
-        self.qkvo_w.label = 'attn'
+        # Weights are stored in parameter banks and passed via forward()
 
-        with torch.no_grad():
-            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
-            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
-
-        # sparse gated attention to enable context based no-op by @classiclarryd
-        self.attn_gate = CastedLinear(16, num_heads)
-        self.attn_gate.weight.label = 'attn_gate'
-        self.attn_gate.weight.lr_mul = 0.1
-
-        # only include gates on layers with value embeds used on forward pass
-        if layer_idx in [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]:
-            self.value_embed_gate = CastedLinear(16, num_heads)
-            self.value_embed_gate.weight.label = 'value_embed_gate'
-            self.value_embed_gate.weight.lr_mul = 0.1
-
-    def forward(self, x: Tensor, attn_args: AttnArgs):
+    def forward(self, x: Tensor|tuple[Tensor, Tensor], attn_args: AttnArgs, qkvo_w: Tensor):
+        is_mudd = isinstance(x, tuple)
+        if is_mudd:
+            x, v_mudd = x
         B, T = x.size(0), x.size(1) # batch size, sequence length
         assert B == 1, "varlen sequences requires B == 1"
         assert T % 16 == 0
@@ -963,16 +1127,22 @@ class CausalSelfAttention(nn.Module):
         cos, sin = attn_args.cos, attn_args.sin
         ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
         seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
 
-        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        if is_mudd:
+            v = v + v_mudd
         q, k = norm(q), norm(k) # QK norm @Grad62304977
         q, k = rotary(q, cos, sin), rotary(k, cos, sin)
         if key_offset:
             # shift keys forward for the stationary head dims. Enables 1-layer induction.
             k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
             k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
-        if ve is not None:
-            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        if ve is not None and ve_gate_w is not None:
+            if attn_args.precomputed_ve_gate is not None:
+                ve_gate_out = attn_args.precomputed_ve_gate + 2.0
+            else:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :ve_gate_w.size(-1)], ve_gate_w)).view(B, T, self.num_heads, 1)
             v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
 
         max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
@@ -982,45 +1152,10 @@ class CausalSelfAttention(nn.Module):
                                                         max_seqlen_q=max_len, max_seqlen_k=max_len,
                                                         causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
         y = y.view(B, T, self.num_heads, self.head_dim)
-        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y * torch.sigmoid(F.linear(x[..., :attn_gate_w.size(-1)], attn_gate_w)).view(B, T, self.num_heads, 1)
         y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
-        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
         return y
-
-class MLP(nn.Module):
-    def __init__(self, dim: int):
-        super().__init__()
-        hdim = 4 * dim
-        # Transposed layout to match attention weights
-        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
-        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
-        # label all modules for explicit optimizer grouping
-        self.c_fc.label = 'mlp'
-        self.c_proj.label = 'mlp'
-        self.c_proj.lr_mul = 2.
-
-        std = 0.5 * (dim ** -0.5)
-        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
-        with torch.no_grad():
-            self.c_fc.uniform_(-bound, bound)
-            self.c_proj.zero_() # zero init suggested by @Grad62304977
-
-    def forward(self, x: Tensor):
-        x = F.linear(x, self.c_fc.type_as(x))
-        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
-        x = F.linear(x, self.c_proj.T.type_as(x))
-        return x
-
-class Block(nn.Module):
-    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
-        super().__init__()
-        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx)
-        self.mlp = MLP(dim)
-
-    def forward(self, x: Tensor, attn_args: AttnArgs):
-        x = x + self.attn(norm(x), attn_args)
-        x = x + self.mlp(norm(x))
-        return x
 
 # -----------------------------------------------------------------------------
 # The main model
@@ -1038,81 +1173,143 @@ class GPT(nn.Module):
     def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
         super().__init__()
         self.num_layers = num_layers
-        vocab_size = next_multiple_of_n(vocab_size, n=128)
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
 
         self.smear_gate = CastedLinear(16, 1)
         self.smear_gate.weight.label = 'smear_gate'
-        self.smear_gate.weight.lr_mul = 0.01
-        self.smear_gate.weight.wd_mul = 0.0
 
-        self.skip_gates = nn.ModuleList([CastedLinear(16, 1) for _ in range(3)])
-        for sg in self.skip_gates:
-            sg.weight.label = 'skip_gate'
-            sg.weight.lr_mul = 0.01
-            sg.weight.wd_mul = 0.0
+        # Skip gate bank: 3 skip gates fused into one parameter
+        self.skip_gate_bank = nn.Parameter(torch.zeros(3, 1, 16))
+        self.skip_gate_bank.label = 'skip_gate_bank'
 
-        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
-        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
-        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
-        for embed in self.value_embeds:
-            nn.init.zeros_(embed.weight)
-        for ve in self.value_embeds:
-            ve.weight.label = 'value_embed'
-        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        # Token value embeddings: fused into one parameter for unified optimizer
+        # by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        self.value_embeds = nn.Parameter(torch.zeros(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+        self.value_embeds.label = 'value_embeds'
+
+        # Attention gate bank: 16 layers, 8 heads, gate_dim=16
+        self.attn_gate_bank = nn.Parameter(torch.zeros(16, num_heads, 16))
+        self.attn_gate_bank.label = 'attn_gate_bank'
+
+        # VE gate bank: 10 layers have VE gates (layers 0-4 and 11-15)
+        self.ve_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 16))
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all 16 attention layers
+        self.attn_bank = nn.Parameter(torch.empty(num_layers, 4 * model_dim, hdim))  # (16, 4096, 1024)
+        self.attn_bank.reshape = (num_layers * 4, hdim, hdim)  # (64, 1024, 1024) -> 64/8=8 per GPU
+        self.attn_bank.label = 'attn_bank'
+
+        # MLP bank: stores c_fc and c_proj for all 16 MLP layers
+        self.mlp_bank = nn.Parameter(torch.empty(num_layers, 2, mlp_hdim, model_dim))  # (16, 2, 4096, 1024)
+        self.mlp_bank.reshape = (num_layers * 2, mlp_hdim, model_dim)  # (32, 4096, 1024) -> 32/8=4 per GPU
+        self.mlp_bank.label = 'mlp_bank'
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-bound, bound)  # QKV
+            self.attn_bank[:, model_dim * 3:, :].zero_()  # O
+            std_mlp = 0.5 * model_dim ** -0.5
+            bound_mlp = (3 ** 0.5) * std_mlp
+            self.mlp_bank[:, 0, :, :].uniform_(-bound_mlp, bound_mlp)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Single attention module (weights come from attn_bank)
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads)
         self.yarn = Yarn(head_dim, max_seq_len)
-        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
-        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
-        use_fp8 = not os.environ.get("DISABLE_FP8", False)
 
-        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        # lm_head: transposed CastedLinearT for faster gradient accumulation
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
         nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
         self.lm_head.weight.label = 'lm_head'
 
-        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
         self.embed.weight.label = 'embed'
 
-        self.embed2 = nn.Embedding(vocab_size, model_dim)
+        self.embed2 = nn.Embedding(self.vocab_size, model_dim)
         self.embed2.weight.label = 'embed2'
 
-        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
-        self.x0_lambdas = nn.Parameter(torch.zeros(2*num_layers))
-        self.x0_lambdas.label = 'x0_lambdas'
-        self.x0_lambdas.lr_mul = 5.0
-        self.x0_lambdas.wd_mul = 0.0
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+        self.bigram_embed.weight.label = 'bigram_embed'
 
-        pad = (-num_layers * 3 - 5) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(2 * num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+        self.bigram_lambdas.label = 'bigram_lambdas'
+
+        pad = (-num_layers * 3 - 4) % dist.get_world_size()
         self.scalars = nn.Parameter(
             torch.cat(
                 [
                     1.05 * torch.ones(num_layers),  # resid lambdas. 1.05 init such that layer i weight is i^(num_layers-i).
                     *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
                     torch.zeros(1), # smear_lambda
-                    0.5*torch.ones(1), # backout_lambda
-                    -1.5 * torch.ones(3),  # skip_lambdas -> σ(-1.5) ≈ 0.18
+                    -1.5 * torch.ones(3),  # skip_lambdas -> sigma(-1.5) ~= 0.18
                     torch.ones(pad),
                 ]
             )
         )
-
         self.scalars.label = 'scalars'
-        # set learning rates
-        for param in self.value_embeds.parameters():
-            param.lr_mul = 75.
-            param.wd_mul = 5.
-        for param in self.embed.parameters():
-            param.wd_mul = 150.
-        for param in self.embed2.parameters():
-            param.lr_mul = 75.
-            param.wd_mul = 5.
-        for param in self.lm_head.parameters():
-            param.wd_mul = 150.
-        self.scalars.lr_mul = 5.0
-        self.scalars.wd_mul = 0.0
-        
-        # start training with tied embed/lm_head
-        self.split_embed = False
 
-    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        self._init_mudd(num_layers, model_dim)
+
+    def _init_mudd(self, num_layers: int, model_dim: int):
+        """
+        MUDD trimmed for speedrun: only layers {N-2, N-1} consume MUDD signals.
+        Connectivity is fixed:
+
+          - layer N-2 (=14): produces v_mudd (-> layer-15 V), residual delta, ve_gate
+                             (-> layer-15 attn), and 6 layer-15 scalar gates:
+                             resid_attn, post_attn, resid_mlp, post_mlp, x0_lambda,
+                             bigram_lambda. Sources: {x0, h11, current x}.
+          - layer N-1 (=15): produces residual delta only.
+                             Sources: {x0, h11, h14, ve_bank0, skip_connection}.
+                             dense_bs[1, 1, 1] = -0.5 absorbs the legacy backout.
+                             skip_connection is the layer-4 output (long-window snapshot).
+        """
+        num_mudd_layers = 2
+        self._mudd_C = 2     # 0 = v_mudd, 1 = residual delta
+        self._mudd_L = 3     # 3 sources on layer N-2 (x0, h_backout, x_self)
+        self._mudd_L_last = 5  # layer N-1 residual: x0, h_backout, h_{N-2}, ve_bank0, skip_connection
+        self._mudd_L_with_gate = self._mudd_L + 5  # 3 + 5 = 8
+        self._mudd_scale = 0.2 / math.sqrt(self._mudd_L)
+        inter_dim = 64
+        self.dense_w1 = nn.Parameter(torch.empty(num_mudd_layers, inter_dim, model_dim))
+        self.dense_w1.reshape = (num_mudd_layers * (inter_dim // 8), 8, model_dim)
+        self.dense_w1.label = 'dense_w1'
+        for j in range(num_mudd_layers):
+            nn.init.kaiming_uniform_(self.dense_w1.data[j], a=math.sqrt(5))
+        self.dense_w2 = nn.Parameter(torch.zeros(
+            num_mudd_layers, inter_dim, self._mudd_C, self._mudd_L_with_gate
+        ))
+        self.dense_w2.reshape = (num_mudd_layers * inter_dim, self._mudd_C, self._mudd_L_with_gate)
+        self.dense_w2.label = 'dense_w2'
+        bs_init = torch.zeros(num_mudd_layers, self._mudd_C, self._mudd_L_with_gate)
+        bs_init[1, 1, 1] = -4.34  # [layer N-1, residual, source h_backout] absorbs legacy backout
+        bs_init[0, 0, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_attn[N-1]
+        bs_init[0, 0, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_attn[N-1]
+        bs_init[0, 1, self._mudd_L + 1] = 1.05 / self._mudd_scale   # resid_mlp[N-1]
+        bs_init[0, 1, self._mudd_L + 2] = 1.0 / self._mudd_scale    # post_mlp[N-1]
+        bs_init[0, 0, self._mudd_L + 3] = 0.0                       # x0_lambda[N-1] (init 0)
+        bs_init[0, 0, self._mudd_L + 4] = 0.05 / self._mudd_scale   # bigram_lambda[N-1]
+        self.dense_bs = nn.Parameter(bs_init)
+        self.dense_bs.label = 'dense_bs'
+        assert self.attn.num_heads % self._mudd_C == 0
+        self._mudd_gate_repeat = self.attn.num_heads // self._mudd_C
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
         assert input_seq.ndim == 1
 
         # unpack schedule_cfg
@@ -1122,35 +1319,49 @@ class GPT(nn.Module):
         skip_connections = []
         skip_in = [2, 4, 6]
         skip_out = [9, 10, 11]
-        x_backout = None
         backout_layer = 11
 
         # set lambdas
         resid_lambdas = self.scalars[: 1 * self.num_layers]
         x0_lambdas = self.x0_lambdas.view(-1, 2)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
         sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
         smear_lambda = self.scalars[3 * self.num_layers]
-        backout_lambda = self.scalars[3 * self.num_layers+1]
-        skip_lambdas = self.scalars[3 * self.num_layers+2: 3*self.num_layers+5]
-        
+        skip_lambdas = self.scalars[3 * self.num_layers+1: 3*self.num_layers+4]
+
         # set block masks and key shift
         short_bm = ws_short * args.block_size
         long_bm = ws_long * args.block_size
-        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, 
+        bm_sizes = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm,
             short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
         assert len(bm_sizes) == self.num_layers
         key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
 
-        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
-        if self.split_embed:
-            x = self.embed(input_seq)
-        else:
-            x = F.embedding(input_seq, self.lm_head.weight)
-        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # Unbind parameter banks
+        attn_weights = self.attn_bank.unbind(0)  # 16 tensors of [4096, 1024]
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 32 tensors of [4096, 1024]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+        ag = self.attn_gate_bank.unbind(0)  # 16 tensors of [8, 16]
+
+        # Map VE gates to layers
+        ve_gate_layers = [0, 1, 2, 3, 4, 11, 12, 13, 14, 15]
+        veg = self.ve_gate_bank.unbind(0)  # 10 tensors of [8, 16]
+        ve_gates = [None] * self.num_layers
+        for idx, layer in enumerate(ve_gate_layers):
+            ve_gates[layer] = veg[idx]
+
+        # Unbind skip gate bank
+        skip_gate_ws = self.skip_gate_bank.unbind(0)  # 3 tensors of [1, 16]
+
+        x = self.embed(input_seq)  # embed is synced from lm_head during tied phase by optimizer
+
+        # Value embeddings - always computed
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
         # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
         # dropping first layer updates this to .12 ... 012
-        ve = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
-        assert len(ve) == self.num_layers
+        ve_list = [ve[0], ve[1], ve[2], ve[3], ve[4]] + [None] * (self.num_layers - 10) + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        assert len(ve_list) == self.num_layers
 
         # smear token embed forward 1 position @classiclarryd
         smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
@@ -1158,63 +1369,131 @@ class GPT(nn.Module):
         x = x0 = norm(x[None])
 
         x02 = norm(self.embed2(input_seq)[None])
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # ---- MUDD state ----
+        h_backout_snap = None  # snapshot at backout_layer (layer 11)
+        h_n2_snap = None       # snapshot at layer N-2 (layer 14)
+        v_mudd = None
+        next_ve_gate = None
+        next_resid_attn_gate = None
+        next_post_attn_gate = None
+        next_resid_mlp_gate = None
+        next_post_mlp_gate = None
+        next_x0_lambda_gate = None
+        next_bigram_lambda_gate = None
+        skip_connection = None  # layer-4 output snapshot for post-loop MUDD
 
         skip_idx = 0
         for i in range(self.num_layers):
             attn_args = AttnArgs(
-                ve=ve[i],
+                ve=ve_list[i],
                 sa_lambdas=sa_lambdas[i],
                 seqlens=seqlens,
                 bm_size=bm_sizes[i],
                 cos=self.yarn.cos,
                 sin=self.yarn.sin,
                 attn_scale=self.yarn.attn_scale,
-                key_offset = key_offset[i]
+                key_offset=key_offset[i],
+                attn_gate_w=ag[i],
+                ve_gate_w=ve_gates[i],
+                precomputed_ve_gate=next_ve_gate,
             )
+            next_ve_gate = None
             if i in skip_out:
-                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(self.skip_gates[skip_idx](x0[..., :self.skip_gates[skip_idx].weight.size(-1)]))
+                skip_gate_out = torch.sigmoid(skip_lambdas[skip_idx]) * 2 * torch.sigmoid(F.linear(x0[..., :skip_gate_ws[skip_idx].size(-1)], skip_gate_ws[skip_idx]))
                 skip_idx += 1
                 x = x + skip_gate_out * skip_connections.pop()
-            if i == 0:
-                x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02
+            if next_resid_attn_gate is None:
+                if i == 0:
+                    x = (resid_lambdas[0] + x0_lambdas[0,0]) * x + x0_lambdas[0,1] * x02 + bigram_lambdas[0] * x0_bigram
+                else:
+                    x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02 + bigram_lambdas[i] * x0_bigram
+            # Attention
+            attn_in = h_backout_snap if h_backout_snap is not None else x
+            if v_mudd is not None:
+                attn_out = self.attn((norm(attn_in), v_mudd), attn_args, attn_weights[i])
+                v_mudd = None
             else:
-                x = resid_lambdas[i] * x + x0_lambdas[i,0] * x0 + x0_lambdas[i,1] * x02
-            x = self.blocks[i](x, attn_args)
+                attn_out = self.attn(norm(attn_in), attn_args, attn_weights[i])
+            if next_resid_attn_gate is not None:
+                x0_inj = next_x0_lambda_gate * x0 + next_bigram_lambda_gate * x0_bigram
+                x = next_resid_attn_gate * x + next_post_attn_gate * attn_out + x0_inj
+                next_resid_attn_gate = None
+                next_post_attn_gate = None
+                next_x0_lambda_gate = None
+                next_bigram_lambda_gate = None
+            else:
+                x = x + attn_out
+            # MLP: inline F.linear + relu().square() + F.linear
+            mlp_in = norm(x)
+            mlp_h = F.linear(mlp_in, mlp_fcs[i].type_as(mlp_in))
+            mlp_h = F.relu(mlp_h).square()  # https://arxiv.org/abs/2109.08668v2
+            mlp_out = F.linear(mlp_h, mlp_projs[i].T.type_as(mlp_h))
+            if next_resid_mlp_gate is not None:
+                x = next_resid_mlp_gate * x + next_post_mlp_gate * mlp_out
+                next_resid_mlp_gate = None
+                next_post_mlp_gate = None
+            else:
+                x = x + mlp_out
+
+            # ---- MUDD: layer N-2 (=14) ----
+            if i == self.num_layers - 2:
+                dw1 = F.gelu(F.linear(x, self.dense_w1[0]))
+                dw = torch.einsum('BTd, dCL -> BTCL', dw1, self.dense_w2[0])
+                dw = (dw + self.dense_bs[0]) * self._mudd_scale  # (B, T, 2, 8)
+                m_v0, m_v_bo, m_v_self = dw[..., 0, :self._mudd_L].split(1, dim=-1)
+                v_mudd_raw = 1.15 * (m_v0 * x0 + m_v_bo * h_backout_snap + m_v_self * x)
+                v_mudd = v_mudd_raw.view(
+                    v_mudd_raw.size(0), v_mudd_raw.size(1),
+                    self.attn.num_heads, self.attn.head_dim,
+                )
+                m_r0, m_r_bo, m_r_self = dw[..., 1, :self._mudd_L].split(1, dim=-1)
+                h_n2_snap = x
+                x = (1 + m_r_self) * x + m_r0 * x0 + m_r_bo * h_backout_snap
+                ve_gate_extra = dw[..., self._mudd_L]  # (B, T, C)
+                next_ve_gate = ve_gate_extra.repeat_interleave(
+                    self._mudd_gate_repeat, dim=-1
+                ).unsqueeze(-1)  # (B, T, num_heads, 1)
+                next_resid_attn_gate = dw[..., 0, self._mudd_L + 1].unsqueeze(-1)
+                next_post_attn_gate  = dw[..., 0, self._mudd_L + 2].unsqueeze(-1)
+                next_resid_mlp_gate  = dw[..., 1, self._mudd_L + 1].unsqueeze(-1)
+                next_post_mlp_gate   = dw[..., 1, self._mudd_L + 2].unsqueeze(-1)
+                next_x0_lambda_gate     = dw[..., 0, self._mudd_L + 3].unsqueeze(-1)
+                next_bigram_lambda_gate = dw[..., 0, self._mudd_L + 4].unsqueeze(-1)
+
+            if i == 4:
+                skip_connection = x
             if i in skip_in:
                 skip_connections.append(x)
             if i == backout_layer:
-                x_backout = x
+                h_backout_snap = x
 
-        # back out contributions from first 2/3 layers that are only required for downstream context and not direct prediction
-        x -= backout_lambda * x_backout
+        # ---- MUDD: layer N-1 (=15) post-loop residual ----
+        # Sources (5): x0, h_backout, h_{N-2}, ve_bank0, skip_connection (layer-4 output).
+        # No self-reference -> no fuse. Uses dense_w2[1, :, 1, :_mudd_L_last].
+        dw1 = F.gelu(F.linear(x, self.dense_w1[1]))
+        dw_r = torch.einsum('BTd, dL -> BTL', dw1, self.dense_w2[1, :, 1, : self._mudd_L_last])
+        dw_r = (dw_r + self.dense_bs[1, 1, : self._mudd_L_last]) * self._mudd_scale
+        m_r0, m_r_bo, m_r_n2, m_rve, m_rsk = dw_r.split(1, dim=-1)
+        ve_bank0 = ve_list[0][None].to(dtype=x.dtype)  # (1, T, D)
+        x = x + m_r0 * x0 + m_r_bo * h_backout_snap + m_r_n2 * h_n2_snap + m_rve * ve_bank0 + m_rsk * skip_connection
+
         x = norm(x)
 
         if not self.training:
             loss = 0
             for i in range(4):
-                logits: Tensor = F.linear(x.flatten(end_dim=1).chunk(4)[i], self.lm_head.weight.bfloat16()).float()
+                logits: Tensor = (x.flatten(end_dim=1).chunk(4)[i] @ self.lm_head.weight.bfloat16()).float()
                 logits = 23 * torch.sigmoid((logits + 5) / 7.5)
                 loss += F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq.chunk(4)[i], reduction="mean")/4
             return loss
-        
-        logits = self.lm_head(x)
-        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
-        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
-        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
-        logits_for_loss = logits.float() if not self.training else logits
 
-        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
-        if n_predict > 1:
-            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
-            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
-            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
-            target_logits = logits_flat.gather(1, idx)
-            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
-            for k in range(1, n_predict):  # zero out preds past end of sequence
-                cross_entropy[-k:, k] = 0
-            loss = (cross_entropy * mtp_weights).sum()
-        else:
-            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        # Fused softcapped cross-entropy with FP8: hidden states + lm_head weight -> loss in one kernel
+        loss = FusedSoftcappedCrossEntropy.apply(
+            x.view(-1, x.size(-1)), target_seq, mtp_weights,
+            self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale
+        ).sum()
         return loss
 
 # -----------------------------------------------------------------------------
@@ -1321,6 +1600,17 @@ class DataPreloader:
             self.thread.join()
         return self.data
 
+def get_bigram_hash(x):
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size - 1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
 def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
     # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -1382,11 +1672,14 @@ def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_l
         _inputs = _inputs.to(dtype=torch.int32)
         _targets = _targets.to(dtype=torch.int64)
         _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
 
         new_params = yield (
             _inputs.to(device="cuda", non_blocking=True),
             _targets.to(device="cuda", non_blocking=True),
-            _cum_lengths.to(device="cuda", non_blocking=True)
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
         )
 
         if new_params is not None:
@@ -1450,15 +1743,14 @@ def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, 
 
 class TrainingManager():
     """
-    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Manages the unified NorMuonAndAdam optimizer for all parameters with explicit ordering.
     Notable Features:
         1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
-        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
-        3. Adam optimizers are only stepped on odd steps @classiclarryd
-        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
-        5. Muon has a linear momentum warmup and cooldown schedule
-        6. Learning rates follow a linear decay schedule
-        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
 
     Manages model architecture, data, and target that changes during training
     Notable Features:
@@ -1473,32 +1765,50 @@ class TrainingManager():
         self.mtp_weights_schedule = self._build_mtp_schedule()
         self.model = model
 
-        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed2', 'embed']
-        scalar_labels = ['scalars']
-        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
-        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
-        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
-        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
-        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded"},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded"},
+            "scalars":        {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "ve_gate_bank":   {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.1},
+            "x0_lambdas":     {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 5.0, "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.95], "lr_mul": 1.0, "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "lm_head":        {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "embed2":         {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "lr_mul": 75., "wd_mul": 5.},
+            "bigram_embed":   {"optim": "adam", "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75., "wd_mul": 5.0},
+            "embed":          {"optim": "adam", "comms": "sharded", "adam_betas": [0.8, 0.95], "wd_mul": 150.},
+            "dense_w1":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_w2":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25},
+            "dense_bs":       {"optim": "adam", "comms": "replicated", "adam_betas": [0.9, 0.99], "lr_mul": 0.25, "wd_mul": 0.0},
+        }
 
-        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.004, betas=(0.8, 0.95), eps=1e-8, weight_decay=0.005)
-        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
-        self.muon_opt = NorMuon(muon_params, lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)
-        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate_bank", "attn_gate_bank", "ve_gate_bank", "dense_bs",
+            "x0_lambdas", "bigram_lambdas",
+            "dense_w2",
+            "value_embeds", "embed2", "bigram_embed",
+            "dense_w1",
+            "lm_head", "embed",
+            "attn_bank", "mlp_bank",
+        ]
+
+        adam_defaults = dict(lr=0.004, eps=1e-8, weight_decay=0.005)
+        normuon_defaults = dict(lr=0.015, momentum=0.95, beta2=0.95, weight_decay=1.2)  # beta2 kept at 0.95 (0.9 tested in v7, no benefit at this step count)
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
         # split after odd number step
         self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
-
-        # set defaults
-        for opt in self.optimizers:
-            opt.freeze_timer = 0
-            opt.odd_step_only = False 
-            opt.should_sync = True
-            for group in opt.param_groups:
-                group["initial_lr"] = group["lr"]
-
-        # on even steps, only step Muon params
-        self.adam_opt.odd_step_only = True
-        self.scalar_opt.odd_step_only = True
 
         self.reset()
 
@@ -1526,9 +1836,9 @@ class TrainingManager():
             ws_short = self.ws_short,
             ws_long = self.ws_long
         )
-    
-    def _is_active_step(self, opt, step: int):
-        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def _is_adam_step(self, step: int):
+        return step % 2 == 1
 
     def get_transition_steps(self):
         transition_steps = [0]
@@ -1554,55 +1864,70 @@ class TrainingManager():
 
         self.ws_long = new_ws_long
         self.mtp_weights = self.mtp_weights_schedule[step]
-    
-    def step_optimizers(self, step: int):                
+
+    def step_optimizers(self, step: int):
         step_lr = get_lr(step)
         muon_momentum = get_muon_momentum(step)
-        for group in self.muon_opt.param_groups:
-            group["momentum"] = muon_momentum
+        do_adam = self._is_adam_step(step)
 
-        for opt in self.optimizers:
-            if opt.freeze_timer > 0:
-                opt.freeze_timer -= 1
-                opt.zero_grad(set_to_none=True)
-            else:
-                if self._is_active_step(opt, step):
-                    for group in opt.param_groups:
-                        group["lr"] = group["initial_lr"] * step_lr
-                    opt.step()
-                    opt.zero_grad(set_to_none=True)
-                    if opt.odd_step_only:
-                        opt.should_sync = False
-        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
         if step == self.split_step:
-            self.adam_opt.copy_lm_to_embed()
-            self.model.split_embed = True
-
-    def start_transition(self, freeze_count=40):
-        # freeze scalar weights during transition
-        self.scalar_opt.freeze_timer = freeze_count
-    
-    def activate_hooks(self, step: int):
-        for opt in self.optimizers:
-            if self._is_active_step(opt, step):
-                opt.should_sync = True
+            self.optimizer.copy_lm_state_to_embed()
 
     def reset(self, state=None):
         if state is not None:
-            for opt, opt_state in zip(self.optimizers, state):
-                opt.should_sync = False
-                opt.load_state_dict(opt_state)
+            self.optimizer.load_state_dict(state)
 
-        # muon momentum buffers not in state dict
-        self.muon_opt.reset()
-        self.model.split_embed = False
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
 
         self.ws_short, self.ws_long = get_ws(0)
         self.batch_size = get_bs(0)
         self.model.yarn.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
 
     def get_state(self):
-        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
 
 # -----------------------------------------------------------------------------
 # int main
@@ -1614,7 +1939,7 @@ class Hyperparameters:
     val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
     val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
     # batch sizes
-    train_bs_schedule: tuple = (131072, 262144, 393216, 524288, 
+    train_bs_schedule: tuple = (131072, 262144, 393216, 524288,
                                 524288, 524288, 524288, 524288,
                                 524288, 524288, 524288, 524288
                                )
@@ -1622,8 +1947,8 @@ class Hyperparameters:
     train_max_seq_len: int = 128 * 16 * 2 # doubled to enable longer window sizes
     val_batch_size: int = 4 * 64 * 1024 * 8
     # optimization
-    num_scheduled_iterations: int = 4700  # number of steps to complete lr and ws schedule
-    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_scheduled_iterations: int = 4125  # reduced from 4700 (v8 crosses 2.92 at step ~4544, 120 step margin)
+    num_extension_iterations: int = 25  # number of steps to continue training at final lr and ws
     num_iterations: int = num_scheduled_iterations + num_extension_iterations
     cooldown_frac: float = 0.70  # fraction of num_scheduled_iterations spent cooling down the learning rate
     split_embed_frac: float = 2/3/4
@@ -1638,6 +1963,7 @@ class Hyperparameters:
                           23, 23, 23, 23)
     ws_final: int = 23 # set final validation ws, used for YaRN extension and short window size
     ws_validate_post_yarn_ext: int = 27 # extend long windows out even further after applying YaRN
+    bigram_vocab_size: int = 50304 * 5
 
 args = Hyperparameters()
 
@@ -1650,10 +1976,11 @@ rank = int(os.environ["RANK"])
 world_size = int(os.environ["WORLD_SIZE"])
 assert 8 % world_size == 0, "world_size must be a divisor of 8"
 grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps
 assert torch.cuda.is_available()
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
-dist.init_process_group(backend="nccl", device_id=device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
 dist.barrier()
 master_process = (rank == 0) # this process will do logging, checkpointing etc.
 
@@ -1696,6 +2023,15 @@ model: nn.Module = GPT(
 for m in model.modules():
     if isinstance(m, (nn.Embedding, nn.Linear)):
         m.weight.data = m.weight.data.bfloat16()
+# Convert bank parameters to bfloat16
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.skip_gate_bank.data = model.skip_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+model.dense_w1.data = model.dense_w1.data.bfloat16()
+model.dense_w2.data = model.dense_w2.data.bfloat16()
+model.dense_bs.data = model.dense_bs.data.bfloat16()
 for param in model.parameters():
     dist.broadcast(param.detach(), 0)
 
@@ -1708,7 +2044,7 @@ training_manager = TrainingManager(model)
 print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
 # Warmup the training kernels, then re-initialize the state so we aren't cheating
 initial_state = dict(model=copy.deepcopy(model.state_dict()),
-                     optimizers=training_manager.get_state()) # save the initial state
+                     optimizer=training_manager.get_state()) # save the initial state
 train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
 val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
 
@@ -1719,21 +2055,22 @@ for step in warmup_steps:
     training_manager.advance_schedule(step)
     model.eval()
     with torch.no_grad():
-        inputs, targets, cum_seqlens = next(val_loader)
-        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
     model.train()
     for idx in range(grad_accum_steps):
-        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
-        if idx == grad_accum_steps - 1:
-            training_manager.activate_hooks(step)
         send_args = training_manager.train_loader_send_args
-        inputs, targets, cum_seqlens = train_loader.send(send_args)
-        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
     training_manager.step_optimizers(step)
 print0("Resetting Model", console=True)
 model.zero_grad(set_to_none=True)
 model.load_state_dict(initial_state["model"])
-training_manager.reset(initial_state["optimizers"])
+training_manager.reset(initial_state["optimizer"])
 del val_loader, train_loader, initial_state
 model.train()
 
@@ -1767,8 +2104,8 @@ for step in range(train_steps + 1):
         val_loss = 0
         with torch.no_grad():
             for _ in range(val_steps):
-                inputs, targets, cum_seqlens = next(val_loader)
-                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
         val_loss /= val_steps
         del val_loader
         dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
@@ -1780,7 +2117,7 @@ for step in range(train_steps + 1):
 
     if last_step:
         if master_process and args.save_checkpoint:
-            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
             os.makedirs(f"logs/{run_id}", exist_ok=True)
             torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
         # the last step only has the validation loop, so break to avoid training
@@ -1788,12 +2125,13 @@ for step in range(train_steps + 1):
 
     # --------------- TRAINING SECTION -----------------
     for idx in range(grad_accum_steps):
-        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
-        if idx == grad_accum_steps - 1:
-            training_manager.activate_hooks(step)
         send_args = training_manager.train_loader_send_args
-        inputs, targets, cum_seqlens = train_loader.send(send_args)
-        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
     training_manager.step_optimizers(step)
 
     # logging


### PR DESCRIPTION

Add MUDD (Multiway Dynamic Dense Connections, [Xiao et al. 2025](https://arxiv.org/abs/2502.12170)) to the **last two transformer blocks** of the Medium speedrun model. The idea matches the Small-track PR #259 : trim routing cost, reuse one small MLP for several cheap “extra outputs,” and fold legacy scalars / backout into learnable MUDD biases so we can squeeze **loss per step** without paying much wall-clock.

```bash
losses = [2.9161, 2.9165, 2.9176, 2.9179, 2.9172, 2.9171]
times = [860467, 860193, 860109, 860808, 860679, 860614]

print("p=%.4f" % scipy.stats.ttest_1samp(losses, 2.92, alternative="less").pvalue)
# p=0.0001

print("losses:", torch.std_mean(torch.tensor(losses)))
# losses: (tensor(0.0007), tensor(2.9171))

print("time:", torch.std_mean(torch.tensor(times)))
# time: (tensor(277.5980), tensor(860478.3125))

```