### PR TITLE
Add Newton-Muon track 3 result

### DIFF
--- a/records/track_3_optimization/README.md
+++ b/records/track_3_optimization/README.md
@@ -40,6 +40,7 @@ which the PR appeared.
 | 10 | 3250 | 3.2789 (n=20)✓ | NorMuon lr=0.035 wd=0.025, end 50 steps early | 2026/05/03 | [log](results/20260503_normuon/e0d0185f-ccb8-426d-8265-a4e762ec69f6.txt) | [PR](https://github.com/KellerJordan/modded-nanogpt/pull/276) | @lliu606 |
 | 11 | 3225 | 3.2785 (n=16)✓ | Setup from #9 plus [Contra-Muon](https://github.com/nilin/contra-muon) technique | 2026/05/01 | [log](results/20260501_contra_muon/08cd60f9-99e2-4e28-b1ac-19136dd42a05.txt) | [PR](https://github.com/KellerJordan/modded-nanogpt/pull/275) | @nilin |
 | 12 | 3325 | 3.2790 (n=20)✓ | Muon with aux Adam, lr=.035 wd=.025, end 50 steps early following #8 & #10 | 2026/05/03 | [log](results/1bd8db7a-f3a3-4195-856d-cab7e0816443.txt) | N/A | @kellerjordan0 |
+| 13 | 3275 | 3.2785 (n=15)✓ | [Newton-Muon](https://arxiv.org/abs/2604.01472) with activation-covariance right-preconditioning refreshed every 64 steps before the Muon Newton-Schulz update ([details](results/20260505_newton_muon/README.md)); qkv lr=.020 wd=.025, attn.proj lr=.025 wd=.025, mlp.fc lr=.030 wd=.0375, mlp.proj lr=.030 wd=.025 | 2026/05/05 | [log](results/20260505_newton_muon/6fb302c7-d271-491b-906f-75cd6ec72075.txt) | TBD | @zhehangdu |
 
 <table>
   <tr>

--- a/records/track_3_optimization/results/20260505_newton_muon/012451d9-a8dc-4383-9ca5-d0c45648d85c.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/012451d9-a8dc-4383-9ca5-d0c45648d85c.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.65656 train_time:99.745s step_avg:797.95ms
+step:250/3300 val_loss:4.11394 train_time:196.776s step_avg:776.25ms
+step:375/3300 val_loss:3.92625 train_time:293.668s step_avg:775.14ms
+step:500/3300 val_loss:3.82141 train_time:390.603s step_avg:775.48ms
+step:625/3300 val_loss:3.75159 train_time:487.449s step_avg:774.77ms
+step:750/3300 val_loss:3.70707 train_time:584.326s step_avg:775.01ms
+step:875/3300 val_loss:3.66613 train_time:681.237s step_avg:775.29ms
+step:1000/3300 val_loss:3.63220 train_time:778.218s step_avg:775.84ms
+step:1125/3300 val_loss:3.60185 train_time:875.141s step_avg:775.39ms
+step:1250/3300 val_loss:3.56945 train_time:972.020s step_avg:775.03ms
+step:1375/3300 val_loss:3.54376 train_time:1068.920s step_avg:775.20ms
+step:1500/3300 val_loss:3.51598 train_time:1165.658s step_avg:773.90ms
+step:1625/3300 val_loss:3.49594 train_time:1262.434s step_avg:774.21ms
+step:1750/3300 val_loss:3.47327 train_time:1359.312s step_avg:775.02ms
+step:1875/3300 val_loss:3.45334 train_time:1456.148s step_avg:774.69ms
+step:2000/3300 val_loss:3.43441 train_time:1552.999s step_avg:774.81ms
+step:2125/3300 val_loss:3.41700 train_time:1649.816s step_avg:774.54ms
+step:2250/3300 val_loss:3.40000 train_time:1746.656s step_avg:774.71ms
+step:2375/3300 val_loss:3.38335 train_time:1843.447s step_avg:774.33ms
+step:2500/3300 val_loss:3.36690 train_time:1940.311s step_avg:774.92ms
+step:2625/3300 val_loss:3.35020 train_time:2037.175s step_avg:774.91ms
+step:2750/3300 val_loss:3.33486 train_time:2134.047s step_avg:774.98ms
+step:2875/3300 val_loss:3.31896 train_time:2230.960s step_avg:775.30ms
+step:2975/3300 val_loss:3.30667 train_time:2308.488s step_avg:775.28ms
+step:3000/3300 val_loss:3.30395 train_time:2327.865s step_avg:775.08ms
+step:3025/3300 val_loss:3.30034 train_time:2347.232s step_avg:774.68ms
+step:3050/3300 val_loss:3.29759 train_time:2366.622s step_avg:775.58ms
+step:3075/3300 val_loss:3.29500 train_time:2386.046s step_avg:776.98ms
+step:3100/3300 val_loss:3.29234 train_time:2405.440s step_avg:775.73ms
+step:3125/3300 val_loss:3.28990 train_time:2424.824s step_avg:775.37ms
+step:3150/3300 val_loss:3.28725 train_time:2444.208s step_avg:775.39ms
+step:3175/3300 val_loss:3.28499 train_time:2463.574s step_avg:774.60ms
+step:3200/3300 val_loss:3.28294 train_time:2482.999s step_avg:777.01ms
+step:3225/3300 val_loss:3.28112 train_time:2502.372s step_avg:774.91ms
+step:3250/3300 val_loss:3.27962 train_time:2521.750s step_avg:775.14ms
+step:3275/3300 val_loss:3.27847 train_time:2541.162s step_avg:776.47ms
+step:3300/3300 val_loss:3.27795 train_time:2560.545s step_avg:775.33ms

--- a/records/track_3_optimization/results/20260505_newton_muon/1e2209a6-95dc-4daa-b688-284e6f0f173e.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/1e2209a6-95dc-4daa-b688-284e6f0f173e.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66548 train_time:99.590s step_avg:796.72ms
+step:250/3300 val_loss:4.11398 train_time:196.431s step_avg:774.73ms
+step:375/3300 val_loss:3.92911 train_time:293.069s step_avg:773.10ms
+step:500/3300 val_loss:3.82460 train_time:389.758s step_avg:773.52ms
+step:625/3300 val_loss:3.75324 train_time:486.283s step_avg:772.19ms
+step:750/3300 val_loss:3.70736 train_time:582.774s step_avg:771.93ms
+step:875/3300 val_loss:3.66551 train_time:679.233s step_avg:771.68ms
+step:1000/3300 val_loss:3.63250 train_time:775.737s step_avg:772.03ms
+step:1125/3300 val_loss:3.60307 train_time:872.174s step_avg:771.49ms
+step:1250/3300 val_loss:3.57088 train_time:968.631s step_avg:771.66ms
+step:1375/3300 val_loss:3.54602 train_time:1065.109s step_avg:771.82ms
+step:1500/3300 val_loss:3.51706 train_time:1161.549s step_avg:771.52ms
+step:1625/3300 val_loss:3.49720 train_time:1257.975s step_avg:771.41ms
+step:1750/3300 val_loss:3.47533 train_time:1354.389s step_avg:771.31ms
+step:1875/3300 val_loss:3.45531 train_time:1450.753s step_avg:770.91ms
+step:2000/3300 val_loss:3.43559 train_time:1547.185s step_avg:771.46ms
+step:2125/3300 val_loss:3.41838 train_time:1643.604s step_avg:771.35ms
+step:2250/3300 val_loss:3.40058 train_time:1740.084s step_avg:771.84ms
+step:2375/3300 val_loss:3.38407 train_time:1836.575s step_avg:771.93ms
+step:2500/3300 val_loss:3.36810 train_time:1933.045s step_avg:771.76ms
+step:2625/3300 val_loss:3.35132 train_time:2029.468s step_avg:771.38ms
+step:2750/3300 val_loss:3.33541 train_time:2125.884s step_avg:771.33ms
+step:2875/3300 val_loss:3.31984 train_time:2222.296s step_avg:771.29ms
+step:2975/3300 val_loss:3.30749 train_time:2299.471s step_avg:771.75ms
+step:3000/3300 val_loss:3.30474 train_time:2318.763s step_avg:771.70ms
+step:3025/3300 val_loss:3.30130 train_time:2338.080s step_avg:772.66ms
+step:3050/3300 val_loss:3.29838 train_time:2357.413s step_avg:773.31ms
+step:3075/3300 val_loss:3.29584 train_time:2376.717s step_avg:772.17ms
+step:3100/3300 val_loss:3.29323 train_time:2396.015s step_avg:771.95ms
+step:3125/3300 val_loss:3.29079 train_time:2415.312s step_avg:771.88ms
+step:3150/3300 val_loss:3.28816 train_time:2434.607s step_avg:771.77ms
+step:3175/3300 val_loss:3.28587 train_time:2453.888s step_avg:771.23ms
+step:3200/3300 val_loss:3.28375 train_time:2473.204s step_avg:772.66ms
+step:3225/3300 val_loss:3.28192 train_time:2492.501s step_avg:771.87ms
+step:3250/3300 val_loss:3.28047 train_time:2511.782s step_avg:771.24ms
+step:3275/3300 val_loss:3.27932 train_time:2531.092s step_avg:772.40ms
+step:3300/3300 val_loss:3.27880 train_time:2550.395s step_avg:772.12ms

--- a/records/track_3_optimization/results/20260505_newton_muon/47ca3026-7669-4d75-98f3-324b67a328fc.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/47ca3026-7669-4d75-98f3-324b67a328fc.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.65504 train_time:99.779s step_avg:798.23ms
+step:250/3300 val_loss:4.11536 train_time:196.883s step_avg:776.83ms
+step:375/3300 val_loss:3.92741 train_time:293.932s step_avg:776.39ms
+step:500/3300 val_loss:3.82200 train_time:391.113s step_avg:777.45ms
+step:625/3300 val_loss:3.75288 train_time:488.150s step_avg:776.29ms
+step:750/3300 val_loss:3.70757 train_time:585.087s step_avg:775.49ms
+step:875/3300 val_loss:3.66435 train_time:682.034s step_avg:775.58ms
+step:1000/3300 val_loss:3.62993 train_time:778.992s step_avg:775.67ms
+step:1125/3300 val_loss:3.60267 train_time:875.861s step_avg:774.95ms
+step:1250/3300 val_loss:3.57046 train_time:972.878s step_avg:776.14ms
+step:1375/3300 val_loss:3.54395 train_time:1069.836s step_avg:775.66ms
+step:1500/3300 val_loss:3.51459 train_time:1166.843s step_avg:776.06ms
+step:1625/3300 val_loss:3.49581 train_time:1263.642s step_avg:774.39ms
+step:1750/3300 val_loss:3.47488 train_time:1360.549s step_avg:775.26ms
+step:1875/3300 val_loss:3.45361 train_time:1457.401s step_avg:774.81ms
+step:2000/3300 val_loss:3.43467 train_time:1554.191s step_avg:774.32ms
+step:2125/3300 val_loss:3.41775 train_time:1650.875s step_avg:773.47ms
+step:2250/3300 val_loss:3.39969 train_time:1747.600s step_avg:773.80ms
+step:2375/3300 val_loss:3.38346 train_time:1844.337s step_avg:773.90ms
+step:2500/3300 val_loss:3.36732 train_time:1940.998s step_avg:773.29ms
+step:2625/3300 val_loss:3.35060 train_time:2037.693s step_avg:773.56ms
+step:2750/3300 val_loss:3.33463 train_time:2134.385s step_avg:773.54ms
+step:2875/3300 val_loss:3.31925 train_time:2231.119s step_avg:773.87ms
+step:2975/3300 val_loss:3.30689 train_time:2308.524s step_avg:774.05ms
+step:3000/3300 val_loss:3.30433 train_time:2327.873s step_avg:773.95ms
+step:3025/3300 val_loss:3.30073 train_time:2347.213s step_avg:773.59ms
+step:3050/3300 val_loss:3.29783 train_time:2366.550s step_avg:773.48ms
+step:3075/3300 val_loss:3.29532 train_time:2385.890s step_avg:773.63ms
+step:3100/3300 val_loss:3.29276 train_time:2405.224s step_avg:773.37ms
+step:3125/3300 val_loss:3.29019 train_time:2424.549s step_avg:773.00ms
+step:3150/3300 val_loss:3.28757 train_time:2443.877s step_avg:773.11ms
+step:3175/3300 val_loss:3.28537 train_time:2463.200s step_avg:772.92ms
+step:3200/3300 val_loss:3.28326 train_time:2482.561s step_avg:774.42ms
+step:3225/3300 val_loss:3.28143 train_time:2501.896s step_avg:773.41ms
+step:3250/3300 val_loss:3.27998 train_time:2521.238s step_avg:773.68ms
+step:3275/3300 val_loss:3.27884 train_time:2540.592s step_avg:774.14ms
+step:3300/3300 val_loss:3.27832 train_time:2559.938s step_avg:773.84ms

--- a/records/track_3_optimization/results/20260505_newton_muon/4ab72a5a-d9e3-4405-b662-8fe05dd6be29.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/4ab72a5a-d9e3-4405-b662-8fe05dd6be29.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66445 train_time:99.114s step_avg:792.91ms
+step:250/3300 val_loss:4.11778 train_time:196.056s step_avg:775.54ms
+step:375/3300 val_loss:3.92844 train_time:292.732s step_avg:773.41ms
+step:500/3300 val_loss:3.82612 train_time:389.470s step_avg:773.90ms
+step:625/3300 val_loss:3.75476 train_time:486.270s step_avg:774.40ms
+step:750/3300 val_loss:3.70809 train_time:582.963s step_avg:773.55ms
+step:875/3300 val_loss:3.66671 train_time:679.609s step_avg:773.16ms
+step:1000/3300 val_loss:3.63250 train_time:776.263s step_avg:773.24ms
+step:1125/3300 val_loss:3.60101 train_time:872.905s step_avg:773.13ms
+step:1250/3300 val_loss:3.57166 train_time:969.464s step_avg:772.47ms
+step:1375/3300 val_loss:3.54457 train_time:1066.008s step_avg:772.35ms
+step:1500/3300 val_loss:3.51870 train_time:1162.583s step_avg:772.60ms
+step:1625/3300 val_loss:3.49755 train_time:1259.137s step_avg:772.43ms
+step:1750/3300 val_loss:3.47380 train_time:1355.748s step_avg:772.88ms
+step:1875/3300 val_loss:3.45412 train_time:1452.349s step_avg:772.81ms
+step:2000/3300 val_loss:3.43463 train_time:1548.952s step_avg:772.83ms
+step:2125/3300 val_loss:3.41726 train_time:1645.500s step_avg:772.38ms
+step:2250/3300 val_loss:3.39943 train_time:1742.003s step_avg:772.03ms
+step:2375/3300 val_loss:3.38371 train_time:1838.499s step_avg:771.97ms
+step:2500/3300 val_loss:3.36687 train_time:1935.063s step_avg:772.52ms
+step:2625/3300 val_loss:3.35066 train_time:2031.635s step_avg:772.57ms
+step:2750/3300 val_loss:3.33436 train_time:2128.199s step_avg:772.51ms
+step:2875/3300 val_loss:3.31910 train_time:2224.849s step_avg:773.20ms
+step:2975/3300 val_loss:3.30672 train_time:2302.180s step_avg:773.31ms
+step:3000/3300 val_loss:3.30396 train_time:2321.514s step_avg:773.37ms
+step:3025/3300 val_loss:3.30050 train_time:2340.878s step_avg:774.58ms
+step:3050/3300 val_loss:3.29766 train_time:2360.256s step_avg:775.12ms
+step:3075/3300 val_loss:3.29507 train_time:2379.608s step_avg:774.08ms
+step:3100/3300 val_loss:3.29249 train_time:2398.944s step_avg:773.42ms
+step:3125/3300 val_loss:3.28999 train_time:2418.294s step_avg:773.99ms
+step:3150/3300 val_loss:3.28737 train_time:2437.638s step_avg:773.77ms
+step:3175/3300 val_loss:3.28520 train_time:2456.941s step_avg:772.11ms
+step:3200/3300 val_loss:3.28304 train_time:2476.319s step_avg:775.11ms
+step:3225/3300 val_loss:3.28126 train_time:2495.643s step_avg:772.97ms
+step:3250/3300 val_loss:3.27975 train_time:2514.971s step_avg:773.11ms
+step:3275/3300 val_loss:3.27864 train_time:2534.297s step_avg:773.04ms
+step:3300/3300 val_loss:3.27812 train_time:2553.690s step_avg:775.73ms

--- a/records/track_3_optimization/results/20260505_newton_muon/504191a8-77da-44cb-b619-751e203bcb14.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/504191a8-77da-44cb-b619-751e203bcb14.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66496 train_time:99.134s step_avg:793.07ms
+step:250/3300 val_loss:4.11055 train_time:196.063s step_avg:775.43ms
+step:375/3300 val_loss:3.92798 train_time:292.917s step_avg:774.83ms
+step:500/3300 val_loss:3.82266 train_time:389.771s step_avg:774.83ms
+step:625/3300 val_loss:3.75594 train_time:486.521s step_avg:774.00ms
+step:750/3300 val_loss:3.70546 train_time:583.327s step_avg:774.44ms
+step:875/3300 val_loss:3.66748 train_time:680.077s step_avg:774.01ms
+step:1000/3300 val_loss:3.63084 train_time:776.853s step_avg:774.20ms
+step:1125/3300 val_loss:3.60145 train_time:873.626s step_avg:774.18ms
+step:1250/3300 val_loss:3.56950 train_time:970.381s step_avg:774.04ms
+step:1375/3300 val_loss:3.54396 train_time:1067.076s step_avg:773.56ms
+step:1500/3300 val_loss:3.51674 train_time:1163.787s step_avg:773.69ms
+step:1625/3300 val_loss:3.49623 train_time:1260.527s step_avg:773.92ms
+step:1750/3300 val_loss:3.47377 train_time:1357.286s step_avg:774.07ms
+step:1875/3300 val_loss:3.45398 train_time:1454.118s step_avg:774.66ms
+step:2000/3300 val_loss:3.43469 train_time:1550.913s step_avg:774.35ms
+step:2125/3300 val_loss:3.41722 train_time:1647.560s step_avg:773.18ms
+step:2250/3300 val_loss:3.39949 train_time:1744.279s step_avg:773.75ms
+step:2375/3300 val_loss:3.38386 train_time:1840.962s step_avg:773.47ms
+step:2500/3300 val_loss:3.36756 train_time:1937.686s step_avg:773.79ms
+step:2625/3300 val_loss:3.35072 train_time:2034.453s step_avg:774.13ms
+step:2750/3300 val_loss:3.33481 train_time:2131.306s step_avg:774.83ms
+step:2875/3300 val_loss:3.31933 train_time:2228.073s step_avg:774.14ms
+step:2975/3300 val_loss:3.30693 train_time:2305.467s step_avg:773.94ms
+step:3000/3300 val_loss:3.30417 train_time:2324.818s step_avg:774.05ms
+step:3025/3300 val_loss:3.30060 train_time:2344.174s step_avg:774.22ms
+step:3050/3300 val_loss:3.29790 train_time:2363.552s step_avg:775.14ms
+step:3075/3300 val_loss:3.29528 train_time:2382.950s step_avg:775.91ms
+step:3100/3300 val_loss:3.29263 train_time:2402.308s step_avg:774.33ms
+step:3125/3300 val_loss:3.29033 train_time:2421.653s step_avg:773.80ms
+step:3150/3300 val_loss:3.28759 train_time:2441.036s step_avg:775.32ms
+step:3175/3300 val_loss:3.28546 train_time:2460.381s step_avg:773.81ms
+step:3200/3300 val_loss:3.28333 train_time:2479.758s step_avg:775.07ms
+step:3225/3300 val_loss:3.28150 train_time:2499.134s step_avg:775.06ms
+step:3250/3300 val_loss:3.28003 train_time:2518.516s step_avg:775.27ms
+step:3275/3300 val_loss:3.27888 train_time:2537.917s step_avg:776.03ms
+step:3300/3300 val_loss:3.27837 train_time:2557.275s step_avg:774.33ms

--- a/records/track_3_optimization/results/20260505_newton_muon/5a4e2561-88ad-40bc-ad8a-c284ffab59f0.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/5a4e2561-88ad-40bc-ad8a-c284ffab59f0.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66756 train_time:99.224s step_avg:793.79ms
+step:250/3300 val_loss:4.11203 train_time:196.259s step_avg:776.28ms
+step:375/3300 val_loss:3.93045 train_time:293.191s step_avg:775.46ms
+step:500/3300 val_loss:3.82646 train_time:390.122s step_avg:775.44ms
+step:625/3300 val_loss:3.75738 train_time:487.072s step_avg:775.60ms
+step:750/3300 val_loss:3.71141 train_time:583.852s step_avg:774.24ms
+step:875/3300 val_loss:3.67000 train_time:680.534s step_avg:773.46ms
+step:1000/3300 val_loss:3.63430 train_time:777.203s step_avg:773.35ms
+step:1125/3300 val_loss:3.60713 train_time:873.887s step_avg:773.47ms
+step:1250/3300 val_loss:3.57405 train_time:970.720s step_avg:774.66ms
+step:1375/3300 val_loss:3.54712 train_time:1067.490s step_avg:774.16ms
+step:1500/3300 val_loss:3.51823 train_time:1164.301s step_avg:774.49ms
+step:1625/3300 val_loss:3.49978 train_time:1261.009s step_avg:773.66ms
+step:1750/3300 val_loss:3.47759 train_time:1357.736s step_avg:773.82ms
+step:1875/3300 val_loss:3.45702 train_time:1454.399s step_avg:773.31ms
+step:2000/3300 val_loss:3.43742 train_time:1551.046s step_avg:773.17ms
+step:2125/3300 val_loss:3.42042 train_time:1647.711s step_avg:773.32ms
+step:2250/3300 val_loss:3.40239 train_time:1744.452s step_avg:773.93ms
+step:2375/3300 val_loss:3.38668 train_time:1841.177s step_avg:773.80ms
+step:2500/3300 val_loss:3.37055 train_time:1937.944s step_avg:774.14ms
+step:2625/3300 val_loss:3.35358 train_time:2034.708s step_avg:774.11ms
+step:2750/3300 val_loss:3.33754 train_time:2131.615s step_avg:775.25ms
+step:2875/3300 val_loss:3.32226 train_time:2228.387s step_avg:774.18ms
+step:2975/3300 val_loss:3.30995 train_time:2305.789s step_avg:774.02ms
+step:3000/3300 val_loss:3.30719 train_time:2325.126s step_avg:773.45ms
+step:3025/3300 val_loss:3.30373 train_time:2344.474s step_avg:773.96ms
+step:3050/3300 val_loss:3.30098 train_time:2363.848s step_avg:774.92ms
+step:3075/3300 val_loss:3.29830 train_time:2383.209s step_avg:774.44ms
+step:3100/3300 val_loss:3.29565 train_time:2402.559s step_avg:774.03ms
+step:3125/3300 val_loss:3.29323 train_time:2421.914s step_avg:774.20ms
+step:3150/3300 val_loss:3.29059 train_time:2441.276s step_avg:774.47ms
+step:3175/3300 val_loss:3.28836 train_time:2460.630s step_avg:774.17ms
+step:3200/3300 val_loss:3.28621 train_time:2480.011s step_avg:775.21ms
+step:3225/3300 val_loss:3.28438 train_time:2499.359s step_avg:773.95ms
+step:3250/3300 val_loss:3.28292 train_time:2518.738s step_avg:775.16ms
+step:3275/3300 val_loss:3.28179 train_time:2538.157s step_avg:776.75ms
+step:3300/3300 val_loss:3.28128 train_time:2557.498s step_avg:773.63ms

--- a/records/track_3_optimization/results/20260505_newton_muon/6e3d3a98-1f61-43ba-a858-9d9ce5ec2d3d.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/6e3d3a98-1f61-43ba-a858-9d9ce5ec2d3d.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66808 train_time:99.278s step_avg:794.22ms
+step:250/3300 val_loss:4.11304 train_time:196.256s step_avg:775.82ms
+step:375/3300 val_loss:3.92727 train_time:293.112s step_avg:774.85ms
+step:500/3300 val_loss:3.82113 train_time:390.052s step_avg:775.52ms
+step:625/3300 val_loss:3.75407 train_time:486.966s step_avg:775.31ms
+step:750/3300 val_loss:3.70585 train_time:583.847s step_avg:775.05ms
+step:875/3300 val_loss:3.66490 train_time:680.528s step_avg:773.45ms
+step:1000/3300 val_loss:3.63155 train_time:777.251s step_avg:773.79ms
+step:1125/3300 val_loss:3.60249 train_time:874.023s step_avg:774.17ms
+step:1250/3300 val_loss:3.56916 train_time:970.694s step_avg:773.37ms
+step:1375/3300 val_loss:3.54365 train_time:1067.395s step_avg:773.61ms
+step:1500/3300 val_loss:3.51672 train_time:1164.033s step_avg:773.10ms
+step:1625/3300 val_loss:3.49661 train_time:1260.697s step_avg:773.31ms
+step:1750/3300 val_loss:3.47436 train_time:1357.385s step_avg:773.51ms
+step:1875/3300 val_loss:3.45393 train_time:1454.014s step_avg:773.03ms
+step:2000/3300 val_loss:3.43498 train_time:1550.675s step_avg:773.29ms
+step:2125/3300 val_loss:3.41765 train_time:1647.297s step_avg:772.98ms
+step:2250/3300 val_loss:3.40060 train_time:1743.940s step_avg:773.15ms
+step:2375/3300 val_loss:3.38398 train_time:1840.609s step_avg:773.35ms
+step:2500/3300 val_loss:3.36781 train_time:1937.348s step_avg:773.91ms
+step:2625/3300 val_loss:3.35107 train_time:2034.084s step_avg:773.89ms
+step:2750/3300 val_loss:3.33534 train_time:2130.703s step_avg:772.95ms
+step:2875/3300 val_loss:3.31970 train_time:2227.372s step_avg:773.36ms
+step:2975/3300 val_loss:3.30734 train_time:2304.713s step_avg:773.40ms
+step:3000/3300 val_loss:3.30459 train_time:2324.026s step_avg:772.54ms
+step:3025/3300 val_loss:3.30112 train_time:2343.375s step_avg:773.97ms
+step:3050/3300 val_loss:3.29830 train_time:2362.719s step_avg:773.76ms
+step:3075/3300 val_loss:3.29575 train_time:2382.082s step_avg:774.50ms
+step:3100/3300 val_loss:3.29313 train_time:2401.416s step_avg:773.38ms
+step:3125/3300 val_loss:3.29067 train_time:2420.769s step_avg:774.12ms
+step:3150/3300 val_loss:3.28805 train_time:2440.129s step_avg:774.38ms
+step:3175/3300 val_loss:3.28583 train_time:2459.481s step_avg:774.08ms
+step:3200/3300 val_loss:3.28370 train_time:2478.872s step_avg:775.65ms
+step:3225/3300 val_loss:3.28189 train_time:2498.232s step_avg:774.39ms
+step:3250/3300 val_loss:3.28043 train_time:2517.581s step_avg:773.95ms
+step:3275/3300 val_loss:3.27932 train_time:2536.919s step_avg:773.52ms
+step:3300/3300 val_loss:3.27879 train_time:2556.231s step_avg:772.47ms

--- a/records/track_3_optimization/results/20260505_newton_muon/6fb302c7-d271-491b-906f-75cd6ec72075.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/6fb302c7-d271-491b-906f-75cd6ec72075.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66507 train_time:99.450s step_avg:795.60ms
+step:250/3300 val_loss:4.11784 train_time:196.340s step_avg:775.12ms
+step:375/3300 val_loss:3.92585 train_time:293.120s step_avg:774.23ms
+step:500/3300 val_loss:3.82416 train_time:389.895s step_avg:774.20ms
+step:625/3300 val_loss:3.75223 train_time:486.631s step_avg:773.89ms
+step:750/3300 val_loss:3.70313 train_time:583.287s step_avg:773.25ms
+step:875/3300 val_loss:3.66289 train_time:680.001s step_avg:773.71ms
+step:1000/3300 val_loss:3.62916 train_time:776.722s step_avg:773.77ms
+step:1125/3300 val_loss:3.59959 train_time:873.289s step_avg:772.53ms
+step:1250/3300 val_loss:3.56677 train_time:969.904s step_avg:772.93ms
+step:1375/3300 val_loss:3.54183 train_time:1066.553s step_avg:773.19ms
+step:1500/3300 val_loss:3.51270 train_time:1163.162s step_avg:772.87ms
+step:1625/3300 val_loss:3.49289 train_time:1259.785s step_avg:772.99ms
+step:1750/3300 val_loss:3.47105 train_time:1356.476s step_avg:773.52ms
+step:1875/3300 val_loss:3.45174 train_time:1453.086s step_avg:772.88ms
+step:2000/3300 val_loss:3.43226 train_time:1549.704s step_avg:772.94ms
+step:2125/3300 val_loss:3.41479 train_time:1646.311s step_avg:772.86ms
+step:2250/3300 val_loss:3.39776 train_time:1743.027s step_avg:773.73ms
+step:2375/3300 val_loss:3.38101 train_time:1839.744s step_avg:773.74ms
+step:2500/3300 val_loss:3.36511 train_time:1936.380s step_avg:773.08ms
+step:2625/3300 val_loss:3.34814 train_time:2033.042s step_avg:773.30ms
+step:2750/3300 val_loss:3.33228 train_time:2129.739s step_avg:773.57ms
+step:2875/3300 val_loss:3.31718 train_time:2226.421s step_avg:773.45ms
+step:2975/3300 val_loss:3.30462 train_time:2303.853s step_avg:774.33ms
+step:3000/3300 val_loss:3.30198 train_time:2323.188s step_avg:773.41ms
+step:3025/3300 val_loss:3.29839 train_time:2342.530s step_avg:773.67ms
+step:3050/3300 val_loss:3.29564 train_time:2361.873s step_avg:773.72ms
+step:3075/3300 val_loss:3.29290 train_time:2381.233s step_avg:774.39ms
+step:3100/3300 val_loss:3.29046 train_time:2400.569s step_avg:773.44ms
+step:3125/3300 val_loss:3.28800 train_time:2419.893s step_avg:772.97ms
+step:3150/3300 val_loss:3.28531 train_time:2439.245s step_avg:774.07ms
+step:3175/3300 val_loss:3.28311 train_time:2458.582s step_avg:773.48ms
+step:3200/3300 val_loss:3.28096 train_time:2477.925s step_avg:773.74ms
+step:3225/3300 val_loss:3.27916 train_time:2497.252s step_avg:773.07ms
+step:3250/3300 val_loss:3.27764 train_time:2516.604s step_avg:774.07ms
+step:3275/3300 val_loss:3.27653 train_time:2535.948s step_avg:773.76ms
+step:3300/3300 val_loss:3.27601 train_time:2555.276s step_avg:773.11ms

--- a/records/track_3_optimization/results/20260505_newton_muon/721c4e04-6771-4845-b4de-1dad265408c5.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/721c4e04-6771-4845-b4de-1dad265408c5.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.67400 train_time:99.184s step_avg:793.47ms
+step:250/3300 val_loss:4.10996 train_time:196.038s step_avg:774.84ms
+step:375/3300 val_loss:3.92512 train_time:292.606s step_avg:772.54ms
+step:500/3300 val_loss:3.82213 train_time:389.135s step_avg:772.23ms
+step:625/3300 val_loss:3.75439 train_time:485.785s step_avg:773.20ms
+step:750/3300 val_loss:3.70491 train_time:582.491s step_avg:773.65ms
+step:875/3300 val_loss:3.66500 train_time:678.983s step_avg:771.94ms
+step:1000/3300 val_loss:3.63217 train_time:775.494s step_avg:772.09ms
+step:1125/3300 val_loss:3.60293 train_time:871.988s step_avg:771.95ms
+step:1250/3300 val_loss:3.57045 train_time:968.482s step_avg:771.95ms
+step:1375/3300 val_loss:3.54360 train_time:1064.943s step_avg:771.69ms
+step:1500/3300 val_loss:3.51782 train_time:1161.438s step_avg:771.96ms
+step:1625/3300 val_loss:3.49804 train_time:1258.024s step_avg:772.69ms
+step:1750/3300 val_loss:3.47522 train_time:1354.557s step_avg:772.26ms
+step:1875/3300 val_loss:3.45612 train_time:1451.030s step_avg:771.78ms
+step:2000/3300 val_loss:3.43578 train_time:1547.460s step_avg:771.44ms
+step:2125/3300 val_loss:3.41843 train_time:1643.986s step_avg:772.21ms
+step:2250/3300 val_loss:3.40128 train_time:1740.648s step_avg:773.30ms
+step:2375/3300 val_loss:3.38458 train_time:1837.257s step_avg:772.87ms
+step:2500/3300 val_loss:3.36861 train_time:1933.875s step_avg:772.94ms
+step:2625/3300 val_loss:3.35187 train_time:2030.481s step_avg:772.85ms
+step:2750/3300 val_loss:3.33613 train_time:2127.036s step_avg:772.44ms
+step:2875/3300 val_loss:3.32057 train_time:2223.643s step_avg:772.86ms
+step:2975/3300 val_loss:3.30813 train_time:2300.995s step_avg:773.52ms
+step:3000/3300 val_loss:3.30537 train_time:2320.327s step_avg:773.29ms
+step:3025/3300 val_loss:3.30195 train_time:2339.662s step_avg:773.38ms
+step:3050/3300 val_loss:3.29913 train_time:2358.988s step_avg:773.07ms
+step:3075/3300 val_loss:3.29668 train_time:2378.317s step_avg:773.15ms
+step:3100/3300 val_loss:3.29396 train_time:2397.612s step_avg:771.80ms
+step:3125/3300 val_loss:3.29156 train_time:2416.946s step_avg:773.35ms
+step:3150/3300 val_loss:3.28894 train_time:2436.258s step_avg:772.51ms
+step:3175/3300 val_loss:3.28673 train_time:2455.605s step_avg:773.89ms
+step:3200/3300 val_loss:3.28458 train_time:2474.946s step_avg:773.64ms
+step:3225/3300 val_loss:3.28272 train_time:2494.283s step_avg:773.48ms
+step:3250/3300 val_loss:3.28124 train_time:2513.598s step_avg:772.58ms
+step:3275/3300 val_loss:3.28012 train_time:2532.940s step_avg:773.68ms
+step:3300/3300 val_loss:3.27962 train_time:2552.261s step_avg:772.85ms

--- a/records/track_3_optimization/results/20260505_newton_muon/796dc285-9340-4cfb-b34c-525c72b1a1f0.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/796dc285-9340-4cfb-b34c-525c72b1a1f0.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.67424 train_time:99.869s step_avg:798.95ms
+step:250/3300 val_loss:4.11007 train_time:196.969s step_avg:776.80ms
+step:375/3300 val_loss:3.92450 train_time:293.862s step_avg:775.14ms
+step:500/3300 val_loss:3.82252 train_time:390.783s step_avg:775.37ms
+step:625/3300 val_loss:3.75052 train_time:487.719s step_avg:775.49ms
+step:750/3300 val_loss:3.70572 train_time:584.603s step_avg:775.07ms
+step:875/3300 val_loss:3.66412 train_time:681.475s step_avg:774.98ms
+step:1000/3300 val_loss:3.62863 train_time:778.336s step_avg:774.89ms
+step:1125/3300 val_loss:3.60203 train_time:875.152s step_avg:774.53ms
+step:1250/3300 val_loss:3.56772 train_time:971.954s step_avg:774.42ms
+step:1375/3300 val_loss:3.54229 train_time:1068.795s step_avg:774.73ms
+step:1500/3300 val_loss:3.51303 train_time:1165.607s step_avg:774.49ms
+step:1625/3300 val_loss:3.49502 train_time:1262.450s step_avg:774.75ms
+step:1750/3300 val_loss:3.47144 train_time:1359.304s step_avg:774.83ms
+step:1875/3300 val_loss:3.45260 train_time:1456.092s step_avg:774.30ms
+step:2000/3300 val_loss:3.43326 train_time:1552.913s step_avg:774.57ms
+step:2125/3300 val_loss:3.41560 train_time:1649.712s step_avg:774.39ms
+step:2250/3300 val_loss:3.39801 train_time:1746.522s step_avg:774.48ms
+step:2375/3300 val_loss:3.38181 train_time:1843.375s step_avg:774.83ms
+step:2500/3300 val_loss:3.36559 train_time:1940.197s step_avg:774.57ms
+step:2625/3300 val_loss:3.34873 train_time:2037.039s step_avg:774.74ms
+step:2750/3300 val_loss:3.33304 train_time:2133.772s step_avg:773.86ms
+step:2875/3300 val_loss:3.31735 train_time:2230.536s step_avg:774.11ms
+step:2975/3300 val_loss:3.30501 train_time:2307.969s step_avg:774.33ms
+step:3000/3300 val_loss:3.30246 train_time:2327.320s step_avg:774.03ms
+step:3025/3300 val_loss:3.29887 train_time:2346.692s step_avg:774.88ms
+step:3050/3300 val_loss:3.29613 train_time:2366.042s step_avg:774.00ms
+step:3075/3300 val_loss:3.29346 train_time:2385.410s step_avg:774.75ms
+step:3100/3300 val_loss:3.29090 train_time:2404.778s step_avg:774.71ms
+step:3125/3300 val_loss:3.28848 train_time:2424.160s step_avg:775.25ms
+step:3150/3300 val_loss:3.28579 train_time:2443.542s step_avg:775.31ms
+step:3175/3300 val_loss:3.28356 train_time:2462.896s step_avg:774.16ms
+step:3200/3300 val_loss:3.28150 train_time:2482.280s step_avg:775.35ms
+step:3225/3300 val_loss:3.27957 train_time:2501.637s step_avg:774.28ms
+step:3250/3300 val_loss:3.27811 train_time:2520.990s step_avg:774.13ms
+step:3275/3300 val_loss:3.27698 train_time:2540.363s step_avg:774.90ms
+step:3300/3300 val_loss:3.27644 train_time:2559.762s step_avg:775.97ms

--- a/records/track_3_optimization/results/20260505_newton_muon/README.md
+++ b/records/track_3_optimization/results/20260505_newton_muon/README.md
@@ -1,0 +1,82 @@
+# Newton-Muon, 3275 Steps
+
+This directory contains a first valid Track 3 benchmark result for
+[Newton-Muon](https://arxiv.org/abs/2604.01472). This is a per-optimizer result
+rather than a global SOTA claim.
+
+The submitted runs were launched with `train_steps = 3300` and logged validation
+every 25 steps near the end of training. The earliest shared checkpoint that
+passes the Track 3 significance rule is step 3275.
+
+## Method
+
+[Newton-Muon](https://arxiv.org/abs/2604.01472) starts from Muon with auxiliary
+AdamW. Before the Newton-Schulz Muon update, hidden-matrix gradients are
+right-preconditioned with activation covariance statistics collected by forward
+hooks. The covariance inverse is refreshed every 64 steps, then the
+preconditioned gradients are passed through the usual Muon momentum and
+Newton-Schulz update.
+
+Matrix hyperparameters:
+
+| group | lr | wd |
+|---|---:|---:|
+| q/k/v | 0.020 | 0.025 |
+| attn.proj | 0.025 | 0.025 |
+| mlp.fc | 0.030 | 0.0375 |
+| mlp.proj | 0.030 | 0.025 |
+
+Auxiliary AdamW, dataset, batch size, architecture, and validation setup are
+unchanged from the Track 3 baseline.
+
+Compute for this result was limited, so this should be treated as a first valid
+baseline. More compute and hyperparameter search may lead to better results.
+
+## Reliability
+
+15 completed non-cherry-picked runs at K=3275:
+
+| log | val loss at 3275 | val loss at 3300 |
+|---|---:|---:|
+| `fcb92725-9ecf-4aec-a9ca-07639f075a10.txt` | 3.27831 | 3.27782 |
+| `adbec91d-e18e-448b-9c4e-17245e4c3035.txt` | 3.27819 | 3.27770 |
+| `5a4e2561-88ad-40bc-ad8a-c284ffab59f0.txt` | 3.28179 | 3.28128 |
+| `e53164a8-cf85-47f1-a43b-6075273ffed0.txt` | 3.27699 | 3.27648 |
+| `012451d9-a8dc-4383-9ca5-d0c45648d85c.txt` | 3.27847 | 3.27795 |
+| `47ca3026-7669-4d75-98f3-324b67a328fc.txt` | 3.27884 | 3.27832 |
+| `796dc285-9340-4cfb-b34c-525c72b1a1f0.txt` | 3.27698 | 3.27644 |
+| `504191a8-77da-44cb-b619-751e203bcb14.txt` | 3.27888 | 3.27837 |
+| `4ab72a5a-d9e3-4405-b662-8fe05dd6be29.txt` | 3.27864 | 3.27812 |
+| `d9d42e73-09da-44ab-9c20-cd2928873f8f.txt` | 3.27709 | 3.27659 |
+| `6fb302c7-d271-491b-906f-75cd6ec72075.txt` | 3.27653 | 3.27601 |
+| `1e2209a6-95dc-4daa-b688-284e6f0f173e.txt` | 3.27932 | 3.27880 |
+| `721c4e04-6771-4845-b4de-1dad265408c5.txt` | 3.28012 | 3.27962 |
+| `6e3d3a98-1f61-43ba-a858-9d9ce5ec2d3d.txt` | 3.27932 | 3.27879 |
+| `c844e66f-2b2e-4f8e-b47f-d8e11ec5cb65.txt` | 3.27826 | 3.27775 |
+| **mean** | **3.27851533** | **3.27800267** |
+
+Sample std at K=3275: `0.00135540`.
+
+Track 3 significance rule:
+
+```text
+(3.28 - 3.27851533) * sqrt(15) = 0.00575009 >= 0.004
+```
+
+## Rules
+
+- Dataset, batch size, architecture, and validation setup are unchanged from
+  the Track 3 baseline.
+- The trainer uses one forward/backward pass per step. Activation covariance
+  statistics are collected by forward hooks during the same forward pass.
+- No third-party optimizer library is imported; the optimizer code is inline in
+  each logfile.
+- The submitted stopping point is the shared K=3275 checkpoint for all 15
+  completed runs. The runs were launched to 3300 steps, and no per-run
+  val-loss early stopping was used.
+
+## Files
+
+The UUID-named `.txt` files are the full-source logfiles. The representative
+script `train_gpt_simple_newton_muon.py` is copied from the run script used
+to produce the logs.

--- a/records/track_3_optimization/results/20260505_newton_muon/adbec91d-e18e-448b-9c4e-17245e4c3035.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/adbec91d-e18e-448b-9c4e-17245e4c3035.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66761 train_time:99.190s step_avg:793.52ms
+step:250/3300 val_loss:4.10500 train_time:196.201s step_avg:776.09ms
+step:375/3300 val_loss:3.92599 train_time:293.097s step_avg:775.17ms
+step:500/3300 val_loss:3.82193 train_time:390.020s step_avg:775.38ms
+step:625/3300 val_loss:3.75364 train_time:486.907s step_avg:775.10ms
+step:750/3300 val_loss:3.70468 train_time:583.821s step_avg:775.31ms
+step:875/3300 val_loss:3.66493 train_time:680.680s step_avg:774.86ms
+step:1000/3300 val_loss:3.62924 train_time:777.522s step_avg:774.74ms
+step:1125/3300 val_loss:3.60158 train_time:874.272s step_avg:774.00ms
+step:1250/3300 val_loss:3.56934 train_time:971.016s step_avg:773.95ms
+step:1375/3300 val_loss:3.54278 train_time:1067.750s step_avg:773.87ms
+step:1500/3300 val_loss:3.51515 train_time:1164.519s step_avg:774.16ms
+step:1625/3300 val_loss:3.49393 train_time:1261.295s step_avg:774.20ms
+step:1750/3300 val_loss:3.47348 train_time:1358.071s step_avg:774.21ms
+step:1875/3300 val_loss:3.45275 train_time:1454.828s step_avg:774.06ms
+step:2000/3300 val_loss:3.43331 train_time:1551.609s step_avg:774.25ms
+step:2125/3300 val_loss:3.41617 train_time:1648.506s step_avg:775.18ms
+step:2250/3300 val_loss:3.39919 train_time:1745.287s step_avg:774.25ms
+step:2375/3300 val_loss:3.38300 train_time:1842.065s step_avg:774.22ms
+step:2500/3300 val_loss:3.36639 train_time:1938.863s step_avg:774.39ms
+step:2625/3300 val_loss:3.34978 train_time:2035.596s step_avg:773.86ms
+step:2750/3300 val_loss:3.33417 train_time:2132.388s step_avg:774.34ms
+step:2875/3300 val_loss:3.31851 train_time:2229.188s step_avg:774.40ms
+step:2975/3300 val_loss:3.30637 train_time:2306.570s step_avg:773.82ms
+step:3000/3300 val_loss:3.30357 train_time:2325.915s step_avg:773.81ms
+step:3025/3300 val_loss:3.30007 train_time:2345.275s step_avg:774.42ms
+step:3050/3300 val_loss:3.29729 train_time:2364.634s step_avg:774.34ms
+step:3075/3300 val_loss:3.29456 train_time:2384.009s step_avg:775.03ms
+step:3100/3300 val_loss:3.29201 train_time:2403.382s step_avg:774.92ms
+step:3125/3300 val_loss:3.28958 train_time:2422.716s step_avg:773.33ms
+step:3150/3300 val_loss:3.28691 train_time:2442.152s step_avg:777.47ms
+step:3175/3300 val_loss:3.28470 train_time:2461.521s step_avg:774.74ms
+step:3200/3300 val_loss:3.28262 train_time:2480.884s step_avg:774.53ms
+step:3225/3300 val_loss:3.28077 train_time:2500.238s step_avg:774.15ms
+step:3250/3300 val_loss:3.27931 train_time:2519.601s step_avg:774.52ms
+step:3275/3300 val_loss:3.27819 train_time:2538.964s step_avg:774.54ms
+step:3300/3300 val_loss:3.27770 train_time:2558.339s step_avg:775.00ms

--- a/records/track_3_optimization/results/20260505_newton_muon/c844e66f-2b2e-4f8e-b47f-d8e11ec5cb65.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/c844e66f-2b2e-4f8e-b47f-d8e11ec5cb65.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66405 train_time:99.005s step_avg:792.04ms
+step:250/3300 val_loss:4.11299 train_time:195.747s step_avg:773.93ms
+step:375/3300 val_loss:3.93088 train_time:292.341s step_avg:772.76ms
+step:500/3300 val_loss:3.82254 train_time:388.948s step_avg:772.86ms
+step:625/3300 val_loss:3.75330 train_time:485.507s step_avg:772.47ms
+step:750/3300 val_loss:3.70498 train_time:582.077s step_avg:772.56ms
+step:875/3300 val_loss:3.66617 train_time:678.740s step_avg:773.31ms
+step:1000/3300 val_loss:3.63007 train_time:775.319s step_avg:772.63ms
+step:1125/3300 val_loss:3.60020 train_time:871.823s step_avg:772.03ms
+step:1250/3300 val_loss:3.56911 train_time:968.325s step_avg:772.01ms
+step:1375/3300 val_loss:3.54266 train_time:1064.829s step_avg:772.04ms
+step:1500/3300 val_loss:3.51499 train_time:1161.719s step_avg:775.11ms
+step:1625/3300 val_loss:3.49505 train_time:1258.210s step_avg:771.93ms
+step:1750/3300 val_loss:3.47286 train_time:1354.653s step_avg:771.55ms
+step:1875/3300 val_loss:3.45379 train_time:1451.140s step_avg:771.89ms
+step:2000/3300 val_loss:3.43420 train_time:1547.622s step_avg:771.85ms
+step:2125/3300 val_loss:3.41644 train_time:1644.118s step_avg:771.97ms
+step:2250/3300 val_loss:3.39934 train_time:1740.616s step_avg:771.98ms
+step:2375/3300 val_loss:3.38324 train_time:1837.236s step_avg:772.96ms
+step:2500/3300 val_loss:3.36658 train_time:1933.811s step_avg:772.60ms
+step:2625/3300 val_loss:3.35017 train_time:2030.288s step_avg:771.82ms
+step:2750/3300 val_loss:3.33421 train_time:2126.756s step_avg:771.75ms
+step:2875/3300 val_loss:3.31869 train_time:2223.291s step_avg:772.28ms
+step:2975/3300 val_loss:3.30641 train_time:2300.525s step_avg:772.33ms
+step:3000/3300 val_loss:3.30382 train_time:2319.822s step_avg:771.88ms
+step:3025/3300 val_loss:3.30018 train_time:2339.136s step_avg:772.56ms
+step:3050/3300 val_loss:3.29738 train_time:2358.438s step_avg:772.10ms
+step:3075/3300 val_loss:3.29474 train_time:2377.751s step_avg:772.53ms
+step:3100/3300 val_loss:3.29213 train_time:2397.045s step_avg:771.73ms
+step:3125/3300 val_loss:3.28983 train_time:2416.364s step_avg:772.79ms
+step:3150/3300 val_loss:3.28707 train_time:2435.678s step_avg:772.53ms
+step:3175/3300 val_loss:3.28485 train_time:2454.972s step_avg:771.78ms
+step:3200/3300 val_loss:3.28271 train_time:2474.278s step_avg:772.25ms
+step:3225/3300 val_loss:3.28086 train_time:2493.567s step_avg:771.55ms
+step:3250/3300 val_loss:3.27937 train_time:2512.875s step_avg:772.30ms
+step:3275/3300 val_loss:3.27826 train_time:2532.303s step_avg:777.13ms
+step:3300/3300 val_loss:3.27775 train_time:2551.603s step_avg:772.02ms

--- a/records/track_3_optimization/results/20260505_newton_muon/d9d42e73-09da-44ab-9c20-cd2928873f8f.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/d9d42e73-09da-44ab-9c20-cd2928873f8f.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.66514 train_time:99.407s step_avg:795.26ms
+step:250/3300 val_loss:4.10948 train_time:196.517s step_avg:776.87ms
+step:375/3300 val_loss:3.92640 train_time:293.554s step_avg:776.30ms
+step:500/3300 val_loss:3.82187 train_time:390.536s step_avg:775.86ms
+step:625/3300 val_loss:3.74916 train_time:487.438s step_avg:775.22ms
+step:750/3300 val_loss:3.70360 train_time:584.317s step_avg:775.03ms
+step:875/3300 val_loss:3.66345 train_time:681.184s step_avg:774.93ms
+step:1000/3300 val_loss:3.63138 train_time:778.004s step_avg:774.56ms
+step:1125/3300 val_loss:3.60088 train_time:874.779s step_avg:774.20ms
+step:1250/3300 val_loss:3.56731 train_time:971.557s step_avg:774.22ms
+step:1375/3300 val_loss:3.54257 train_time:1068.301s step_avg:773.95ms
+step:1500/3300 val_loss:3.51402 train_time:1165.034s step_avg:773.87ms
+step:1625/3300 val_loss:3.49363 train_time:1261.723s step_avg:773.51ms
+step:1750/3300 val_loss:3.47330 train_time:1358.436s step_avg:773.70ms
+step:1875/3300 val_loss:3.45199 train_time:1455.107s step_avg:773.37ms
+step:2000/3300 val_loss:3.43310 train_time:1551.743s step_avg:773.09ms
+step:2125/3300 val_loss:3.41504 train_time:1648.332s step_avg:772.71ms
+step:2250/3300 val_loss:3.39821 train_time:1745.028s step_avg:773.57ms
+step:2375/3300 val_loss:3.38198 train_time:1841.779s step_avg:774.01ms
+step:2500/3300 val_loss:3.36563 train_time:1938.500s step_avg:773.76ms
+step:2625/3300 val_loss:3.34876 train_time:2035.152s step_avg:773.22ms
+step:2750/3300 val_loss:3.33302 train_time:2131.756s step_avg:772.83ms
+step:2875/3300 val_loss:3.31784 train_time:2228.394s step_avg:773.11ms
+step:2975/3300 val_loss:3.30525 train_time:2305.729s step_avg:773.35ms
+step:3000/3300 val_loss:3.30255 train_time:2325.058s step_avg:773.15ms
+step:3025/3300 val_loss:3.29899 train_time:2344.424s step_avg:774.62ms
+step:3050/3300 val_loss:3.29624 train_time:2363.761s step_avg:773.50ms
+step:3075/3300 val_loss:3.29350 train_time:2383.106s step_avg:773.80ms
+step:3100/3300 val_loss:3.29088 train_time:2402.442s step_avg:773.43ms
+step:3125/3300 val_loss:3.28848 train_time:2421.768s step_avg:773.04ms
+step:3150/3300 val_loss:3.28584 train_time:2441.130s step_avg:774.49ms
+step:3175/3300 val_loss:3.28371 train_time:2460.469s step_avg:773.56ms
+step:3200/3300 val_loss:3.28160 train_time:2479.841s step_avg:774.86ms
+step:3225/3300 val_loss:3.27968 train_time:2499.171s step_avg:773.22ms
+step:3250/3300 val_loss:3.27823 train_time:2518.492s step_avg:772.82ms
+step:3275/3300 val_loss:3.27709 train_time:2537.847s step_avg:774.19ms
+step:3300/3300 val_loss:3.27659 train_time:2557.187s step_avg:773.62ms

--- a/records/track_3_optimization/results/20260505_newton_muon/e53164a8-cf85-47f1-a43b-6075273ffed0.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/e53164a8-cf85-47f1-a43b-6075273ffed0.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.67845 train_time:99.408s step_avg:795.26ms
+step:250/3300 val_loss:4.10925 train_time:196.468s step_avg:776.48ms
+step:375/3300 val_loss:3.92474 train_time:293.368s step_avg:775.20ms
+step:500/3300 val_loss:3.81901 train_time:390.267s step_avg:775.20ms
+step:625/3300 val_loss:3.75211 train_time:487.108s step_avg:774.73ms
+step:750/3300 val_loss:3.70575 train_time:583.945s step_avg:774.70ms
+step:875/3300 val_loss:3.66421 train_time:680.821s step_avg:775.01ms
+step:1000/3300 val_loss:3.62938 train_time:777.753s step_avg:775.46ms
+step:1125/3300 val_loss:3.60100 train_time:874.644s step_avg:775.13ms
+step:1250/3300 val_loss:3.56782 train_time:971.582s step_avg:775.50ms
+step:1375/3300 val_loss:3.54099 train_time:1068.392s step_avg:774.48ms
+step:1500/3300 val_loss:3.51530 train_time:1165.213s step_avg:774.57ms
+step:1625/3300 val_loss:3.49363 train_time:1262.038s step_avg:774.60ms
+step:1750/3300 val_loss:3.47254 train_time:1358.824s step_avg:774.29ms
+step:1875/3300 val_loss:3.45192 train_time:1455.618s step_avg:774.35ms
+step:2000/3300 val_loss:3.43285 train_time:1552.619s step_avg:776.01ms
+step:2125/3300 val_loss:3.41544 train_time:1649.482s step_avg:774.90ms
+step:2250/3300 val_loss:3.39807 train_time:1746.300s step_avg:774.55ms
+step:2375/3300 val_loss:3.38170 train_time:1843.078s step_avg:774.22ms
+step:2500/3300 val_loss:3.36563 train_time:1939.793s step_avg:773.73ms
+step:2625/3300 val_loss:3.34890 train_time:2036.573s step_avg:774.24ms
+step:2750/3300 val_loss:3.33302 train_time:2133.319s step_avg:773.97ms
+step:2875/3300 val_loss:3.31741 train_time:2230.045s step_avg:773.81ms
+step:2975/3300 val_loss:3.30519 train_time:2307.470s step_avg:774.25ms
+step:3000/3300 val_loss:3.30242 train_time:2326.821s step_avg:774.05ms
+step:3025/3300 val_loss:3.29883 train_time:2346.201s step_avg:775.19ms
+step:3050/3300 val_loss:3.29602 train_time:2365.552s step_avg:774.06ms
+step:3075/3300 val_loss:3.29332 train_time:2384.932s step_avg:775.17ms
+step:3100/3300 val_loss:3.29084 train_time:2404.272s step_avg:773.60ms
+step:3125/3300 val_loss:3.28840 train_time:2423.637s step_avg:774.62ms
+step:3150/3300 val_loss:3.28570 train_time:2443.043s step_avg:776.25ms
+step:3175/3300 val_loss:3.28357 train_time:2462.434s step_avg:775.63ms
+step:3200/3300 val_loss:3.28144 train_time:2481.821s step_avg:775.46ms
+step:3225/3300 val_loss:3.27959 train_time:2501.192s step_avg:774.84ms
+step:3250/3300 val_loss:3.27815 train_time:2520.603s step_avg:776.44ms
+step:3275/3300 val_loss:3.27699 train_time:2540.020s step_avg:776.71ms
+step:3300/3300 val_loss:3.27648 train_time:2559.395s step_avg:774.99ms

--- a/records/track_3_optimization/results/20260505_newton_muon/fcb92725-9ecf-4aec-a9ca-07639f075a10.txt
+++ b/records/track_3_optimization/results/20260505_newton_muon/fcb92725-9ecf-4aec-a9ca-07639f075a10.txt
@@ -1,0 +1,585 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 NVL with world_size 2
+====================================================================================================
+step:0/3300 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3300 val_loss:4.65293 train_time:99.165s step_avg:793.32ms
+step:250/3300 val_loss:4.11372 train_time:196.176s step_avg:776.09ms
+step:375/3300 val_loss:3.92798 train_time:293.054s step_avg:775.03ms
+step:500/3300 val_loss:3.82263 train_time:389.927s step_avg:774.98ms
+step:625/3300 val_loss:3.75125 train_time:486.715s step_avg:774.30ms
+step:750/3300 val_loss:3.70706 train_time:583.567s step_avg:774.82ms
+step:875/3300 val_loss:3.66711 train_time:680.378s step_avg:774.49ms
+step:1000/3300 val_loss:3.63141 train_time:777.231s step_avg:774.82ms
+step:1125/3300 val_loss:3.60201 train_time:874.111s step_avg:775.04ms
+step:1250/3300 val_loss:3.57069 train_time:970.991s step_avg:775.04ms
+step:1375/3300 val_loss:3.54449 train_time:1067.780s step_avg:774.31ms
+step:1500/3300 val_loss:3.51569 train_time:1164.557s step_avg:774.21ms
+step:1625/3300 val_loss:3.49606 train_time:1261.313s step_avg:774.05ms
+step:1750/3300 val_loss:3.47447 train_time:1358.073s step_avg:774.08ms
+step:1875/3300 val_loss:3.45332 train_time:1454.815s step_avg:773.93ms
+step:2000/3300 val_loss:3.43461 train_time:1551.596s step_avg:774.25ms
+step:2125/3300 val_loss:3.41763 train_time:1648.313s step_avg:773.73ms
+step:2250/3300 val_loss:3.39946 train_time:1745.041s step_avg:773.82ms
+step:2375/3300 val_loss:3.38331 train_time:1841.722s step_avg:773.45ms
+step:2500/3300 val_loss:3.36723 train_time:1938.408s step_avg:773.49ms
+step:2625/3300 val_loss:3.35015 train_time:2035.090s step_avg:773.45ms
+step:2750/3300 val_loss:3.33437 train_time:2131.780s step_avg:773.53ms
+step:2875/3300 val_loss:3.31861 train_time:2228.498s step_avg:773.74ms
+step:2975/3300 val_loss:3.30649 train_time:2305.914s step_avg:774.16ms
+step:3000/3300 val_loss:3.30372 train_time:2325.250s step_avg:773.43ms
+step:3025/3300 val_loss:3.30028 train_time:2344.605s step_avg:774.19ms
+step:3050/3300 val_loss:3.29744 train_time:2363.970s step_avg:774.60ms
+step:3075/3300 val_loss:3.29480 train_time:2383.318s step_avg:773.92ms
+step:3100/3300 val_loss:3.29218 train_time:2402.655s step_avg:773.48ms
+step:3125/3300 val_loss:3.28974 train_time:2421.997s step_avg:773.69ms
+step:3150/3300 val_loss:3.28712 train_time:2441.363s step_avg:774.63ms
+step:3175/3300 val_loss:3.28489 train_time:2460.703s step_avg:773.61ms
+step:3200/3300 val_loss:3.28275 train_time:2480.075s step_avg:774.88ms
+step:3225/3300 val_loss:3.28092 train_time:2499.427s step_avg:774.07ms
+step:3250/3300 val_loss:3.27945 train_time:2518.776s step_avg:773.97ms
+step:3275/3300 val_loss:3.27831 train_time:2538.140s step_avg:774.57ms
+step:3300/3300 val_loss:3.27782 train_time:2557.485s step_avg:773.79ms

--- a/records/track_3_optimization/results/20260505_newton_muon/train_gpt_simple_newton_muon.py
+++ b/records/track_3_optimization/results/20260505_newton_muon/train_gpt_simple_newton_muon.py
@@ -1,0 +1,543 @@
+"""
+train_gpt_simple_newton_muon.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+@torch.compiler.disable
+@torch.no_grad()
+def accum_xtx_(x: Tensor, accum: Tensor, count: Tensor):
+    x = x.detach().flatten(0, -2).float()
+    if accum.ndim == 2:
+        accum.add_(x.T @ x, alpha=1 / x.size(0))
+    else:
+        n, d = x.size(0), accum.size(-1)
+        x = x.reshape(n, 4, d).permute(1, 2, 0)
+        accum.add_(torch.bmm(x, x.mT), alpha=1 / n)
+    count.add_(1)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+        self.register_buffer("qkv_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("qkv_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("o_xtx", torch.zeros(hdim, hdim, dtype=torch.float32), persistent=False)
+        self.register_buffer("o_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.register_buffer("fc_xtx", torch.zeros(dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("fc_count", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_xtx", torch.zeros(4, dim, dim, dtype=torch.float32), persistent=False)
+        self.register_buffer("proj_count", torch.zeros((), dtype=torch.float32), persistent=False)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+def attach_precond_stats(model: GPT):
+    for block in model.blocks:
+        a, m = block.attn, block.mlp
+        qkv = dict(accum=a.qkv_xtx, count=a.qkv_count)
+        for mod, ref in ((a.q, qkv), (a.k, qkv), (a.v, qkv),
+                         (a.proj, dict(accum=a.o_xtx, count=a.o_count)),
+                         (m.fc, dict(accum=m.fc_xtx, count=m.fc_count)),
+                         (m.proj, dict(accum=m.proj_xtx, count=m.proj_count))):
+            mod.weight._stats_ref = ref
+
+@torch.compiler.disable
+def precond_stat_hook(module, inputs, output):
+    ref = module.weight._stats_ref
+    accum_xtx_(inputs[0], ref["accum"], ref["count"])
+
+def enable_precond_hooks(model: GPT):
+    return [m.register_forward_hook(precond_stat_hook)
+            for b in model.blocks for m in (b.attn.q, b.attn.proj, b.mlp.fc, b.mlp.proj)]
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95, refresh_interval=64):
+        assert isinstance(params, list) and len(params) >= 1
+        if isinstance(params[0], torch.nn.Parameter):
+            params = sorted(params, key=lambda x: x.size(), reverse=True)
+        else:
+            assert isinstance(params[0], dict)
+            params = [dict(group, params=sorted(list(group["params"]), key=lambda x: x.size(), reverse=True))
+                      for group in params]
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.global_step = 0
+        self._precond_attached = self._precond_has_inv = False
+        self._precond_stats = []
+        self._precond_K = self._precond_count = None
+        self._precond_cov = None
+        self._precond_matrix_stat_idx = None
+        self._precond_matrix_count = self._precond_matrix_count_clamped = None
+        self._precond_alpha = None
+        self.refresh_interval = refresh_interval
+
+    @staticmethod
+    def _eye_(x, value):
+        x.zero_()
+        x.diagonal(dim1=-2, dim2=-1).fill_(value)
+
+    @torch.no_grad()
+    def attach_preconditioner(self):
+        self._precond_attached = True
+        stats = {}
+        for group in self.param_groups:
+            for p in group["params"]:
+                ref = getattr(p, "_stats_ref", None)
+                assert ref is not None, f"Missing preconditioner stats for parameter {tuple(p.shape)}"
+                key = id(ref["accum"])
+                if key not in stats:
+                    stats[key] = dict(accum=ref["accum"], count=ref["count"])
+                self.state[p]["precond"] = stats[key]
+        self._precond_stats = list(stats.values())
+        d = self._precond_stats[0]["accum"].size(-1)
+        n_by_stat = [s["accum"].numel() // (d * d) for s in self._precond_stats]
+        n = sum(n_by_stat)
+        device = self._precond_stats[0]["accum"].device
+        self._precond_K = torch.empty(n, d, d, device=device)
+        self._precond_cov = torch.empty_like(self._precond_K)
+        self._precond_count = torch.empty(len(self._precond_stats), device=device)
+        self._precond_matrix_count = torch.empty(n, device=device)
+        self._precond_matrix_count_clamped = torch.empty(n, device=device)
+        self._precond_matrix_stat_idx = torch.repeat_interleave(
+            torch.arange(len(self._precond_stats), device=device),
+            torch.tensor(n_by_stat, device=device),
+        )
+        self._precond_alpha = torch.empty(n, 1, 1, device=device)
+        i = 0
+        for s, stat_n in zip(self._precond_stats, n_by_stat):
+            s["n"] = stat_n
+            s["cov"] = self._precond_cov[i:i+stat_n].reshape_as(s["accum"])
+            s["inv"] = self._precond_K[i:i+stat_n].reshape_as(s["accum"])
+            self._eye_(s["cov"], 0.001)
+            self._eye_(s["inv"], 1.0)
+            s["accum"].zero_()
+            s["count"].zero_()
+            i += stat_n
+
+    def precond_flag_for_step(self, step: int):
+        return self._precond_attached and (int(step) + 1) % self.refresh_interval == 0
+
+    @torch.no_grad()
+    def _refresh_preconditioner(self):
+        K, d, i = self._precond_K, self._precond_K.size(-1), 0
+        for j, s in enumerate(self._precond_stats):
+            n = s["n"]
+            K[i:i+n].copy_(s["accum"].reshape(n, d, d))
+            self._precond_count[j].copy_(s["count"])
+            i += n
+        dist.all_reduce(K, op=dist.ReduceOp.SUM)
+        dist.all_reduce(self._precond_count, op=dist.ReduceOp.SUM)
+
+        torch.index_select(self._precond_count, 0, self._precond_matrix_stat_idx, out=self._precond_matrix_count)
+        self._precond_matrix_count_clamped.copy_(self._precond_matrix_count).clamp_min_(1)
+        K.div_(self._precond_matrix_count_clamped.view(-1, 1, 1))
+        self._precond_alpha.copy_(self._precond_matrix_count.gt(0).view(-1, 1, 1)).mul_(0.05)
+        self._precond_cov.lerp_(K, self._precond_alpha)
+
+        diag = self._precond_cov.diagonal(dim1=-2, dim2=-1)
+        reg = (diag.sum(-1) / d * 0.2 + 1e-8).unsqueeze(-1)
+        diag.add_(reg)
+        L, info = torch.linalg.cholesky_ex(self._precond_cov, upper=False, check_errors=False)
+        diag.sub_(reg)
+        torch.cholesky_inverse(L, upper=False, out=K)
+        if info.any():
+            self._eye_(K[info != 0], 1.0)
+
+        for s in self._precond_stats:
+            s["accum"].zero_()
+            s["count"].zero_()
+        self._precond_has_inv = True
+
+    @torch.no_grad()
+    def _precondition_grads(self):
+        if not self._precond_has_inv:
+            return
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.float()
+                if grad is not p.grad:
+                    p.grad = grad
+                inv = self.state[p]["precond"]["inv"]
+                if inv.ndim == 3:
+                    d = inv.size(-1)
+                    g = grad.view(grad.size(0), 4, d).permute(1, 0, 2)
+                    p.grad.copy_(torch.bmm(g, inv).permute(1, 0, 2).reshape_as(p.grad))
+                else:
+                    p.grad.copy_(grad @ inv)
+
+    @torch.no_grad()
+    def step(self):
+        if self._precond_attached and self.precond_flag_for_step(self.global_step):
+            self._refresh_preconditioner()
+        if self._precond_attached:
+            self._precondition_grads()
+
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if "momentum" not in state:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.global_step += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+attach_precond_stats(model)
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3300
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    named_block_params = [(n, p) for n, p in model.named_parameters()
+                          if n.startswith("blocks.") and p.ndim >= 2]
+    qkv_params = [p for n, p in named_block_params
+                  if n.endswith(".attn.q.weight") or n.endswith(".attn.k.weight") or n.endswith(".attn.v.weight")]
+    attn_out_params = [p for n, p in named_block_params if n.endswith(".attn.proj.weight")]
+    mlp_fc_params = [p for n, p in named_block_params if n.endswith(".mlp.fc.weight")]
+    mlp_proj_params = [p for n, p in named_block_params if n.endswith(".mlp.proj.weight")]
+    optimizer2 = Muon([dict(params=qkv_params, lr=0.020, weight_decay=0.025),
+                       dict(params=attn_out_params, lr=0.025, weight_decay=0.025),
+                       dict(params=mlp_fc_params, lr=0.030, weight_decay=0.0375),
+                       dict(params=mlp_proj_params, lr=0.030, weight_decay=0.025)],
+                      refresh_interval=64)
+    optimizer2.attach_preconditioner()
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        optimizer2.global_step = step
+        precond_hooks = enable_precond_hooks(model) if optimizer2.precond_flag_for_step(step) else []
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for h in precond_hooks:
+            h.remove()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()


### PR DESCRIPTION
# Add first valid benchmark result for vanilla Newton-Muon on track_3_optimization: 3275 steps

## Summary

Adds the first valid Track 3 benchmark result for **Newton-Muon**. This is a per-optimizer result, not a global SOTA claim.

Newton-Muon reaches the 3.28 target at **3275 steps** across 15 completed non-cherry-picked runs.

Our compute for this result was limited, so this should be treated as a first valid baseline. More compute and hyperparameter search may lead to better results.

## Method

[Newton-Muon](https://arxiv.org/abs/2604.01472) starts from Muon with auxiliary AdamW. Before the Newton-Schulz Muon update, hidden-matrix gradients are right-preconditioned using activation covariance statistics collected by forward hooks. The covariance inverse is refreshed every 64 steps, then the preconditioned gradients are passed through the usual Muon momentum and Newton-Schulz update.

Matrix hyperparameters:

| group | lr | wd |
|---|---:|---:|
| q/k/v | 0.020 | 0.025 |
| attn.proj | 0.025 | 0.025 |
| mlp.fc | 0.030 | 0.0375 |
| mlp.proj | 0.030 | 0.025 |

Auxiliary AdamW, dataset, batch size, architecture, and validation setup are unchanged from the Track 3 baseline.

## Reliability

15 completed non-cherry-picked runs at K=3275:

| log | val loss at 3275 | val loss at 3300 |
|---|---:|---:|
| `fcb92725-9ecf-4aec-a9ca-07639f075a10.txt` | 3.27831 | 3.27782 |
| `adbec91d-e18e-448b-9c4e-17245e4c3035.txt` | 3.27819 | 3.27770 |
| `5a4e2561-88ad-40bc-ad8a-c284ffab59f0.txt` | 3.28179 | 3.28128 |
| `e53164a8-cf85-47f1-a43b-6075273ffed0.txt` | 3.27699 | 3.27648 |
| `012451d9-a8dc-4383-9ca5-d0c45648d85c.txt` | 3.27847 | 3.27795 |
| `47ca3026-7669-4d75-98f3-324b67a328fc.txt` | 3.27884 | 3.27832 |
| `796dc285-9340-4cfb-b34c-525c72b1a1f0.txt` | 3.27698 | 3.27644 |
| `504191a8-77da-44cb-b619-751e203bcb14.txt` | 3.27888 | 3.27837 |
| `4ab72a5a-d9e3-4405-b662-8fe05dd6be29.txt` | 3.27864 | 3.27812 |
| `d9d42e73-09da-44ab-9c20-cd2928873f8f.txt` | 3.27709 | 3.27659 |
| `6fb302c7-d271-491b-906f-75cd6ec72075.txt` | 3.27653 | 3.27601 |
| `1e2209a6-95dc-4daa-b688-284e6f0f173e.txt` | 3.27932 | 3.27880 |
| `721c4e04-6771-4845-b4de-1dad265408c5.txt` | 3.28012 | 3.27962 |
| `6e3d3a98-1f61-43ba-a858-9d9ce5ec2d3d.txt` | 3.27932 | 3.27879 |
| `c844e66f-2b2e-4f8e-b47f-d8e11ec5cb65.txt` | 3.27826 | 3.27775 |
| **mean** | **3.27851533** | **3.27800267** |

Sample std at K=3275: `0.00135540`.

Track 3 significance rule:

```text
(3.28 - 3.27851533) * sqrt(15) = 0.00575009 >= 0.004
```

## Rules

- Dataset, batch size, architecture, and validation setup are unchanged from the Track 3 baseline.
- The trainer uses one forward/backward pass per step. Activation covariance statistics are collected by forward hooks during the same forward pass.
- No third-party optimizer library is imported; the optimizer code is inline in each logfile.
- The submitted stopping point is the shared K=3275 checkpoint for all 15 completed runs. The runs were launched to 3300 steps, and no per-run val-loss early stopping was used.

## Files

- `records/track_3_optimization/README.md` adds the result-history row.
- `records/track_3_optimization/results/20260505_newton_muon/README.md` summarizes the method and stats.
- `records/track_3_optimization/results/20260505_newton_muon/*.txt` contains the UUID-named full-source logfiles.
- `records/track_3_optimization/results/20260505_newton_muon/train_gpt_simple_newton_muon.py` is the representative train script.

## Validation

- Recomputed 3275-step and 3300-step means from the copied logs.
- Verified all 15 logs contain `step:3275/3300 val_loss:`.
- `python -m py_compile records/track_3_optimization/results/20260505_newton_muon/train_gpt_simple_newton_muon.py`
- `git diff --check`
