### PR TITLE
Track 3: Muown @ 3075 steps

### DIFF
--- a/records/track_3_optimization/results/20260508_muown/97782bd6-1339-430f-b870-0c7309fa5004.txt
+++ b/records/track_3_optimization/results/20260508_muown/97782bd6-1339-430f-b870-0c7309fa5004.txt
@@ -1,0 +1,950 @@
+"""Track 3 Muown speedrunning submission."""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import glob
+import uuid
+import time
+from pathlib import Path
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+from torch.optim.optimizer import Optimizer
+import torch.nn.functional as F
+import torch.distributed as dist
+
+RANK = int(os.environ["RANK"])
+WORLD_SIZE = int(os.environ["WORLD_SIZE"])
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path(p) for p in glob.glob(filename_pattern))
+    if not files:
+        raise FileNotFoundError(
+            f"DATA_FILES_NOT_FOUND pattern={filename_pattern!r} cwd={Path.cwd()} "
+            f"data_dir={os.environ.get('DATA_DIR', '<unset>')!r}",
+        )
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+
+POLAR_EXPRESS_LONG_COEFFS = (
+    (8.2051, -22.9019, 16.4607),
+    (4.0664, -2.8612, 0.5184),
+    (3.9096, -2.8234, 0.5250),
+    (3.2856, -2.4153, 0.4853),
+    (2.2779, -1.6198, 0.3985),
+    (1.8726, -1.2307, 0.3585),
+    (1.8564, -1.2132, 0.3568),
+    (1.8750, -1.2500, 0.3750),
+)
+
+
+def zeropower_via_polar_express_long(G: Tensor, steps: int = 12, eps: float = 1e-7) -> Tensor:
+    """Longer Polar Express variant. Coefficients beyond the list repeat the stable terminal polynomial."""
+    assert len(G.shape) == 2
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+    X.div_(X.norm() + eps)
+    for step in range(steps):
+        a, b, c = POLAR_EXPRESS_LONG_COEFFS[min(step, len(POLAR_EXPRESS_LONG_COEFFS) - 1)]
+        A = X @ X.T
+        B = torch.addmm(A, A, A, beta=b, alpha=c)
+        X = torch.addmm(X, B, X, beta=a)
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+
+def _wn_pre_ns(W: Tensor, g: Tensor, v_norm: Tensor, grad_W: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    """Reconstruct v from (W, g, v_norm) and compute weight-norm gradients."""
+    u = W / g
+    v = u * v_norm
+    grad_g = (grad_W * u).sum(dim=1, keepdim=True)
+    grad_v = (g / v_norm) * (grad_W - u * grad_g)
+    return v, grad_g, grad_v
+
+
+def _wn_recompose(W: Tensor, g: Tensor, v_new: Tensor, v_norm_eps: float) -> None:
+    v_norm_new = v_new.norm(dim=1, keepdim=True).clamp_min(v_norm_eps)
+    W.copy_(g * (v_new / v_norm_new))
+
+
+def _smoothstep_v_norm(start_v_norm: Tensor, step: int, total_steps: int, target_scale: float) -> Tensor:
+    if total_steps <= 1:
+        progress = 1.0
+    else:
+        p = min(max(step - 1, 0) / (total_steps - 1), 1.0)
+        progress = p * p * (3.0 - 2.0 * p)
+    target = start_v_norm.new_full(start_v_norm.shape, target_scale)
+    return torch.lerp(start_v_norm, target, progress)
+
+def _param_to_complexity(p: Tensor) -> int:
+    """Approximate zeropower cost for load-balanced parameter ordering."""
+    m, n = p.shape[0], p[0].numel()
+    return 2 * (m**2) * n + m**3
+
+
+
+class MuownDP(Optimizer):
+    """Data-parallel Muown: shard zeropower work across ranks, then sync weights."""
+
+    rank_sharded = True
+
+    def __init__(
+        self,
+        params,
+        lr: float = 3e-4,
+        momentum: float = 0.95,
+        betas: Tuple[float, float] = (0.9, 0.95),
+        adam_eps: float = 1e-8,
+        ns_steps: int = 12,
+        v_norm_schedule_steps: int = 0,
+        v_norm_target_scale: float = 1.0,
+        v_norm_eps: float = 1e-12,
+        direction_scale: float = 0.2,
+    ):
+        if not isinstance(params, list):
+            params = list(params)
+        if not dist.is_initialized():
+            raise ValueError("Using MuownDP in a non-distributed run.")
+
+        if isinstance(params[0], dict):
+            for group in params:
+                group["params"] = sorted(group["params"], key=_param_to_complexity, reverse=True)
+        else:
+            params = sorted(params, key=_param_to_complexity, reverse=True)
+
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            betas=betas,
+            adam_eps=adam_eps,
+            ns_steps=ns_steps,
+            v_norm_schedule_steps=v_norm_schedule_steps,
+            v_norm_target_scale=v_norm_target_scale,
+            v_norm_eps=v_norm_eps,
+            direction_scale=direction_scale,
+        )
+        super().__init__(params, defaults)
+
+    def _init_state_2d(self, p: Tensor, state: dict, v_norm_eps: float) -> None:
+        w_norm_raw = p.data.norm(dim=1, keepdim=True)
+        w_norm = w_norm_raw.clamp_min(v_norm_eps)
+        zero_rows = w_norm_raw <= v_norm_eps
+        if zero_rows.any():
+            w_norm = torch.where(zero_rows, w_norm.new_full(w_norm.shape, 0.33**0.5), w_norm)
+        state["g"] = w_norm.clone()
+        state["v_norm"] = w_norm.clone()
+        state["v_norm_init"] = w_norm.clone()
+        state["m_v"] = torch.zeros_like(p.data)
+        state["m_g"] = torch.zeros_like(w_norm)
+        state["v_g"] = torch.zeros_like(w_norm)
+        state["step"] = 0
+
+    @torch.no_grad()
+    def step(self, closure: Optional[Callable] = None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            betas = group["betas"]
+            adam_eps = group["adam_eps"]
+            ns_steps = group["ns_steps"]
+            v_norm_eps = group["v_norm_eps"]
+            direction_scale = group["direction_scale"]
+            v_norm_interpolation_steps = group["v_norm_schedule_steps"]
+            v_norm_target_scale = group["v_norm_target_scale"]
+            params = group["params"]
+
+            for block_start in range(0, len(params), WORLD_SIZE):
+                if block_start + RANK < len(params):
+                    p = params[block_start + RANK]
+                    if p.grad is None:
+                        p.grad = torch.zeros_like(p)
+                    grad = p.grad
+                    state = self.state[p]
+                    if len(state) == 0:
+                        self._init_state_2d(
+                            p,
+                            state,
+                            v_norm_eps,
+                        )
+
+                    state["step"] += 1
+                    step = state["step"]
+
+                    g = state["g"]
+                    v_norm = state["v_norm"]
+                    start_v_norm = state["v_norm_init"]
+                    m_v = state["m_v"]
+                    v, grad_g, grad_v = _wn_pre_ns(p.data, g, v_norm, grad)
+
+                    m_v.mul_(momentum).add_(grad_v)
+                    update = grad_v.add(m_v, alpha=momentum)
+                    update = zeropower_via_polar_express_long(update, steps=ns_steps)
+                    scale = direction_scale * max(update.size(0), update.size(1)) ** 0.5
+                    v_new = v.add(update, alpha=-lr * scale)
+
+                    beta1, beta2 = betas
+                    m_g = state["m_g"]
+                    v_g = state["v_g"]
+                    m_g.mul_(beta1).add_(grad_g, alpha=1 - beta1)
+                    v_g.mul_(beta2).addcmul_(grad_g, grad_g, value=1 - beta2)
+                    bc1 = 1 - beta1**step
+                    bc2 = 1 - beta2**step
+                    g.addcdiv_(m_g / bc1, (v_g / bc2).sqrt().add_(adam_eps), value=-lr)
+
+                    _wn_recompose(p.data, g, v_new, v_norm_eps)
+                    state["v_norm"] = _smoothstep_v_norm(
+                        start_v_norm, step, v_norm_interpolation_steps, v_norm_target_scale
+                    )
+                # Different block matrices have different shapes, so broadcast
+                # each updated parameter from its owner rank.
+                for owner in range(WORLD_SIZE):
+                    param_idx = block_start + owner
+                    if param_idx < len(params):
+                        dist.broadcast(params[param_idx].data, src=owner)
+
+        return loss
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+
+
+# Optimization hyperparameters.
+DATA_DIR = os.environ.get("DATA_DIR", "data/fineweb10B")
+TRIAL_SEEDS = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+LR_EMBED = 0.9
+LR_HEAD = 0.009375
+LR_1D = 0.03
+LR_MUOWN = 0.0035
+LR_COOLDOWN_FRAC_ADAM = 0.7
+LR_COOLDOWN_FRAC_MUOWN = 0.7
+V_NORM_TARGET_SCALE = 2.688
+V_NORM_FAMILY_MULT = {
+    "attn.q.weight": 1.0,
+    "attn.k.weight": 1.0,
+    "attn.v.weight": 1.0,
+    "attn.proj.weight": 1,
+    "mlp.fc.weight": 1.0,
+    "mlp.proj.weight": 3.33333333333,
+}
+batch_size = 524288
+mbs = 32
+train_steps = 3200
+
+
+print0(
+    f"config data_dir={DATA_DIR} train_steps={train_steps} batch_size={batch_size} mbs={mbs} "
+    f"lr_embed={LR_EMBED} lr_head={LR_HEAD} lr_1d={LR_1D} lr_muown={LR_MUOWN} "
+    f"v_norm_target_scale={V_NORM_TARGET_SCALE} family_mult={V_NORM_FAMILY_MULT} "
+    f"trial_seeds={TRIAL_SEEDS}",
+    console=True,
+)
+
+val_tokens = 20 * 524288
+val_inputs, val_targets = next(distributed_data_generator(f"{DATA_DIR}/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+if num_trials < 1 or num_trials > len(TRIAL_SEEDS):
+    raise ValueError(f"num_trials must be between 1 and {len(TRIAL_SEEDS)}, got {num_trials}")
+
+for trial_idx in range(num_trials):
+    TRACK3_SEED = TRIAL_SEEDS[trial_idx]
+    torch.manual_seed(TRACK3_SEED)
+    torch.cuda.manual_seed_all(TRACK3_SEED)
+    print0(f"trial:{trial_idx + 1}/{num_trials} seed:{TRACK3_SEED}", console=True)
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    muown_param_groups = [
+        dict(
+            params=[p for name, p in model.blocks.named_parameters() if name.endswith(suffix)],
+            v_norm_target_scale=V_NORM_TARGET_SCALE * multiplier,
+        )
+        for suffix, multiplier in V_NORM_FAMILY_MULT.items()
+    ]
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=LR_EMBED),
+                        dict(params=[model.proj.weight], lr=LR_HEAD),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=LR_1D)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    optimizer2 = MuownDP(
+        muown_param_groups,
+        lr=LR_MUOWN,
+        momentum=0.95,
+        ns_steps=12,
+        v_norm_schedule_steps=train_steps,
+        direction_scale=0.2,
+    )
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay, optionally to a nonzero floor.
+    def lr_eta(step: int, cooldown_frac: float) -> float:
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if cooldown_frac == 0.0 or progress < 1 - cooldown_frac:
+            return 1.0
+        return (1 - progress) / cooldown_frac
+
+
+    def set_hparams(step):
+        adam_eta = lr_eta(step, LR_COOLDOWN_FRAC_ADAM)
+        muown_eta = lr_eta(step, LR_COOLDOWN_FRAC_MUOWN)
+        for group in optimizer1.param_groups:
+            group["lr"] = group["initial_lr"] * adam_eta
+        for group in optimizer2.param_groups:
+            group["lr"] = group["initial_lr"] * muown_eta
+
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator(f"{DATA_DIR}/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if val_inputs is not None and (step == train_steps or step % val_step_freq == 0):
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            train_loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+            train_loss.backward()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0a0+a36e1d39eb.nv26.01.42222806 compiled for CUDA 13.1 on NVIDIA GH200 120GB with world_size 4
+====================================================================================================
+config data_dir=/iopsstor/scratch/cscs/fhueb/modded-nanogpt-data/data/fineweb10B train_steps=3200 batch_size=524288 mbs=32 lr_embed=0.9 lr_head=0.009375 lr_1d=0.03 lr_muown=0.0035 v_norm_target_scale=2.688 family_mult={'attn.q.weight': 1.0, 'attn.k.weight': 1.0, 'attn.v.weight': 1.0, 'attn.proj.weight': 1, 'mlp.fc.weight': 1.0, 'mlp.proj.weight': 3.33333333333} trial_seeds=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+trial:1/10 seed:1
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.82555 train_time:99.402s step_avg:795.22ms
+step:250/3200 val_loss:4.24469 train_time:196.931s step_avg:780.23ms
+step:375/3200 val_loss:4.09331 train_time:294.350s step_avg:779.36ms
+step:500/3200 val_loss:3.97900 train_time:391.693s step_avg:778.74ms
+step:625/3200 val_loss:3.90232 train_time:489.005s step_avg:778.50ms
+step:750/3200 val_loss:3.83675 train_time:586.257s step_avg:778.01ms
+step:875/3200 val_loss:3.77449 train_time:683.527s step_avg:778.16ms
+step:1000/3200 val_loss:3.72021 train_time:780.739s step_avg:777.69ms
+step:1125/3200 val_loss:3.67291 train_time:877.934s step_avg:777.57ms
+step:1250/3200 val_loss:3.61906 train_time:975.176s step_avg:777.93ms
+step:1375/3200 val_loss:3.57718 train_time:1072.444s step_avg:778.14ms
+step:1500/3200 val_loss:3.53654 train_time:1169.653s step_avg:777.67ms
+step:1625/3200 val_loss:3.50410 train_time:1266.956s step_avg:778.42ms
+step:1750/3200 val_loss:3.46938 train_time:1364.255s step_avg:778.39ms
+step:1875/3200 val_loss:3.44367 train_time:1461.474s step_avg:777.75ms
+step:2000/3200 val_loss:3.41551 train_time:1558.756s step_avg:778.26ms
+step:2125/3200 val_loss:3.39364 train_time:1656.023s step_avg:778.13ms
+step:2250/3200 val_loss:3.37288 train_time:1753.198s step_avg:777.41ms
+step:2375/3200 val_loss:3.35441 train_time:1850.467s step_avg:778.15ms
+step:2500/3200 val_loss:3.33739 train_time:1947.718s step_avg:778.01ms
+step:2625/3200 val_loss:3.32157 train_time:2044.989s step_avg:778.17ms
+step:2750/3200 val_loss:3.30799 train_time:2142.289s step_avg:778.40ms
+step:2875/3200 val_loss:3.29593 train_time:2239.607s step_avg:778.54ms
+step:2900/3200 val_loss:3.29387 train_time:2259.063s step_avg:778.24ms
+step:2925/3200 val_loss:3.29119 train_time:2278.513s step_avg:777.98ms
+step:2950/3200 val_loss:3.28918 train_time:2297.968s step_avg:778.21ms
+step:2975/3200 val_loss:3.28747 train_time:2317.415s step_avg:777.89ms
+step:3000/3200 val_loss:3.28558 train_time:2336.866s step_avg:778.01ms
+step:3025/3200 val_loss:3.28339 train_time:2356.315s step_avg:777.97ms
+step:3050/3200 val_loss:3.28174 train_time:2376.055s step_avg:789.59ms
+step:3075/3200 val_loss:3.28024 train_time:2395.509s step_avg:778.16ms
+step:3100/3200 val_loss:3.27888 train_time:2414.956s step_avg:777.91ms
+step:3125/3200 val_loss:3.27763 train_time:2434.412s step_avg:778.22ms
+step:3150/3200 val_loss:3.27647 train_time:2453.870s step_avg:778.34ms
+step:3175/3200 val_loss:3.27576 train_time:2473.328s step_avg:778.32ms
+step:3200/3200 val_loss:3.27541 train_time:2492.778s step_avg:778.00ms
+trial:2/10 seed:2
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.80951 train_time:97.630s step_avg:781.04ms
+step:250/3200 val_loss:4.24943 train_time:195.136s step_avg:780.05ms
+step:375/3200 val_loss:4.07540 train_time:292.582s step_avg:779.57ms
+step:500/3200 val_loss:3.98272 train_time:389.994s step_avg:779.29ms
+step:625/3200 val_loss:3.88402 train_time:487.333s step_avg:778.71ms
+step:750/3200 val_loss:3.82978 train_time:584.595s step_avg:778.10ms
+step:875/3200 val_loss:3.77192 train_time:681.883s step_avg:778.31ms
+step:1000/3200 val_loss:3.72075 train_time:779.150s step_avg:778.13ms
+step:1125/3200 val_loss:3.67172 train_time:876.395s step_avg:777.96ms
+step:1250/3200 val_loss:3.62263 train_time:973.627s step_avg:777.86ms
+step:1375/3200 val_loss:3.58278 train_time:1070.901s step_avg:778.19ms
+step:1500/3200 val_loss:3.53634 train_time:1168.176s step_avg:778.20ms
+step:1625/3200 val_loss:3.50332 train_time:1265.467s step_avg:778.33ms
+step:1750/3200 val_loss:3.47081 train_time:1362.785s step_avg:778.54ms
+step:1875/3200 val_loss:3.44453 train_time:1460.098s step_avg:778.51ms
+step:2000/3200 val_loss:3.41746 train_time:1557.495s step_avg:779.17ms
+step:2125/3200 val_loss:3.39490 train_time:1654.846s step_avg:778.81ms
+step:2250/3200 val_loss:3.37408 train_time:1752.233s step_avg:779.10ms
+step:2375/3200 val_loss:3.35600 train_time:1849.654s step_avg:779.37ms
+step:2500/3200 val_loss:3.33863 train_time:1947.126s step_avg:779.78ms
+step:2625/3200 val_loss:3.32302 train_time:2044.564s step_avg:779.50ms
+step:2750/3200 val_loss:3.30919 train_time:2142.015s step_avg:779.61ms
+step:2875/3200 val_loss:3.29701 train_time:2239.474s step_avg:779.67ms
+step:2900/3200 val_loss:3.29478 train_time:2258.947s step_avg:778.92ms
+step:2925/3200 val_loss:3.29230 train_time:2278.418s step_avg:778.83ms
+step:2950/3200 val_loss:3.29028 train_time:2297.898s step_avg:779.22ms
+step:2975/3200 val_loss:3.28854 train_time:2317.370s step_avg:778.88ms
+step:3000/3200 val_loss:3.28655 train_time:2336.846s step_avg:779.01ms
+step:3025/3200 val_loss:3.28441 train_time:2356.316s step_avg:778.81ms
+step:3050/3200 val_loss:3.28275 train_time:2375.813s step_avg:779.88ms
+step:3075/3200 val_loss:3.28114 train_time:2395.292s step_avg:779.16ms
+step:3100/3200 val_loss:3.27979 train_time:2414.770s step_avg:779.11ms
+step:3125/3200 val_loss:3.27859 train_time:2434.253s step_avg:779.32ms
+step:3150/3200 val_loss:3.27748 train_time:2453.721s step_avg:778.71ms
+step:3175/3200 val_loss:3.27676 train_time:2473.200s step_avg:779.17ms
+step:3200/3200 val_loss:3.27642 train_time:2492.675s step_avg:778.99ms
+trial:3/10 seed:3
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.83754 train_time:97.765s step_avg:782.12ms
+step:250/3200 val_loss:4.24143 train_time:195.300s step_avg:780.27ms
+step:375/3200 val_loss:4.09199 train_time:292.798s step_avg:779.99ms
+step:500/3200 val_loss:3.97127 train_time:390.256s step_avg:779.66ms
+step:625/3200 val_loss:3.89270 train_time:487.656s step_avg:779.20ms
+step:750/3200 val_loss:3.82696 train_time:585.004s step_avg:778.79ms
+step:875/3200 val_loss:3.76807 train_time:682.371s step_avg:778.93ms
+step:1000/3200 val_loss:3.71633 train_time:779.730s step_avg:778.87ms
+step:1125/3200 val_loss:3.67130 train_time:877.072s step_avg:778.73ms
+step:1250/3200 val_loss:3.61805 train_time:974.431s step_avg:778.88ms
+step:1375/3200 val_loss:3.57716 train_time:1071.818s step_avg:779.10ms
+step:1500/3200 val_loss:3.53456 train_time:1169.167s step_avg:778.79ms
+step:1625/3200 val_loss:3.50471 train_time:1266.551s step_avg:779.07ms
+step:1750/3200 val_loss:3.46934 train_time:1363.947s step_avg:779.16ms
+step:1875/3200 val_loss:3.44161 train_time:1461.300s step_avg:778.82ms
+step:2000/3200 val_loss:3.41595 train_time:1558.662s step_avg:778.90ms
+step:2125/3200 val_loss:3.39390 train_time:1656.098s step_avg:779.49ms
+step:2250/3200 val_loss:3.37331 train_time:1753.500s step_avg:779.21ms
+step:2375/3200 val_loss:3.35481 train_time:1850.980s step_avg:779.84ms
+step:2500/3200 val_loss:3.33820 train_time:1948.525s step_avg:780.35ms
+step:2625/3200 val_loss:3.32240 train_time:2045.975s step_avg:779.60ms
+step:2750/3200 val_loss:3.30848 train_time:2143.401s step_avg:779.41ms
+step:2875/3200 val_loss:3.29648 train_time:2240.815s step_avg:779.31ms
+step:2900/3200 val_loss:3.29436 train_time:2260.304s step_avg:779.58ms
+step:2925/3200 val_loss:3.29188 train_time:2279.782s step_avg:779.11ms
+step:2950/3200 val_loss:3.28986 train_time:2299.261s step_avg:779.17ms
+step:2975/3200 val_loss:3.28801 train_time:2318.732s step_avg:778.83ms
+step:3000/3200 val_loss:3.28610 train_time:2338.212s step_avg:779.22ms
+step:3025/3200 val_loss:3.28393 train_time:2357.694s step_avg:779.25ms
+step:3050/3200 val_loss:3.28228 train_time:2377.194s step_avg:780.02ms
+step:3075/3200 val_loss:3.28076 train_time:2396.670s step_avg:779.02ms
+step:3100/3200 val_loss:3.27938 train_time:2416.140s step_avg:778.82ms
+step:3125/3200 val_loss:3.27812 train_time:2435.617s step_avg:779.07ms
+step:3150/3200 val_loss:3.27706 train_time:2455.097s step_avg:779.20ms
+step:3175/3200 val_loss:3.27634 train_time:2474.564s step_avg:778.66ms
+step:3200/3200 val_loss:3.27600 train_time:2494.036s step_avg:778.90ms
+trial:4/10 seed:4
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.80722 train_time:97.737s step_avg:781.89ms
+step:250/3200 val_loss:4.24702 train_time:195.297s step_avg:780.48ms
+step:375/3200 val_loss:4.08348 train_time:292.763s step_avg:779.74ms
+step:500/3200 val_loss:3.97982 train_time:390.204s step_avg:779.53ms
+step:625/3200 val_loss:3.89493 train_time:487.578s step_avg:778.99ms
+step:750/3200 val_loss:3.83753 train_time:584.938s step_avg:778.88ms
+step:875/3200 val_loss:3.77154 train_time:682.355s step_avg:779.34ms
+step:1000/3200 val_loss:3.71651 train_time:779.775s step_avg:779.36ms
+step:1125/3200 val_loss:3.66795 train_time:877.128s step_avg:778.82ms
+step:1250/3200 val_loss:3.62101 train_time:974.548s step_avg:779.36ms
+step:1375/3200 val_loss:3.57742 train_time:1071.925s step_avg:779.02ms
+step:1500/3200 val_loss:3.53438 train_time:1169.280s step_avg:778.84ms
+step:1625/3200 val_loss:3.50131 train_time:1266.683s step_avg:779.23ms
+step:1750/3200 val_loss:3.46853 train_time:1364.031s step_avg:778.79ms
+step:1875/3200 val_loss:3.44038 train_time:1461.450s step_avg:779.35ms
+step:2000/3200 val_loss:3.41465 train_time:1558.918s step_avg:779.74ms
+step:2125/3200 val_loss:3.39220 train_time:1656.387s step_avg:779.76ms
+step:2250/3200 val_loss:3.37153 train_time:1753.802s step_avg:779.32ms
+step:2375/3200 val_loss:3.35290 train_time:1851.303s step_avg:780.01ms
+step:2500/3200 val_loss:3.33604 train_time:1948.825s step_avg:780.17ms
+step:2625/3200 val_loss:3.32057 train_time:2046.325s step_avg:780.00ms
+step:2750/3200 val_loss:3.30690 train_time:2143.845s step_avg:780.16ms
+step:2875/3200 val_loss:3.29467 train_time:2241.404s step_avg:780.47ms
+step:2900/3200 val_loss:3.29252 train_time:2260.899s step_avg:779.77ms
+step:2925/3200 val_loss:3.28984 train_time:2280.398s step_avg:779.99ms
+step:2950/3200 val_loss:3.28803 train_time:2299.895s step_avg:779.85ms
+step:2975/3200 val_loss:3.28618 train_time:2319.376s step_avg:779.24ms
+step:3000/3200 val_loss:3.28425 train_time:2338.860s step_avg:779.38ms
+step:3025/3200 val_loss:3.28206 train_time:2358.345s step_avg:779.39ms
+step:3050/3200 val_loss:3.28053 train_time:2377.860s step_avg:780.59ms
+step:3075/3200 val_loss:3.27897 train_time:2397.350s step_avg:779.63ms
+step:3100/3200 val_loss:3.27754 train_time:2416.830s step_avg:779.17ms
+step:3125/3200 val_loss:3.27636 train_time:2436.312s step_avg:779.30ms
+step:3150/3200 val_loss:3.27525 train_time:2455.780s step_avg:778.70ms
+step:3175/3200 val_loss:3.27451 train_time:2475.258s step_avg:779.13ms
+step:3200/3200 val_loss:3.27415 train_time:2494.733s step_avg:779.01ms
+trial:5/10 seed:5
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.81654 train_time:97.752s step_avg:782.02ms
+step:250/3200 val_loss:4.24423 train_time:195.305s step_avg:780.43ms
+step:375/3200 val_loss:4.08922 train_time:292.743s step_avg:779.50ms
+step:500/3200 val_loss:3.97021 train_time:390.239s step_avg:779.97ms
+step:625/3200 val_loss:3.90082 train_time:487.646s step_avg:779.26ms
+step:750/3200 val_loss:3.82382 train_time:585.020s step_avg:778.99ms
+step:875/3200 val_loss:3.77734 train_time:682.389s step_avg:778.95ms
+step:1000/3200 val_loss:3.72058 train_time:779.753s step_avg:778.91ms
+step:1125/3200 val_loss:3.67119 train_time:877.105s step_avg:778.82ms
+step:1250/3200 val_loss:3.61985 train_time:974.472s step_avg:778.93ms
+step:1375/3200 val_loss:3.57676 train_time:1071.786s step_avg:778.51ms
+step:1500/3200 val_loss:3.53654 train_time:1169.113s step_avg:778.62ms
+step:1625/3200 val_loss:3.50280 train_time:1266.466s step_avg:778.83ms
+step:1750/3200 val_loss:3.47068 train_time:1363.833s step_avg:778.93ms
+step:1875/3200 val_loss:3.44306 train_time:1461.174s step_avg:778.73ms
+step:2000/3200 val_loss:3.41637 train_time:1558.554s step_avg:779.04ms
+step:2125/3200 val_loss:3.39454 train_time:1655.924s step_avg:778.95ms
+step:2250/3200 val_loss:3.37371 train_time:1753.296s step_avg:778.98ms
+step:2375/3200 val_loss:3.35513 train_time:1850.708s step_avg:779.30ms
+step:2500/3200 val_loss:3.33813 train_time:1948.157s step_avg:779.60ms
+step:2625/3200 val_loss:3.32255 train_time:2045.478s step_avg:778.57ms
+step:2750/3200 val_loss:3.30853 train_time:2142.833s step_avg:778.84ms
+step:2875/3200 val_loss:3.29657 train_time:2240.214s step_avg:779.04ms
+step:2900/3200 val_loss:3.29461 train_time:2259.678s step_avg:778.59ms
+step:2925/3200 val_loss:3.29198 train_time:2279.134s step_avg:778.23ms
+step:2950/3200 val_loss:3.28989 train_time:2298.594s step_avg:778.39ms
+step:2975/3200 val_loss:3.28818 train_time:2318.067s step_avg:778.94ms
+step:3000/3200 val_loss:3.28620 train_time:2337.550s step_avg:779.31ms
+step:3025/3200 val_loss:3.28402 train_time:2357.030s step_avg:779.20ms
+step:3050/3200 val_loss:3.28234 train_time:2376.529s step_avg:779.96ms
+step:3075/3200 val_loss:3.28088 train_time:2395.992s step_avg:778.53ms
+step:3100/3200 val_loss:3.27953 train_time:2415.464s step_avg:778.89ms
+step:3125/3200 val_loss:3.27825 train_time:2434.944s step_avg:779.17ms
+step:3150/3200 val_loss:3.27715 train_time:2454.423s step_avg:779.16ms
+step:3175/3200 val_loss:3.27642 train_time:2473.890s step_avg:778.68ms
+step:3200/3200 val_loss:3.27607 train_time:2493.355s step_avg:778.59ms
+trial:6/10 seed:6
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.84505 train_time:97.705s step_avg:781.64ms
+step:250/3200 val_loss:4.26632 train_time:195.249s step_avg:780.35ms
+step:375/3200 val_loss:4.09183 train_time:292.728s step_avg:779.84ms
+step:500/3200 val_loss:3.97812 train_time:390.129s step_avg:779.21ms
+step:625/3200 val_loss:3.89187 train_time:487.550s step_avg:779.37ms
+step:750/3200 val_loss:3.82793 train_time:584.874s step_avg:778.60ms
+step:875/3200 val_loss:3.77594 train_time:682.166s step_avg:778.34ms
+step:1000/3200 val_loss:3.72156 train_time:779.434s step_avg:778.14ms
+step:1125/3200 val_loss:3.66933 train_time:876.670s step_avg:777.88ms
+step:1250/3200 val_loss:3.62266 train_time:973.912s step_avg:777.94ms
+step:1375/3200 val_loss:3.57758 train_time:1071.133s step_avg:777.76ms
+step:1500/3200 val_loss:3.53627 train_time:1168.379s step_avg:777.97ms
+step:1625/3200 val_loss:3.50306 train_time:1265.672s step_avg:778.34ms
+step:1750/3200 val_loss:3.47085 train_time:1362.970s step_avg:778.39ms
+step:1875/3200 val_loss:3.44270 train_time:1460.296s step_avg:778.60ms
+step:2000/3200 val_loss:3.41643 train_time:1557.649s step_avg:778.83ms
+step:2125/3200 val_loss:3.39431 train_time:1655.026s step_avg:779.02ms
+step:2250/3200 val_loss:3.37333 train_time:1752.390s step_avg:778.91ms
+step:2375/3200 val_loss:3.35504 train_time:1849.748s step_avg:778.86ms
+step:2500/3200 val_loss:3.33794 train_time:1947.143s step_avg:779.16ms
+step:2625/3200 val_loss:3.32210 train_time:2044.526s step_avg:779.06ms
+step:2750/3200 val_loss:3.30823 train_time:2142.022s step_avg:779.97ms
+step:2875/3200 val_loss:3.29626 train_time:2239.545s step_avg:780.18ms
+step:2900/3200 val_loss:3.29417 train_time:2259.027s step_avg:779.25ms
+step:2925/3200 val_loss:3.29151 train_time:2278.509s step_avg:779.31ms
+step:2950/3200 val_loss:3.28964 train_time:2298.005s step_avg:779.82ms
+step:2975/3200 val_loss:3.28777 train_time:2317.488s step_avg:779.34ms
+step:3000/3200 val_loss:3.28579 train_time:2336.981s step_avg:779.71ms
+step:3025/3200 val_loss:3.28373 train_time:2356.467s step_avg:779.42ms
+step:3050/3200 val_loss:3.28200 train_time:2375.987s step_avg:780.83ms
+step:3075/3200 val_loss:3.28046 train_time:2395.477s step_avg:779.58ms
+step:3100/3200 val_loss:3.27913 train_time:2414.958s step_avg:779.26ms
+step:3125/3200 val_loss:3.27787 train_time:2434.434s step_avg:779.03ms
+step:3150/3200 val_loss:3.27678 train_time:2453.903s step_avg:778.74ms
+step:3175/3200 val_loss:3.27604 train_time:2473.376s step_avg:778.94ms
+step:3200/3200 val_loss:3.27569 train_time:2492.839s step_avg:778.53ms
+trial:7/10 seed:7
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.81415 train_time:97.783s step_avg:782.26ms
+step:250/3200 val_loss:4.23986 train_time:195.353s step_avg:780.56ms
+step:375/3200 val_loss:4.10640 train_time:292.832s step_avg:779.83ms
+step:500/3200 val_loss:3.96420 train_time:390.265s step_avg:779.47ms
+step:625/3200 val_loss:3.88423 train_time:487.707s step_avg:779.53ms
+step:750/3200 val_loss:3.83779 train_time:585.071s step_avg:778.91ms
+step:875/3200 val_loss:3.77053 train_time:682.416s step_avg:778.76ms
+step:1000/3200 val_loss:3.71912 train_time:779.777s step_avg:778.89ms
+step:1125/3200 val_loss:3.67117 train_time:877.137s step_avg:778.89ms
+step:1250/3200 val_loss:3.61792 train_time:974.582s step_avg:779.55ms
+step:1375/3200 val_loss:3.57704 train_time:1072.015s step_avg:779.47ms
+step:1500/3200 val_loss:3.53524 train_time:1169.456s step_avg:779.52ms
+step:1625/3200 val_loss:3.50313 train_time:1266.895s step_avg:779.51ms
+step:1750/3200 val_loss:3.47133 train_time:1364.369s step_avg:779.79ms
+step:1875/3200 val_loss:3.44234 train_time:1461.829s step_avg:779.68ms
+step:2000/3200 val_loss:3.41565 train_time:1559.229s step_avg:779.20ms
+step:2125/3200 val_loss:3.39415 train_time:1656.600s step_avg:778.97ms
+step:2250/3200 val_loss:3.37285 train_time:1753.944s step_avg:778.75ms
+step:2375/3200 val_loss:3.35463 train_time:1851.329s step_avg:779.08ms
+step:2500/3200 val_loss:3.33767 train_time:1948.706s step_avg:779.02ms
+step:2625/3200 val_loss:3.32170 train_time:2046.041s step_avg:778.68ms
+step:2750/3200 val_loss:3.30809 train_time:2143.406s step_avg:778.92ms
+step:2875/3200 val_loss:3.29595 train_time:2240.771s step_avg:778.92ms
+step:2900/3200 val_loss:3.29403 train_time:2260.245s step_avg:778.98ms
+step:2925/3200 val_loss:3.29135 train_time:2279.707s step_avg:778.47ms
+step:2950/3200 val_loss:3.28934 train_time:2299.181s step_avg:778.97ms
+step:2975/3200 val_loss:3.28763 train_time:2318.662s step_avg:779.21ms
+step:3000/3200 val_loss:3.28571 train_time:2338.146s step_avg:779.37ms
+step:3025/3200 val_loss:3.28353 train_time:2357.631s step_avg:779.39ms
+step:3050/3200 val_loss:3.28195 train_time:2377.134s step_avg:780.15ms
+step:3075/3200 val_loss:3.28043 train_time:2396.615s step_avg:779.24ms
+step:3100/3200 val_loss:3.27899 train_time:2416.091s step_avg:779.02ms
+step:3125/3200 val_loss:3.27778 train_time:2435.554s step_avg:778.52ms
+step:3150/3200 val_loss:3.27665 train_time:2455.019s step_avg:778.62ms
+step:3175/3200 val_loss:3.27594 train_time:2474.484s step_avg:778.59ms
+step:3200/3200 val_loss:3.27558 train_time:2493.956s step_avg:778.86ms
+trial:8/10 seed:8
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.81209 train_time:97.722s step_avg:781.78ms
+step:250/3200 val_loss:4.26701 train_time:195.256s step_avg:780.27ms
+step:375/3200 val_loss:4.09058 train_time:292.745s step_avg:779.92ms
+step:500/3200 val_loss:3.96860 train_time:390.206s step_avg:779.68ms
+step:625/3200 val_loss:3.88808 train_time:487.645s step_avg:779.51ms
+step:750/3200 val_loss:3.83573 train_time:585.042s step_avg:779.18ms
+step:875/3200 val_loss:3.77159 train_time:682.457s step_avg:779.31ms
+step:1000/3200 val_loss:3.72855 train_time:779.815s step_avg:778.86ms
+step:1125/3200 val_loss:3.67273 train_time:877.142s step_avg:778.62ms
+step:1250/3200 val_loss:3.61868 train_time:974.440s step_avg:778.39ms
+step:1375/3200 val_loss:3.58084 train_time:1071.750s step_avg:778.48ms
+step:1500/3200 val_loss:3.53298 train_time:1169.025s step_avg:778.20ms
+step:1625/3200 val_loss:3.50439 train_time:1266.383s step_avg:778.86ms
+step:1750/3200 val_loss:3.46952 train_time:1363.737s step_avg:778.83ms
+step:1875/3200 val_loss:3.44083 train_time:1461.016s step_avg:778.24ms
+step:2000/3200 val_loss:3.41502 train_time:1558.263s step_avg:777.97ms
+step:2125/3200 val_loss:3.39304 train_time:1655.528s step_avg:778.12ms
+step:2250/3200 val_loss:3.37251 train_time:1752.810s step_avg:778.25ms
+step:2375/3200 val_loss:3.35440 train_time:1850.114s step_avg:778.43ms
+step:2500/3200 val_loss:3.33750 train_time:1947.408s step_avg:778.35ms
+step:2625/3200 val_loss:3.32181 train_time:2044.667s step_avg:778.07ms
+step:2750/3200 val_loss:3.30796 train_time:2141.995s step_avg:778.63ms
+step:2875/3200 val_loss:3.29603 train_time:2239.337s step_avg:778.74ms
+step:2900/3200 val_loss:3.29387 train_time:2258.792s step_avg:778.18ms
+step:2925/3200 val_loss:3.29130 train_time:2278.255s step_avg:778.55ms
+step:2950/3200 val_loss:3.28934 train_time:2297.711s step_avg:778.24ms
+step:2975/3200 val_loss:3.28762 train_time:2317.168s step_avg:778.27ms
+step:3000/3200 val_loss:3.28563 train_time:2336.613s step_avg:777.80ms
+step:3025/3200 val_loss:3.28348 train_time:2356.056s step_avg:777.73ms
+step:3050/3200 val_loss:3.28189 train_time:2375.528s step_avg:778.87ms
+step:3075/3200 val_loss:3.28032 train_time:2394.988s step_avg:778.40ms
+step:3100/3200 val_loss:3.27892 train_time:2414.450s step_avg:778.47ms
+step:3125/3200 val_loss:3.27765 train_time:2433.925s step_avg:779.01ms
+step:3150/3200 val_loss:3.27655 train_time:2453.397s step_avg:778.88ms
+step:3175/3200 val_loss:3.27585 train_time:2472.874s step_avg:779.07ms
+step:3200/3200 val_loss:3.27548 train_time:2492.345s step_avg:778.87ms
+trial:9/10 seed:9
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.81921 train_time:97.762s step_avg:782.10ms
+step:250/3200 val_loss:4.27160 train_time:195.245s step_avg:779.86ms
+step:375/3200 val_loss:4.07943 train_time:292.596s step_avg:778.81ms
+step:500/3200 val_loss:3.97563 train_time:389.905s step_avg:778.47ms
+step:625/3200 val_loss:3.89946 train_time:487.237s step_avg:778.66ms
+step:750/3200 val_loss:3.83231 train_time:584.464s step_avg:777.82ms
+step:875/3200 val_loss:3.76934 train_time:681.677s step_avg:777.70ms
+step:1000/3200 val_loss:3.72199 train_time:778.872s step_avg:777.56ms
+step:1125/3200 val_loss:3.67224 train_time:876.066s step_avg:777.55ms
+step:1250/3200 val_loss:3.61752 train_time:973.299s step_avg:777.87ms
+step:1375/3200 val_loss:3.57773 train_time:1070.523s step_avg:777.79ms
+step:1500/3200 val_loss:3.53478 train_time:1167.695s step_avg:777.38ms
+step:1625/3200 val_loss:3.50154 train_time:1264.903s step_avg:777.66ms
+step:1750/3200 val_loss:3.46894 train_time:1362.123s step_avg:777.76ms
+step:1875/3200 val_loss:3.44072 train_time:1459.300s step_avg:777.41ms
+step:2000/3200 val_loss:3.41520 train_time:1556.510s step_avg:777.69ms
+step:2125/3200 val_loss:3.39271 train_time:1653.751s step_avg:777.92ms
+step:2250/3200 val_loss:3.37180 train_time:1750.974s step_avg:777.79ms
+step:2375/3200 val_loss:3.35382 train_time:1848.264s step_avg:778.32ms
+step:2500/3200 val_loss:3.33649 train_time:1945.544s step_avg:778.24ms
+step:2625/3200 val_loss:3.32057 train_time:2042.781s step_avg:777.90ms
+step:2750/3200 val_loss:3.30676 train_time:2140.046s step_avg:778.11ms
+step:2875/3200 val_loss:3.29461 train_time:2237.326s step_avg:778.24ms
+step:2900/3200 val_loss:3.29264 train_time:2256.780s step_avg:778.14ms
+step:2925/3200 val_loss:3.29007 train_time:2276.242s step_avg:778.51ms
+step:2950/3200 val_loss:3.28801 train_time:2295.695s step_avg:778.12ms
+step:2975/3200 val_loss:3.28622 train_time:2315.144s step_avg:777.93ms
+step:3000/3200 val_loss:3.28436 train_time:2334.601s step_avg:778.31ms
+step:3025/3200 val_loss:3.28219 train_time:2354.060s step_avg:778.37ms
+step:3050/3200 val_loss:3.28050 train_time:2373.540s step_avg:779.17ms
+step:3075/3200 val_loss:3.27901 train_time:2392.986s step_avg:777.84ms
+step:3100/3200 val_loss:3.27768 train_time:2412.435s step_avg:777.96ms
+step:3125/3200 val_loss:3.27640 train_time:2431.879s step_avg:777.76ms
+step:3150/3200 val_loss:3.27529 train_time:2451.327s step_avg:777.94ms
+step:3175/3200 val_loss:3.27455 train_time:2470.770s step_avg:777.72ms
+step:3200/3200 val_loss:3.27421 train_time:2490.215s step_avg:777.77ms
+trial:10/10 seed:10
+step:0/3200 val_loss:10.82585 train_time:0.000s step_avg:nanms
+step:125/3200 val_loss:4.82427 train_time:97.581s step_avg:780.65ms
+step:250/3200 val_loss:4.25207 train_time:195.019s step_avg:779.51ms
+step:375/3200 val_loss:4.08274 train_time:292.293s step_avg:778.19ms
+step:500/3200 val_loss:3.97867 train_time:389.543s step_avg:778.00ms
+step:625/3200 val_loss:3.90014 train_time:486.756s step_avg:777.71ms
+step:750/3200 val_loss:3.83382 train_time:583.932s step_avg:777.41ms
+step:875/3200 val_loss:3.77582 train_time:681.128s step_avg:777.56ms
+step:1000/3200 val_loss:3.72213 train_time:778.297s step_avg:777.35ms
+step:1125/3200 val_loss:3.67154 train_time:875.484s step_avg:777.50ms
+step:1250/3200 val_loss:3.62194 train_time:972.701s step_avg:777.74ms
+step:1375/3200 val_loss:3.57779 train_time:1069.943s step_avg:777.93ms
+step:1500/3200 val_loss:3.53743 train_time:1167.160s step_avg:777.74ms
+step:1625/3200 val_loss:3.50091 train_time:1264.419s step_avg:778.07ms
+step:1750/3200 val_loss:3.46968 train_time:1361.672s step_avg:778.02ms
+step:1875/3200 val_loss:3.44048 train_time:1458.889s step_avg:777.74ms
+step:2000/3200 val_loss:3.41484 train_time:1556.121s step_avg:777.86ms
+step:2125/3200 val_loss:3.39275 train_time:1653.347s step_avg:777.81ms
+step:2250/3200 val_loss:3.37194 train_time:1750.619s step_avg:778.18ms
+step:2375/3200 val_loss:3.35344 train_time:1847.886s step_avg:778.13ms
+step:2500/3200 val_loss:3.33656 train_time:1945.136s step_avg:778.00ms
+step:2625/3200 val_loss:3.32074 train_time:2042.372s step_avg:777.89ms
+step:2750/3200 val_loss:3.30695 train_time:2139.642s step_avg:778.16ms
+step:2875/3200 val_loss:3.29501 train_time:2236.922s step_avg:778.24ms
+step:2900/3200 val_loss:3.29264 train_time:2256.374s step_avg:778.09ms
+step:2925/3200 val_loss:3.29020 train_time:2275.826s step_avg:778.10ms
+step:2950/3200 val_loss:3.28828 train_time:2295.274s step_avg:777.89ms
+step:2975/3200 val_loss:3.28644 train_time:2314.716s step_avg:777.68ms
+step:3000/3200 val_loss:3.28445 train_time:2334.161s step_avg:777.81ms
+step:3025/3200 val_loss:3.28233 train_time:2353.607s step_avg:777.82ms
+step:3050/3200 val_loss:3.28058 train_time:2373.083s step_avg:779.06ms
+step:3075/3200 val_loss:3.27912 train_time:2392.529s step_avg:777.82ms
+step:3100/3200 val_loss:3.27782 train_time:2411.984s step_avg:778.20ms
+step:3125/3200 val_loss:3.27656 train_time:2431.441s step_avg:778.28ms
+step:3150/3200 val_loss:3.27544 train_time:2450.890s step_avg:777.97ms
+step:3175/3200 val_loss:3.27473 train_time:2470.341s step_avg:778.05ms
+step:3200/3200 val_loss:3.27437 train_time:2489.802s step_avg:778.42ms

--- a/records/track_3_optimization/results/20260508_muown/README.md
+++ b/records/track_3_optimization/results/20260508_muown/README.md
@@ -1,0 +1,72 @@
+# Muown — Track 3 Submission
+
+Submission authored by: fhuebler, kcc-lion
+
+Muown decomposes every 2-D weight matrix into a per-row gain `g` and a
+direction vector `v` via weight normalization (`W = g * v / ||v||`), then
+updates the two factors with different geometries:
+
+* **Direction (`v`):** Nesterov-style momentum followed by Newton-Schulz
+  orthogonalization (Polar Express, 12 iterations) of the update.  The
+  orthogonalized update is applied to `v` with a scale proportional to
+  `sqrt(max(m, n))`, gated by `direction_scale=0.2`.
+* **Gain (`g`):** Standard Adam with bias correction (`betas=(0.9, 0.95)`).
+* **V-norm schedule (angular step-size attenuation):** After each step, the
+  stored `||v||` is smoothstep-interpolated from its initial value toward a
+  fixed `v_norm_target_scale`.  Because the weight-norm recomposition
+  normalizes `v` before multiplying by `g`, growing `||v||` relative to the
+  actual update magnitude shrinks the effective angular displacement on the
+  unit sphere, attenuating the angular step size as training progresses.
+  The target scale is layer-family-dependent (`mlp.proj` receives a 3.33x
+  multiplier; all other families use 1x).
+
+Auxiliary parameters (embeddings, head, 1-D norms/biases) are trained with
+fused AdamW at per-group learning rates.
+
+## Key hyperparameters
+
+| Parameter | Value |
+| - | - |
+| `lr_muown` | 0.0035 |
+| `momentum` | 0.95 |
+| `ns_steps` | 12 |
+| `direction_scale` | 0.2 |
+| `v_norm_target_scale` | 2.688 (x family mult) |
+| `lr_cooldown_frac` (both) | 0.7 |
+| `lr_embed` / `lr_head` / `lr_1d` | 0.9 / 0.009375 / 0.03 |
+| `batch_size` | 524288 |
+| `train_steps` | 3200 |
+
+## Statistical significance
+
+The benchmark requires `(3.28 - mu) * sqrt(n) >= 0.004`.  For n=10, this yields a threshold of
+`mu < 3.28 - 0.004/sqrt(10) = 3.27874`.
+
+Ten non-cherry-picked seeds (1-10) were run for 3200 steps.  The
+significance condition is first satisfied at **step 3125**:
+
+| Step | Mean | Std | Min | Max | (3.28-mu)*sqrt(10) |
+| -: | -: | -: | -: | -: | -: |
+| 3100 | 3.27877 | 0.00080 | 3.27754 | 3.27979 | 0.00390 |
+| **3125** | **3.27752** | **0.00080** | **3.27636** | **3.27859** | **0.00784** |
+| 3150 | 3.27641 | 0.00081 | 3.27525 | 3.27748 | 0.01135 |
+| 3175 | 3.27569 | 0.00081 | 3.27451 | 3.27676 | 0.01362 |
+| 3200 | 3.27534 | 0.00081 | 3.27415 | 3.27642 | 0.01474 |
+
+At step **3125**, `(3.28 - 3.27752) * sqrt(10) = 0.00784 >= 0.004`.
+
+## Per-seed final losses (step 3200)
+
+| Seed | Val loss |
+| -: | -: |
+| 1 | 3.27541 |
+| 2 | 3.27642 |
+| 3 | 3.27600 |
+| 4 | 3.27415 |
+| 5 | 3.27607 |
+| 6 | 3.27569 |
+| 7 | 3.27558 |
+| 8 | 3.27548 |
+| 9 | 3.27421 |
+| 10 | 3.27437 |
+| **Mean** | **3.27534** |

--- a/records/track_3_optimization/results/20260508_muown/a26c8aa2-993d-443f-b931-845724d07015.txt
+++ b/records/track_3_optimization/results/20260508_muown/a26c8aa2-993d-443f-b931-845724d07015.txt
@@ -1,0 +1,1672 @@
+"""Track 3 Muown speedrunning submission."""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import glob
+import uuid
+import time
+from pathlib import Path
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+from torch.optim.optimizer import Optimizer
+import torch.nn.functional as F
+import torch.distributed as dist
+
+RANK = int(os.environ["RANK"])
+WORLD_SIZE = int(os.environ["WORLD_SIZE"])
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path(p) for p in glob.glob(filename_pattern))
+    if not files:
+        raise FileNotFoundError(
+            f"DATA_FILES_NOT_FOUND pattern={filename_pattern!r} cwd={Path.cwd()} "
+            f"data_dir={os.environ.get('DATA_DIR', '<unset>')!r}",
+        )
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+########################################
+#              Optimizer               #
+########################################
+
+POLAR_EXPRESS_LONG_COEFFS = (
+    (8.2051, -22.9019, 16.4607),
+    (4.0664, -2.8612, 0.5184),
+    (3.9096, -2.8234, 0.5250),
+    (3.2856, -2.4153, 0.4853),
+    (2.2779, -1.6198, 0.3985),
+    (1.8726, -1.2307, 0.3585),
+    (1.8564, -1.2132, 0.3568),
+    (1.8750, -1.2500, 0.3750),
+)
+
+@torch.compile
+def zeropower_via_polar_express_long(G: Tensor, steps: int = 12, eps: float = 1e-7) -> Tensor:
+    """Longer Polar Express variant. Coefficients beyond the list repeat the stable terminal polynomial."""
+    assert len(G.shape) == 2
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+    X.div_(X.norm() + eps)
+    for step in range(steps):
+        a, b, c = POLAR_EXPRESS_LONG_COEFFS[min(step, len(POLAR_EXPRESS_LONG_COEFFS) - 1)]
+        A = X @ X.T
+        B = torch.addmm(A, A, A, beta=b, alpha=c)
+        X = torch.addmm(X, B, X, beta=a)
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+@torch.compile
+def _wn_pre_ns(W: Tensor, g: Tensor, v_norm: Tensor, grad_W: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    """Reconstruct v from (W, g, v_norm) and compute weight-norm gradients."""
+    u = W / g
+    v = u * v_norm
+    grad_g = (grad_W * u).sum(dim=1, keepdim=True)
+    grad_v = (g / v_norm) * (grad_W - u * grad_g)
+    return v, grad_g, grad_v
+
+@torch.compile
+def _wn_recompose(W: Tensor, g: Tensor, v_new: Tensor, v_norm_eps: float) -> None:
+    v_norm_new = v_new.norm(dim=1, keepdim=True).clamp_min(v_norm_eps)
+    W.copy_(g * (v_new / v_norm_new))
+
+def _power_v_norm(start_v_norm: Tensor, step: int, total_steps: int, target_scale: float, power: float) -> Tensor:
+    if total_steps <= 1:
+        progress = 1.0
+    else:
+        p = min(max(step - 1, 0) / (total_steps - 1), 1.0)
+        progress = p ** power
+    target = start_v_norm.new_full(start_v_norm.shape, target_scale)
+    return torch.lerp(start_v_norm, target, progress)
+
+def _param_to_complexity(p: Tensor) -> int:
+    """Approximate zeropower cost for load-balanced parameter ordering."""
+    m, n = p.shape[0], p[0].numel()
+    return 2 * (m**2) * n + m**3
+
+
+
+class MuownDP(Optimizer):
+    """Data-parallel Muown: shard zeropower work across ranks, then sync weights."""
+
+    rank_sharded = True
+
+    def __init__(
+        self,
+        params,
+        lr: float = 3e-4,
+        momentum: float = 0.95,
+        betas: Tuple[float, float] = (0.9, 0.95),
+        adam_eps: float = 1e-8,
+        ns_steps: int = 12,
+        v_norm_schedule_steps: int = 0,
+        v_norm_schedule_power: float = 1.2,
+        v_norm_target_scale: float = 1.0,
+        v_norm_eps: float = 1e-12,
+        direction_scale: float = 0.2,
+    ):
+        if not isinstance(params, list):
+            params = list(params)
+        if not dist.is_initialized():
+            raise ValueError("Using MuownDP in a non-distributed run.")
+
+        if isinstance(params[0], dict):
+            for group in params:
+                group["params"] = sorted(group["params"], key=_param_to_complexity, reverse=True)
+        else:
+            params = sorted(params, key=_param_to_complexity, reverse=True)
+
+        defaults = dict(
+            lr=lr,
+            momentum=momentum,
+            betas=betas,
+            adam_eps=adam_eps,
+            ns_steps=ns_steps,
+            v_norm_schedule_steps=v_norm_schedule_steps,
+            v_norm_schedule_power=v_norm_schedule_power,
+            v_norm_target_scale=v_norm_target_scale,
+            v_norm_eps=v_norm_eps,
+            direction_scale=direction_scale,
+        )
+        super().__init__(params, defaults)
+
+    def _init_state_2d(self, p: Tensor, state: dict, v_norm_eps: float) -> None:
+        w_norm_raw = p.data.norm(dim=1, keepdim=True)
+        w_norm = w_norm_raw.clamp_min(v_norm_eps)
+        zero_rows = w_norm_raw <= v_norm_eps
+        if zero_rows.any():
+            w_norm = torch.where(zero_rows, w_norm.new_full(w_norm.shape, 0.33**0.5), w_norm)
+        state["g"] = w_norm.clone()
+        state["v_norm"] = w_norm.clone()
+        state["v_norm_init"] = w_norm.clone()
+        state["m_v"] = torch.zeros_like(p.data)
+        state["m_g"] = torch.zeros_like(w_norm)
+        state["v_g"] = torch.zeros_like(w_norm)
+        state["step"] = 0
+
+    @torch.no_grad()
+    def step(self, closure: Optional[Callable] = None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            betas = group["betas"]
+            adam_eps = group["adam_eps"]
+            ns_steps = group["ns_steps"]
+            v_norm_eps = group["v_norm_eps"]
+            direction_scale = group["direction_scale"]
+            v_norm_interpolation_steps = group["v_norm_schedule_steps"]
+            v_norm_schedule_power = group["v_norm_schedule_power"]
+            v_norm_target_scale = group["v_norm_target_scale"]
+            params = group["params"]
+
+            for block_start in range(0, len(params), WORLD_SIZE):
+                if block_start + RANK < len(params):
+                    p = params[block_start + RANK]
+                    if p.grad is None:
+                        p.grad = torch.zeros_like(p)
+                    grad = p.grad
+                    state = self.state[p]
+                    if len(state) == 0:
+                        self._init_state_2d(
+                            p,
+                            state,
+                            v_norm_eps,
+                        )
+
+                    state["step"] += 1
+                    step = state["step"]
+
+                    g = state["g"]
+                    v_norm = state["v_norm"]
+                    start_v_norm = state["v_norm_init"]
+                    m_v = state["m_v"]
+                    v, grad_g, grad_v = _wn_pre_ns(p.data, g, v_norm, grad)
+
+                    m_v.mul_(momentum).add_(grad_v)
+                    update = grad_v.add(m_v, alpha=momentum)
+                    update = zeropower_via_polar_express_long(update, steps=ns_steps)
+                    scale = direction_scale * max(update.size(0), update.size(1)) ** 0.5
+                    v_new = v.add(update, alpha=-lr * scale)
+
+                    beta1, beta2 = betas
+                    m_g = state["m_g"]
+                    v_g = state["v_g"]
+                    m_g.mul_(beta1).add_(grad_g, alpha=1 - beta1)
+                    v_g.mul_(beta2).addcmul_(grad_g, grad_g, value=1 - beta2)
+                    bc1 = 1 - beta1**step
+                    bc2 = 1 - beta2**step
+                    g.addcdiv_(m_g / bc1, (v_g / bc2).sqrt().add_(adam_eps), value=-lr)
+
+                    _wn_recompose(p.data, g, v_new, v_norm_eps)
+                    state["v_norm"] = _power_v_norm(
+                        start_v_norm, step, v_norm_interpolation_steps, v_norm_target_scale, v_norm_schedule_power
+                    )
+                # Different block matrices have different shapes, so broadcast
+                # each updated parameter from its owner rank.
+                for owner in range(WORLD_SIZE):
+                    param_idx = block_start + owner
+                    if param_idx < len(params):
+                        dist.broadcast(params[param_idx].data, src=owner)
+
+        return loss
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+# Optimization hyperparameters.
+DATA_DIR = os.environ.get("DATA_DIR", "data/fineweb10B")
+LR_EMBED = 0.6
+LR_HEAD = 0.009375
+LR_1D = 0.03
+LR_MUOWN = 0.00325
+LR_COOLDOWN_FRAC = 0.7
+LR_POWER = 0.9
+LR_SCHEDULE_STEPS = 3165
+V_NORM_SCHEDULE_STEPS = 3165
+V_NORM_SCHEDULE_POWER = 1.2
+V_NORM_TARGET_SCALE = 2.496
+V_NORM_FAMILY_MULT = {
+    "attn.q.weight": 1.0,
+    "attn.k.weight": 1.0,
+    "attn.v.weight": 1.0,
+    "attn.proj.weight": 1,
+    "mlp.fc.weight": 1.0,
+    "mlp.proj.weight": 3.33333333333,
+}
+batch_size = 524288
+mbs = 64
+train_steps = 3090
+num_trials = 30
+
+print0(
+    f"config data_dir={DATA_DIR} train_steps={train_steps} batch_size={batch_size} mbs={mbs} "
+    f"lr_embed={LR_EMBED} lr_head={LR_HEAD} lr_1d={LR_1D} lr_muown={LR_MUOWN} "
+    f"lr_power={LR_POWER} lr_schedule_steps={LR_SCHEDULE_STEPS} "
+    f"v_norm_target_scale={V_NORM_TARGET_SCALE} v_norm_schedule_power={V_NORM_SCHEDULE_POWER} "
+    f"v_norm_schedule_steps={V_NORM_SCHEDULE_STEPS} family_mult={V_NORM_FAMILY_MULT} "
+    f"num_trials={num_trials}",
+    console=True,
+)
+
+val_tokens = 20 * 524288
+val_inputs, val_targets = next(distributed_data_generator(f"{DATA_DIR}/fineweb_val_*.bin", val_tokens))
+
+for trial_idx in range(num_trials):
+    torch.manual_seed(trial_idx)
+    torch.cuda.manual_seed_all(trial_idx)
+    print0(f"trial:{trial_idx + 1}/{num_trials} seed:{trial_idx}", console=True)
+
+    model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+    model.compile(dynamic=False)
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    muown_param_groups = [
+        dict(
+            params=[p for name, p in model.blocks.named_parameters() if name.endswith(suffix)],
+            v_norm_target_scale=V_NORM_TARGET_SCALE * multiplier,
+        )
+        for suffix, multiplier in V_NORM_FAMILY_MULT.items()
+    ]
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=LR_EMBED),
+                        dict(params=[model.proj.weight], lr=LR_HEAD),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=LR_1D)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    optimizer2 = MuownDP(
+        muown_param_groups,
+        lr=LR_MUOWN,
+        momentum=0.95,
+        ns_steps=12,
+        v_norm_schedule_steps=V_NORM_SCHEDULE_STEPS,
+        v_norm_schedule_power=V_NORM_SCHEDULE_POWER,
+        direction_scale=0.2,
+    )
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then powered cooldown.
+    def lr_eta(step: int) -> float:
+        progress = step / LR_SCHEDULE_STEPS
+        assert 0 <= progress < 1
+        if progress < 1 - LR_COOLDOWN_FRAC:
+            return 1.0
+        return ((1 - progress) / LR_COOLDOWN_FRAC) ** LR_POWER
+
+
+    def set_hparams(step):
+        eta = lr_eta(step)
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator(f"{DATA_DIR}/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if val_inputs is not None and (step == train_steps or step % val_step_freq == 0):
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            train_loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+            train_loss.backward()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+
+    del train_loader, optimizers, optimizer1, optimizer2, model
+    torch.cuda.empty_cache()
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0 on NVIDIA GH200 120GB with world_size 4
+====================================================================================================
+config data_dir=/iopsstor/scratch/cscs/klion/track3-data/fineweb10B train_steps=3090 batch_size=524288 mbs=64 lr_embed=0.6 lr_head=0.009375 lr_1d=0.03 lr_muown=0.00325 lr_power=0.9 lr_schedule_steps=3165 v_norm_target_scale=2.496 v_norm_schedule_power=1.2 v_norm_schedule_steps=3165 family_mult={'attn.q.weight': 1.0, 'attn.k.weight': 1.0, 'attn.v.weight': 1.0, 'attn.proj.weight': 1, 'mlp.fc.weight': 1.0, 'mlp.proj.weight': 3.33333333333} num_trials=30
+trial:1/30 seed:0
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78423 train_time:76.803s step_avg:614.43ms
+step:250/3090 val_loss:4.20616 train_time:116.694s step_avg:319.13ms
+step:375/3090 val_loss:4.03278 train_time:156.541s step_avg:318.78ms
+step:500/3090 val_loss:3.92291 train_time:196.452s step_avg:319.28ms
+step:625/3090 val_loss:3.85240 train_time:236.385s step_avg:319.46ms
+step:750/3090 val_loss:3.80589 train_time:276.415s step_avg:320.24ms
+step:875/3090 val_loss:3.75527 train_time:316.341s step_avg:319.41ms
+step:1000/3090 val_loss:3.70162 train_time:356.247s step_avg:319.25ms
+step:1125/3090 val_loss:3.66229 train_time:396.215s step_avg:319.74ms
+step:1250/3090 val_loss:3.62115 train_time:436.125s step_avg:319.28ms
+step:1375/3090 val_loss:3.58326 train_time:476.044s step_avg:319.35ms
+step:1500/3090 val_loss:3.54129 train_time:515.982s step_avg:319.51ms
+step:1625/3090 val_loss:3.51092 train_time:555.939s step_avg:319.65ms
+step:1750/3090 val_loss:3.48046 train_time:595.937s step_avg:319.99ms
+step:1875/3090 val_loss:3.45250 train_time:635.856s step_avg:319.35ms
+step:2000/3090 val_loss:3.42681 train_time:675.864s step_avg:320.06ms
+step:2125/3090 val_loss:3.40454 train_time:715.888s step_avg:320.19ms
+step:2250/3090 val_loss:3.38175 train_time:755.858s step_avg:319.76ms
+step:2375/3090 val_loss:3.36166 train_time:795.871s step_avg:320.10ms
+step:2500/3090 val_loss:3.34318 train_time:835.858s step_avg:319.90ms
+step:2625/3090 val_loss:3.32538 train_time:875.837s step_avg:319.83ms
+step:2750/3090 val_loss:3.30961 train_time:915.881s step_avg:320.35ms
+step:2800/3090 val_loss:3.30303 train_time:931.872s step_avg:319.83ms
+step:2825/3090 val_loss:3.30031 train_time:939.869s step_avg:319.87ms
+step:2850/3090 val_loss:3.29791 train_time:947.869s step_avg:320.00ms
+step:2875/3090 val_loss:3.29524 train_time:955.910s step_avg:321.66ms
+step:2900/3090 val_loss:3.29254 train_time:963.916s step_avg:320.23ms
+step:2925/3090 val_loss:3.28976 train_time:971.924s step_avg:320.30ms
+step:2950/3090 val_loss:3.28734 train_time:979.944s step_avg:320.80ms
+step:2975/3090 val_loss:3.28522 train_time:987.939s step_avg:319.81ms
+step:3000/3090 val_loss:3.28295 train_time:995.933s step_avg:319.77ms
+step:3025/3090 val_loss:3.28040 train_time:1003.928s step_avg:319.78ms
+step:3050/3090 val_loss:3.27843 train_time:1011.977s step_avg:321.95ms
+step:3075/3090 val_loss:3.27657 train_time:1019.969s step_avg:319.70ms
+step:3090/3090 val_loss:3.27566 train_time:1024.771s step_avg:320.15ms
+trial:2/30 seed:1
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.79779 train_time:40.363s step_avg:322.91ms
+step:250/3090 val_loss:4.25771 train_time:80.437s step_avg:320.59ms
+step:375/3090 val_loss:4.05481 train_time:120.434s step_avg:319.97ms
+step:500/3090 val_loss:3.93336 train_time:160.451s step_avg:320.14ms
+step:625/3090 val_loss:3.85998 train_time:200.459s step_avg:320.06ms
+step:750/3090 val_loss:3.80865 train_time:240.425s step_avg:319.72ms
+step:875/3090 val_loss:3.75913 train_time:280.415s step_avg:319.92ms
+step:1000/3090 val_loss:3.70366 train_time:320.390s step_avg:319.80ms
+step:1125/3090 val_loss:3.66955 train_time:360.365s step_avg:319.80ms
+step:1250/3090 val_loss:3.61881 train_time:400.358s step_avg:319.94ms
+step:1375/3090 val_loss:3.58296 train_time:440.355s step_avg:319.98ms
+step:1500/3090 val_loss:3.54496 train_time:480.332s step_avg:319.81ms
+step:1625/3090 val_loss:3.51285 train_time:520.326s step_avg:319.96ms
+step:1750/3090 val_loss:3.48357 train_time:560.326s step_avg:320.00ms
+step:1875/3090 val_loss:3.45582 train_time:600.294s step_avg:319.74ms
+step:2000/3090 val_loss:3.43005 train_time:640.296s step_avg:320.02ms
+step:2125/3090 val_loss:3.40762 train_time:680.286s step_avg:319.92ms
+step:2250/3090 val_loss:3.38533 train_time:720.278s step_avg:319.93ms
+step:2375/3090 val_loss:3.36540 train_time:760.292s step_avg:320.11ms
+step:2500/3090 val_loss:3.34644 train_time:800.304s step_avg:320.09ms
+step:2625/3090 val_loss:3.32906 train_time:840.340s step_avg:320.29ms
+step:2750/3090 val_loss:3.31314 train_time:880.360s step_avg:320.16ms
+step:2800/3090 val_loss:3.30689 train_time:896.371s step_avg:320.21ms
+step:2825/3090 val_loss:3.30421 train_time:904.387s step_avg:320.67ms
+step:2850/3090 val_loss:3.30181 train_time:912.391s step_avg:320.16ms
+step:2875/3090 val_loss:3.29921 train_time:920.412s step_avg:320.82ms
+step:2900/3090 val_loss:3.29666 train_time:928.417s step_avg:320.23ms
+step:2925/3090 val_loss:3.29368 train_time:936.427s step_avg:320.37ms
+step:2950/3090 val_loss:3.29132 train_time:944.439s step_avg:320.50ms
+step:2975/3090 val_loss:3.28932 train_time:952.445s step_avg:320.25ms
+step:3000/3090 val_loss:3.28677 train_time:960.452s step_avg:320.26ms
+step:3025/3090 val_loss:3.28431 train_time:968.455s step_avg:320.13ms
+step:3050/3090 val_loss:3.28234 train_time:976.475s step_avg:320.80ms
+step:3075/3090 val_loss:3.28054 train_time:984.485s step_avg:320.40ms
+step:3090/3090 val_loss:3.27963 train_time:989.292s step_avg:320.43ms
+trial:3/30 seed:2
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77982 train_time:40.423s step_avg:323.38ms
+step:250/3090 val_loss:4.20950 train_time:80.573s step_avg:321.20ms
+step:375/3090 val_loss:4.04125 train_time:120.601s step_avg:320.22ms
+step:500/3090 val_loss:3.93146 train_time:160.627s step_avg:320.22ms
+step:625/3090 val_loss:3.86280 train_time:200.663s step_avg:320.28ms
+step:750/3090 val_loss:3.80553 train_time:240.677s step_avg:320.11ms
+step:875/3090 val_loss:3.75246 train_time:280.715s step_avg:320.30ms
+step:1000/3090 val_loss:3.70524 train_time:320.748s step_avg:320.26ms
+step:1125/3090 val_loss:3.66545 train_time:360.750s step_avg:320.01ms
+step:1250/3090 val_loss:3.61994 train_time:400.755s step_avg:320.04ms
+step:1375/3090 val_loss:3.58204 train_time:440.763s step_avg:320.07ms
+step:1500/3090 val_loss:3.54749 train_time:480.747s step_avg:319.87ms
+step:1625/3090 val_loss:3.51305 train_time:520.727s step_avg:319.83ms
+step:1750/3090 val_loss:3.48209 train_time:560.756s step_avg:320.23ms
+step:1875/3090 val_loss:3.45710 train_time:600.752s step_avg:319.97ms
+step:2000/3090 val_loss:3.42943 train_time:640.753s step_avg:320.00ms
+step:2125/3090 val_loss:3.40674 train_time:680.751s step_avg:319.99ms
+step:2250/3090 val_loss:3.38448 train_time:720.788s step_avg:320.29ms
+step:2375/3090 val_loss:3.36465 train_time:761.171s step_avg:323.06ms
+step:2500/3090 val_loss:3.34611 train_time:801.425s step_avg:322.03ms
+step:2625/3090 val_loss:3.32810 train_time:841.517s step_avg:320.74ms
+step:2750/3090 val_loss:3.31242 train_time:881.543s step_avg:320.21ms
+step:2800/3090 val_loss:3.30588 train_time:897.533s step_avg:319.81ms
+step:2825/3090 val_loss:3.30335 train_time:905.541s step_avg:320.28ms
+step:2850/3090 val_loss:3.30069 train_time:913.536s step_avg:319.84ms
+step:2875/3090 val_loss:3.29819 train_time:921.549s step_avg:320.49ms
+step:2900/3090 val_loss:3.29565 train_time:929.579s step_avg:321.21ms
+step:2925/3090 val_loss:3.29277 train_time:937.577s step_avg:319.93ms
+step:2950/3090 val_loss:3.29033 train_time:945.582s step_avg:320.17ms
+step:2975/3090 val_loss:3.28824 train_time:953.578s step_avg:319.86ms
+step:3000/3090 val_loss:3.28591 train_time:961.594s step_avg:320.64ms
+step:3025/3090 val_loss:3.28340 train_time:969.599s step_avg:320.19ms
+step:3050/3090 val_loss:3.28142 train_time:977.617s step_avg:320.71ms
+step:3075/3090 val_loss:3.27964 train_time:985.625s step_avg:320.32ms
+step:3090/3090 val_loss:3.27864 train_time:990.421s step_avg:319.78ms
+trial:4/30 seed:3
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.79074 train_time:40.461s step_avg:323.68ms
+step:250/3090 val_loss:4.21078 train_time:80.623s step_avg:321.29ms
+step:375/3090 val_loss:4.05226 train_time:120.679s step_avg:320.46ms
+step:500/3090 val_loss:3.92879 train_time:160.709s step_avg:320.24ms
+step:625/3090 val_loss:3.85810 train_time:200.781s step_avg:320.57ms
+step:750/3090 val_loss:3.80814 train_time:240.785s step_avg:320.03ms
+step:875/3090 val_loss:3.75055 train_time:280.817s step_avg:320.26ms
+step:1000/3090 val_loss:3.71038 train_time:320.843s step_avg:320.21ms
+step:1125/3090 val_loss:3.66047 train_time:360.859s step_avg:320.13ms
+step:1250/3090 val_loss:3.62191 train_time:400.876s step_avg:320.14ms
+step:1375/3090 val_loss:3.58084 train_time:440.895s step_avg:320.15ms
+step:1500/3090 val_loss:3.54390 train_time:480.894s step_avg:320.00ms
+step:1625/3090 val_loss:3.51607 train_time:520.900s step_avg:320.04ms
+step:1750/3090 val_loss:3.48355 train_time:560.905s step_avg:320.04ms
+step:1875/3090 val_loss:3.45502 train_time:600.903s step_avg:319.99ms
+step:2000/3090 val_loss:3.42920 train_time:640.924s step_avg:320.17ms
+step:2125/3090 val_loss:3.40593 train_time:680.961s step_avg:320.29ms
+step:2250/3090 val_loss:3.38402 train_time:720.966s step_avg:320.05ms
+step:2375/3090 val_loss:3.36411 train_time:760.995s step_avg:320.23ms
+step:2500/3090 val_loss:3.34513 train_time:801.044s step_avg:320.39ms
+step:2625/3090 val_loss:3.32729 train_time:841.169s step_avg:321.00ms
+step:2750/3090 val_loss:3.31146 train_time:881.253s step_avg:320.67ms
+step:2800/3090 val_loss:3.30492 train_time:897.266s step_avg:320.25ms
+step:2825/3090 val_loss:3.30238 train_time:905.270s step_avg:320.17ms
+step:2850/3090 val_loss:3.30006 train_time:913.273s step_avg:320.10ms
+step:2875/3090 val_loss:3.29736 train_time:921.332s step_avg:322.36ms
+step:2900/3090 val_loss:3.29485 train_time:929.336s step_avg:320.17ms
+step:2925/3090 val_loss:3.29183 train_time:937.339s step_avg:320.11ms
+step:2950/3090 val_loss:3.28945 train_time:945.341s step_avg:320.10ms
+step:2975/3090 val_loss:3.28739 train_time:953.344s step_avg:320.14ms
+step:3000/3090 val_loss:3.28504 train_time:961.346s step_avg:320.07ms
+step:3025/3090 val_loss:3.28245 train_time:969.345s step_avg:319.97ms
+step:3050/3090 val_loss:3.28045 train_time:977.399s step_avg:322.15ms
+step:3075/3090 val_loss:3.27860 train_time:985.400s step_avg:320.06ms
+step:3090/3090 val_loss:3.27775 train_time:990.195s step_avg:319.65ms
+trial:5/30 seed:4
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77814 train_time:40.431s step_avg:323.45ms
+step:250/3090 val_loss:4.20664 train_time:80.617s step_avg:321.49ms
+step:375/3090 val_loss:4.05974 train_time:120.656s step_avg:320.31ms
+step:500/3090 val_loss:3.93054 train_time:160.709s step_avg:320.42ms
+step:625/3090 val_loss:3.86533 train_time:200.726s step_avg:320.14ms
+step:750/3090 val_loss:3.80560 train_time:240.702s step_avg:319.80ms
+step:875/3090 val_loss:3.75587 train_time:280.701s step_avg:319.99ms
+step:1000/3090 val_loss:3.70280 train_time:320.713s step_avg:320.10ms
+step:1125/3090 val_loss:3.66483 train_time:360.698s step_avg:319.88ms
+step:1250/3090 val_loss:3.62260 train_time:400.720s step_avg:320.17ms
+step:1375/3090 val_loss:3.58133 train_time:440.740s step_avg:320.16ms
+step:1500/3090 val_loss:3.54211 train_time:480.728s step_avg:319.90ms
+step:1625/3090 val_loss:3.51205 train_time:520.753s step_avg:320.20ms
+step:1750/3090 val_loss:3.48292 train_time:560.790s step_avg:320.30ms
+step:1875/3090 val_loss:3.45489 train_time:600.810s step_avg:320.16ms
+step:2000/3090 val_loss:3.42811 train_time:640.847s step_avg:320.29ms
+step:2125/3090 val_loss:3.40559 train_time:680.894s step_avg:320.38ms
+step:2250/3090 val_loss:3.38305 train_time:720.902s step_avg:320.07ms
+step:2375/3090 val_loss:3.36354 train_time:760.921s step_avg:320.15ms
+step:2500/3090 val_loss:3.34420 train_time:800.922s step_avg:320.01ms
+step:2625/3090 val_loss:3.32648 train_time:840.915s step_avg:319.94ms
+step:2750/3090 val_loss:3.31068 train_time:880.923s step_avg:320.07ms
+step:2800/3090 val_loss:3.30424 train_time:896.943s step_avg:320.38ms
+step:2825/3090 val_loss:3.30177 train_time:904.942s step_avg:319.97ms
+step:2850/3090 val_loss:3.29938 train_time:912.952s step_avg:320.42ms
+step:2875/3090 val_loss:3.29655 train_time:920.974s step_avg:320.88ms
+step:2900/3090 val_loss:3.29396 train_time:928.972s step_avg:319.92ms
+step:2925/3090 val_loss:3.29086 train_time:936.971s step_avg:319.95ms
+step:2950/3090 val_loss:3.28859 train_time:944.967s step_avg:319.85ms
+step:2975/3090 val_loss:3.28649 train_time:952.976s step_avg:320.35ms
+step:3000/3090 val_loss:3.28410 train_time:960.970s step_avg:319.74ms
+step:3025/3090 val_loss:3.28154 train_time:968.949s step_avg:319.17ms
+step:3050/3090 val_loss:3.27956 train_time:976.951s step_avg:320.08ms
+step:3075/3090 val_loss:3.27782 train_time:984.937s step_avg:319.43ms
+step:3090/3090 val_loss:3.27689 train_time:989.724s step_avg:319.12ms
+trial:6/30 seed:5
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77555 train_time:40.397s step_avg:323.17ms
+step:250/3090 val_loss:4.21394 train_time:80.476s step_avg:320.63ms
+step:375/3090 val_loss:4.04549 train_time:120.478s step_avg:320.02ms
+step:500/3090 val_loss:3.93175 train_time:160.874s step_avg:323.16ms
+step:625/3090 val_loss:3.86756 train_time:200.911s step_avg:320.30ms
+step:750/3090 val_loss:3.80612 train_time:240.850s step_avg:319.51ms
+step:875/3090 val_loss:3.76079 train_time:280.989s step_avg:321.11ms
+step:1000/3090 val_loss:3.70619 train_time:321.053s step_avg:320.51ms
+step:1125/3090 val_loss:3.66322 train_time:361.025s step_avg:319.78ms
+step:1250/3090 val_loss:3.62311 train_time:400.975s step_avg:319.59ms
+step:1375/3090 val_loss:3.58224 train_time:441.044s step_avg:320.56ms
+step:1500/3090 val_loss:3.54375 train_time:481.140s step_avg:320.77ms
+step:1625/3090 val_loss:3.51594 train_time:521.191s step_avg:320.41ms
+step:1750/3090 val_loss:3.48300 train_time:561.186s step_avg:319.96ms
+step:1875/3090 val_loss:3.45639 train_time:601.189s step_avg:320.02ms
+step:2000/3090 val_loss:3.43027 train_time:641.176s step_avg:319.89ms
+step:2125/3090 val_loss:3.40720 train_time:681.152s step_avg:319.80ms
+step:2250/3090 val_loss:3.38532 train_time:721.157s step_avg:320.04ms
+step:2375/3090 val_loss:3.36529 train_time:761.168s step_avg:320.08ms
+step:2500/3090 val_loss:3.34677 train_time:801.309s step_avg:321.13ms
+step:2625/3090 val_loss:3.32879 train_time:841.621s step_avg:322.50ms
+step:2750/3090 val_loss:3.31305 train_time:881.735s step_avg:320.91ms
+step:2800/3090 val_loss:3.30657 train_time:897.848s step_avg:322.26ms
+step:2825/3090 val_loss:3.30410 train_time:905.904s step_avg:322.25ms
+step:2850/3090 val_loss:3.30159 train_time:913.948s step_avg:321.76ms
+step:2875/3090 val_loss:3.29913 train_time:922.011s step_avg:322.52ms
+step:2900/3090 val_loss:3.29644 train_time:930.042s step_avg:321.22ms
+step:2925/3090 val_loss:3.29353 train_time:938.063s step_avg:320.85ms
+step:2950/3090 val_loss:3.29106 train_time:946.065s step_avg:320.08ms
+step:2975/3090 val_loss:3.28903 train_time:954.087s step_avg:320.90ms
+step:3000/3090 val_loss:3.28671 train_time:962.095s step_avg:320.32ms
+step:3025/3090 val_loss:3.28422 train_time:970.112s step_avg:320.69ms
+step:3050/3090 val_loss:3.28225 train_time:978.133s step_avg:320.82ms
+step:3075/3090 val_loss:3.28045 train_time:986.140s step_avg:320.29ms
+step:3090/3090 val_loss:3.27951 train_time:990.944s step_avg:320.28ms
+trial:7/30 seed:6
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78604 train_time:40.493s step_avg:323.94ms
+step:250/3090 val_loss:4.22865 train_time:80.680s step_avg:321.50ms
+step:375/3090 val_loss:4.03424 train_time:120.736s step_avg:320.45ms
+step:500/3090 val_loss:3.93216 train_time:160.756s step_avg:320.16ms
+step:625/3090 val_loss:3.86558 train_time:200.781s step_avg:320.20ms
+step:750/3090 val_loss:3.80414 train_time:240.776s step_avg:319.96ms
+step:875/3090 val_loss:3.75397 train_time:280.772s step_avg:319.96ms
+step:1000/3090 val_loss:3.70398 train_time:320.853s step_avg:320.65ms
+step:1125/3090 val_loss:3.67010 train_time:360.847s step_avg:319.95ms
+step:1250/3090 val_loss:3.61679 train_time:400.856s step_avg:320.07ms
+step:1375/3090 val_loss:3.58229 train_time:440.855s step_avg:320.00ms
+step:1500/3090 val_loss:3.54310 train_time:480.848s step_avg:319.95ms
+step:1625/3090 val_loss:3.51384 train_time:520.845s step_avg:319.98ms
+step:1750/3090 val_loss:3.48338 train_time:560.865s step_avg:320.16ms
+step:1875/3090 val_loss:3.45557 train_time:600.863s step_avg:319.98ms
+step:2000/3090 val_loss:3.42844 train_time:640.894s step_avg:320.25ms
+step:2125/3090 val_loss:3.40553 train_time:681.058s step_avg:321.31ms
+step:2250/3090 val_loss:3.38324 train_time:721.195s step_avg:321.09ms
+step:2375/3090 val_loss:3.36339 train_time:761.246s step_avg:320.41ms
+step:2500/3090 val_loss:3.34452 train_time:801.281s step_avg:320.28ms
+step:2625/3090 val_loss:3.32651 train_time:841.298s step_avg:320.14ms
+step:2750/3090 val_loss:3.31109 train_time:881.330s step_avg:320.25ms
+step:2800/3090 val_loss:3.30443 train_time:897.319s step_avg:319.77ms
+step:2825/3090 val_loss:3.30183 train_time:905.327s step_avg:320.34ms
+step:2850/3090 val_loss:3.29919 train_time:913.328s step_avg:320.03ms
+step:2875/3090 val_loss:3.29650 train_time:921.343s step_avg:320.59ms
+step:2900/3090 val_loss:3.29384 train_time:929.341s step_avg:319.92ms
+step:2925/3090 val_loss:3.29093 train_time:937.353s step_avg:320.50ms
+step:2950/3090 val_loss:3.28860 train_time:945.367s step_avg:320.57ms
+step:2975/3090 val_loss:3.28644 train_time:953.384s step_avg:320.68ms
+step:3000/3090 val_loss:3.28399 train_time:961.397s step_avg:320.50ms
+step:3025/3090 val_loss:3.28149 train_time:969.417s step_avg:320.80ms
+step:3050/3090 val_loss:3.27961 train_time:977.439s step_avg:320.89ms
+step:3075/3090 val_loss:3.27772 train_time:985.451s step_avg:320.48ms
+step:3090/3090 val_loss:3.27685 train_time:990.256s step_avg:320.31ms
+trial:8/30 seed:7
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.82807 train_time:40.458s step_avg:323.66ms
+step:250/3090 val_loss:4.20154 train_time:80.616s step_avg:321.27ms
+step:375/3090 val_loss:4.04925 train_time:120.651s step_avg:320.28ms
+step:500/3090 val_loss:3.92593 train_time:160.675s step_avg:320.20ms
+step:625/3090 val_loss:3.86302 train_time:200.688s step_avg:320.10ms
+step:750/3090 val_loss:3.80763 train_time:240.694s step_avg:320.06ms
+step:875/3090 val_loss:3.75619 train_time:280.708s step_avg:320.11ms
+step:1000/3090 val_loss:3.70193 train_time:320.743s step_avg:320.28ms
+step:1125/3090 val_loss:3.66398 train_time:360.752s step_avg:320.07ms
+step:1250/3090 val_loss:3.62208 train_time:400.758s step_avg:320.05ms
+step:1375/3090 val_loss:3.57944 train_time:440.763s step_avg:320.04ms
+step:1500/3090 val_loss:3.54322 train_time:480.770s step_avg:320.05ms
+step:1625/3090 val_loss:3.51428 train_time:520.796s step_avg:320.21ms
+step:1750/3090 val_loss:3.48208 train_time:560.976s step_avg:321.43ms
+step:1875/3090 val_loss:3.45484 train_time:600.978s step_avg:320.02ms
+step:2000/3090 val_loss:3.42761 train_time:641.005s step_avg:320.21ms
+step:2125/3090 val_loss:3.40467 train_time:680.970s step_avg:319.72ms
+step:2250/3090 val_loss:3.38255 train_time:720.919s step_avg:319.59ms
+step:2375/3090 val_loss:3.36269 train_time:760.873s step_avg:319.64ms
+step:2500/3090 val_loss:3.34375 train_time:800.891s step_avg:320.14ms
+step:2625/3090 val_loss:3.32614 train_time:841.003s step_avg:320.90ms
+step:2750/3090 val_loss:3.31026 train_time:881.117s step_avg:320.91ms
+step:2800/3090 val_loss:3.30379 train_time:897.128s step_avg:320.22ms
+step:2825/3090 val_loss:3.30124 train_time:905.123s step_avg:319.80ms
+step:2850/3090 val_loss:3.29863 train_time:913.113s step_avg:319.62ms
+step:2875/3090 val_loss:3.29601 train_time:921.164s step_avg:322.03ms
+step:2900/3090 val_loss:3.29349 train_time:929.170s step_avg:320.22ms
+step:2925/3090 val_loss:3.29038 train_time:937.164s step_avg:319.77ms
+step:2950/3090 val_loss:3.28811 train_time:945.142s step_avg:319.13ms
+step:2975/3090 val_loss:3.28599 train_time:953.140s step_avg:319.91ms
+step:3000/3090 val_loss:3.28362 train_time:961.149s step_avg:320.37ms
+step:3025/3090 val_loss:3.28117 train_time:969.145s step_avg:319.85ms
+step:3050/3090 val_loss:3.27918 train_time:977.193s step_avg:321.91ms
+step:3075/3090 val_loss:3.27728 train_time:985.193s step_avg:320.00ms
+step:3090/3090 val_loss:3.27636 train_time:989.984s step_avg:319.39ms
+trial:9/30 seed:8
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78546 train_time:40.404s step_avg:323.23ms
+step:250/3090 val_loss:4.21202 train_time:80.487s step_avg:320.67ms
+step:375/3090 val_loss:4.03615 train_time:120.653s step_avg:321.32ms
+step:500/3090 val_loss:3.93210 train_time:160.659s step_avg:320.05ms
+step:625/3090 val_loss:3.86507 train_time:200.663s step_avg:320.03ms
+step:750/3090 val_loss:3.80881 train_time:240.678s step_avg:320.12ms
+step:875/3090 val_loss:3.75365 train_time:280.683s step_avg:320.04ms
+step:1000/3090 val_loss:3.70447 train_time:320.734s step_avg:320.41ms
+step:1125/3090 val_loss:3.66549 train_time:360.926s step_avg:321.53ms
+step:1250/3090 val_loss:3.62474 train_time:400.941s step_avg:320.12ms
+step:1375/3090 val_loss:3.58473 train_time:440.935s step_avg:319.95ms
+step:1500/3090 val_loss:3.54560 train_time:480.934s step_avg:319.99ms
+step:1625/3090 val_loss:3.51295 train_time:520.943s step_avg:320.08ms
+step:1750/3090 val_loss:3.48408 train_time:560.981s step_avg:320.30ms
+step:1875/3090 val_loss:3.45534 train_time:600.979s step_avg:319.98ms
+step:2000/3090 val_loss:3.42970 train_time:640.974s step_avg:319.96ms
+step:2125/3090 val_loss:3.40687 train_time:680.971s step_avg:319.97ms
+step:2250/3090 val_loss:3.38501 train_time:720.999s step_avg:320.22ms
+step:2375/3090 val_loss:3.36517 train_time:761.012s step_avg:320.10ms
+step:2500/3090 val_loss:3.34577 train_time:801.033s step_avg:320.17ms
+step:2625/3090 val_loss:3.32830 train_time:841.028s step_avg:319.96ms
+step:2750/3090 val_loss:3.31258 train_time:881.016s step_avg:319.90ms
+step:2800/3090 val_loss:3.30602 train_time:897.013s step_avg:319.94ms
+step:2825/3090 val_loss:3.30340 train_time:904.998s step_avg:319.37ms
+step:2850/3090 val_loss:3.30079 train_time:912.997s step_avg:319.98ms
+step:2875/3090 val_loss:3.29810 train_time:921.014s step_avg:320.69ms
+step:2900/3090 val_loss:3.29568 train_time:929.002s step_avg:319.52ms
+step:2925/3090 val_loss:3.29262 train_time:936.990s step_avg:319.52ms
+step:2950/3090 val_loss:3.29038 train_time:944.983s step_avg:319.73ms
+step:2975/3090 val_loss:3.28833 train_time:952.982s step_avg:319.95ms
+step:3000/3090 val_loss:3.28574 train_time:960.969s step_avg:319.48ms
+step:3025/3090 val_loss:3.28328 train_time:968.975s step_avg:320.24ms
+step:3050/3090 val_loss:3.28121 train_time:976.965s step_avg:319.58ms
+step:3075/3090 val_loss:3.27949 train_time:984.961s step_avg:319.85ms
+step:3090/3090 val_loss:3.27852 train_time:989.754s step_avg:319.55ms
+trial:10/30 seed:9
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.79578 train_time:40.369s step_avg:322.95ms
+step:250/3090 val_loss:4.22149 train_time:80.416s step_avg:320.37ms
+step:375/3090 val_loss:4.03842 train_time:120.542s step_avg:321.01ms
+step:500/3090 val_loss:3.93516 train_time:160.601s step_avg:320.47ms
+step:625/3090 val_loss:3.85763 train_time:200.593s step_avg:319.93ms
+step:750/3090 val_loss:3.80373 train_time:240.587s step_avg:319.95ms
+step:875/3090 val_loss:3.75187 train_time:280.636s step_avg:320.39ms
+step:1000/3090 val_loss:3.70287 train_time:320.582s step_avg:319.57ms
+step:1125/3090 val_loss:3.66559 train_time:360.519s step_avg:319.50ms
+step:1250/3090 val_loss:3.61871 train_time:400.455s step_avg:319.48ms
+step:1375/3090 val_loss:3.57964 train_time:440.380s step_avg:319.40ms
+step:1500/3090 val_loss:3.54328 train_time:480.353s step_avg:319.78ms
+step:1625/3090 val_loss:3.51280 train_time:520.350s step_avg:319.98ms
+step:1750/3090 val_loss:3.48114 train_time:560.344s step_avg:319.96ms
+step:1875/3090 val_loss:3.45350 train_time:600.345s step_avg:320.00ms
+step:2000/3090 val_loss:3.42714 train_time:640.346s step_avg:320.01ms
+step:2125/3090 val_loss:3.40480 train_time:680.352s step_avg:320.05ms
+step:2250/3090 val_loss:3.38245 train_time:720.350s step_avg:319.98ms
+step:2375/3090 val_loss:3.36269 train_time:760.322s step_avg:319.78ms
+step:2500/3090 val_loss:3.34374 train_time:800.332s step_avg:320.08ms
+step:2625/3090 val_loss:3.32577 train_time:840.320s step_avg:319.90ms
+step:2750/3090 val_loss:3.31013 train_time:880.294s step_avg:319.79ms
+step:2800/3090 val_loss:3.30366 train_time:896.303s step_avg:320.18ms
+step:2825/3090 val_loss:3.30124 train_time:904.301s step_avg:319.89ms
+step:2850/3090 val_loss:3.29871 train_time:912.293s step_avg:319.68ms
+step:2875/3090 val_loss:3.29589 train_time:920.306s step_avg:320.51ms
+step:2900/3090 val_loss:3.29357 train_time:928.302s step_avg:319.87ms
+step:2925/3090 val_loss:3.29057 train_time:936.309s step_avg:320.28ms
+step:2950/3090 val_loss:3.28814 train_time:944.376s step_avg:322.68ms
+step:2975/3090 val_loss:3.28587 train_time:952.461s step_avg:323.40ms
+step:3000/3090 val_loss:3.28364 train_time:960.524s step_avg:322.51ms
+step:3025/3090 val_loss:3.28115 train_time:968.573s step_avg:321.95ms
+step:3050/3090 val_loss:3.27918 train_time:976.635s step_avg:322.51ms
+step:3075/3090 val_loss:3.27738 train_time:984.690s step_avg:322.18ms
+step:3090/3090 val_loss:3.27645 train_time:989.503s step_avg:320.86ms
+trial:11/30 seed:10
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78805 train_time:40.429s step_avg:323.43ms
+step:250/3090 val_loss:4.20258 train_time:80.498s step_avg:320.55ms
+step:375/3090 val_loss:4.05962 train_time:120.498s step_avg:320.01ms
+step:500/3090 val_loss:3.92980 train_time:160.486s step_avg:319.90ms
+step:625/3090 val_loss:3.85288 train_time:200.475s step_avg:319.91ms
+step:750/3090 val_loss:3.81103 train_time:240.451s step_avg:319.81ms
+step:875/3090 val_loss:3.75374 train_time:280.433s step_avg:319.85ms
+step:1000/3090 val_loss:3.70414 train_time:320.414s step_avg:319.85ms
+step:1125/3090 val_loss:3.66565 train_time:360.380s step_avg:319.73ms
+step:1250/3090 val_loss:3.61916 train_time:400.265s step_avg:319.07ms
+step:1375/3090 val_loss:3.58332 train_time:440.185s step_avg:319.36ms
+step:1500/3090 val_loss:3.54206 train_time:480.058s step_avg:318.99ms
+step:1625/3090 val_loss:3.51189 train_time:519.933s step_avg:319.00ms
+step:1750/3090 val_loss:3.48146 train_time:559.779s step_avg:318.76ms
+step:1875/3090 val_loss:3.45453 train_time:599.604s step_avg:318.60ms
+step:2000/3090 val_loss:3.42843 train_time:639.461s step_avg:318.86ms
+step:2125/3090 val_loss:3.40550 train_time:679.373s step_avg:319.30ms
+step:2250/3090 val_loss:3.38341 train_time:719.259s step_avg:319.09ms
+step:2375/3090 val_loss:3.36363 train_time:759.168s step_avg:319.27ms
+step:2500/3090 val_loss:3.34452 train_time:799.108s step_avg:319.52ms
+step:2625/3090 val_loss:3.32681 train_time:839.130s step_avg:320.18ms
+step:2750/3090 val_loss:3.31099 train_time:879.079s step_avg:319.59ms
+step:2800/3090 val_loss:3.30473 train_time:895.066s step_avg:319.74ms
+step:2825/3090 val_loss:3.30222 train_time:903.067s step_avg:320.05ms
+step:2850/3090 val_loss:3.29956 train_time:911.074s step_avg:320.29ms
+step:2875/3090 val_loss:3.29679 train_time:919.083s step_avg:320.34ms
+step:2900/3090 val_loss:3.29424 train_time:927.066s step_avg:319.34ms
+step:2925/3090 val_loss:3.29122 train_time:935.068s step_avg:320.07ms
+step:2950/3090 val_loss:3.28894 train_time:943.052s step_avg:319.38ms
+step:2975/3090 val_loss:3.28682 train_time:951.038s step_avg:319.41ms
+step:3000/3090 val_loss:3.28453 train_time:959.016s step_avg:319.15ms
+step:3025/3090 val_loss:3.28195 train_time:967.027s step_avg:320.41ms
+step:3050/3090 val_loss:3.27999 train_time:975.069s step_avg:321.70ms
+step:3075/3090 val_loss:3.27820 train_time:983.107s step_avg:321.50ms
+step:3090/3090 val_loss:3.27724 train_time:987.933s step_avg:321.75ms
+trial:12/30 seed:11
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77040 train_time:40.511s step_avg:324.08ms
+step:250/3090 val_loss:4.22835 train_time:80.597s step_avg:320.69ms
+step:375/3090 val_loss:4.03327 train_time:120.605s step_avg:320.06ms
+step:500/3090 val_loss:3.92481 train_time:160.617s step_avg:320.10ms
+step:625/3090 val_loss:3.85520 train_time:200.569s step_avg:319.62ms
+step:750/3090 val_loss:3.79903 train_time:240.556s step_avg:319.90ms
+step:875/3090 val_loss:3.75269 train_time:280.529s step_avg:319.79ms
+step:1000/3090 val_loss:3.70608 train_time:320.464s step_avg:319.48ms
+step:1125/3090 val_loss:3.66602 train_time:360.535s step_avg:320.57ms
+step:1250/3090 val_loss:3.62547 train_time:400.596s step_avg:320.49ms
+step:1375/3090 val_loss:3.58132 train_time:440.573s step_avg:319.81ms
+step:1500/3090 val_loss:3.54465 train_time:480.516s step_avg:319.54ms
+step:1625/3090 val_loss:3.51265 train_time:520.421s step_avg:319.24ms
+step:1750/3090 val_loss:3.48249 train_time:560.338s step_avg:319.34ms
+step:1875/3090 val_loss:3.45561 train_time:600.313s step_avg:319.80ms
+step:2000/3090 val_loss:3.42964 train_time:640.294s step_avg:319.85ms
+step:2125/3090 val_loss:3.40672 train_time:680.273s step_avg:319.84ms
+step:2250/3090 val_loss:3.38454 train_time:720.232s step_avg:319.67ms
+step:2375/3090 val_loss:3.36491 train_time:760.222s step_avg:319.93ms
+step:2500/3090 val_loss:3.34623 train_time:800.261s step_avg:320.30ms
+step:2625/3090 val_loss:3.32851 train_time:840.243s step_avg:319.86ms
+step:2750/3090 val_loss:3.31288 train_time:880.242s step_avg:319.99ms
+step:2800/3090 val_loss:3.30619 train_time:896.250s step_avg:320.16ms
+step:2825/3090 val_loss:3.30364 train_time:904.243s step_avg:319.74ms
+step:2850/3090 val_loss:3.30125 train_time:912.233s step_avg:319.58ms
+step:2875/3090 val_loss:3.29851 train_time:920.263s step_avg:321.22ms
+step:2900/3090 val_loss:3.29603 train_time:928.269s step_avg:320.24ms
+step:2925/3090 val_loss:3.29310 train_time:936.267s step_avg:319.93ms
+step:2950/3090 val_loss:3.29071 train_time:944.265s step_avg:319.90ms
+step:2975/3090 val_loss:3.28847 train_time:952.264s step_avg:319.95ms
+step:3000/3090 val_loss:3.28610 train_time:960.260s step_avg:319.83ms
+step:3025/3090 val_loss:3.28362 train_time:968.247s step_avg:319.51ms
+step:3050/3090 val_loss:3.28169 train_time:976.264s step_avg:320.67ms
+step:3075/3090 val_loss:3.27987 train_time:984.260s step_avg:319.84ms
+step:3090/3090 val_loss:3.27887 train_time:989.061s step_avg:320.06ms
+trial:13/30 seed:12
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78008 train_time:40.280s step_avg:322.24ms
+step:250/3090 val_loss:4.21000 train_time:80.320s step_avg:320.32ms
+step:375/3090 val_loss:4.02663 train_time:120.316s step_avg:319.97ms
+step:500/3090 val_loss:3.93781 train_time:160.266s step_avg:319.60ms
+step:625/3090 val_loss:3.85231 train_time:200.175s step_avg:319.27ms
+step:750/3090 val_loss:3.80938 train_time:240.087s step_avg:319.30ms
+step:875/3090 val_loss:3.75646 train_time:279.994s step_avg:319.25ms
+step:1000/3090 val_loss:3.70918 train_time:320.012s step_avg:320.14ms
+step:1125/3090 val_loss:3.66861 train_time:359.954s step_avg:319.54ms
+step:1250/3090 val_loss:3.62120 train_time:399.947s step_avg:319.94ms
+step:1375/3090 val_loss:3.58391 train_time:439.929s step_avg:319.85ms
+step:1500/3090 val_loss:3.54502 train_time:479.914s step_avg:319.88ms
+step:1625/3090 val_loss:3.51461 train_time:519.898s step_avg:319.87ms
+step:1750/3090 val_loss:3.48403 train_time:559.906s step_avg:320.06ms
+step:1875/3090 val_loss:3.45650 train_time:600.068s step_avg:321.30ms
+step:2000/3090 val_loss:3.43056 train_time:640.304s step_avg:321.89ms
+step:2125/3090 val_loss:3.40829 train_time:680.348s step_avg:320.35ms
+step:2250/3090 val_loss:3.38584 train_time:720.348s step_avg:320.00ms
+step:2375/3090 val_loss:3.36620 train_time:760.365s step_avg:320.14ms
+step:2500/3090 val_loss:3.34774 train_time:800.390s step_avg:320.20ms
+step:2625/3090 val_loss:3.32952 train_time:840.391s step_avg:320.01ms
+step:2750/3090 val_loss:3.31372 train_time:880.366s step_avg:319.80ms
+step:2800/3090 val_loss:3.30743 train_time:896.365s step_avg:319.98ms
+step:2825/3090 val_loss:3.30496 train_time:904.372s step_avg:320.26ms
+step:2850/3090 val_loss:3.30238 train_time:912.376s step_avg:320.17ms
+step:2875/3090 val_loss:3.29980 train_time:920.388s step_avg:320.49ms
+step:2900/3090 val_loss:3.29740 train_time:928.397s step_avg:320.36ms
+step:2925/3090 val_loss:3.29417 train_time:936.387s step_avg:319.58ms
+step:2950/3090 val_loss:3.29173 train_time:944.388s step_avg:320.05ms
+step:2975/3090 val_loss:3.28971 train_time:952.386s step_avg:319.91ms
+step:3000/3090 val_loss:3.28735 train_time:960.380s step_avg:319.79ms
+step:3025/3090 val_loss:3.28477 train_time:968.390s step_avg:320.39ms
+step:3050/3090 val_loss:3.28272 train_time:976.393s step_avg:320.12ms
+step:3075/3090 val_loss:3.28092 train_time:984.391s step_avg:319.93ms
+step:3090/3090 val_loss:3.28001 train_time:989.196s step_avg:320.31ms
+trial:14/30 seed:13
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78966 train_time:40.438s step_avg:323.51ms
+step:250/3090 val_loss:4.22683 train_time:80.598s step_avg:321.28ms
+step:375/3090 val_loss:4.04296 train_time:120.618s step_avg:320.16ms
+step:500/3090 val_loss:3.93051 train_time:160.638s step_avg:320.16ms
+step:625/3090 val_loss:3.85242 train_time:200.640s step_avg:320.02ms
+step:750/3090 val_loss:3.80882 train_time:240.631s step_avg:319.93ms
+step:875/3090 val_loss:3.74951 train_time:280.633s step_avg:320.01ms
+step:1000/3090 val_loss:3.70286 train_time:320.642s step_avg:320.07ms
+step:1125/3090 val_loss:3.66697 train_time:360.619s step_avg:319.82ms
+step:1250/3090 val_loss:3.62355 train_time:400.617s step_avg:319.98ms
+step:1375/3090 val_loss:3.58261 train_time:440.600s step_avg:319.87ms
+step:1500/3090 val_loss:3.54448 train_time:480.600s step_avg:319.99ms
+step:1625/3090 val_loss:3.51327 train_time:520.566s step_avg:319.73ms
+step:1750/3090 val_loss:3.48161 train_time:560.498s step_avg:319.45ms
+step:1875/3090 val_loss:3.45522 train_time:600.403s step_avg:319.25ms
+step:2000/3090 val_loss:3.42903 train_time:640.302s step_avg:319.19ms
+step:2125/3090 val_loss:3.40566 train_time:680.219s step_avg:319.33ms
+step:2250/3090 val_loss:3.38320 train_time:720.205s step_avg:319.89ms
+step:2375/3090 val_loss:3.36345 train_time:760.183s step_avg:319.82ms
+step:2500/3090 val_loss:3.34455 train_time:800.121s step_avg:319.51ms
+step:2625/3090 val_loss:3.32664 train_time:840.036s step_avg:319.32ms
+step:2750/3090 val_loss:3.31083 train_time:879.996s step_avg:319.68ms
+step:2800/3090 val_loss:3.30472 train_time:895.997s step_avg:320.02ms
+step:2825/3090 val_loss:3.30207 train_time:903.985s step_avg:319.51ms
+step:2850/3090 val_loss:3.29926 train_time:911.974s step_avg:319.58ms
+step:2875/3090 val_loss:3.29667 train_time:919.990s step_avg:320.63ms
+step:2900/3090 val_loss:3.29416 train_time:927.998s step_avg:320.31ms
+step:2925/3090 val_loss:3.29129 train_time:935.995s step_avg:319.88ms
+step:2950/3090 val_loss:3.28884 train_time:943.996s step_avg:320.05ms
+step:2975/3090 val_loss:3.28674 train_time:951.995s step_avg:319.97ms
+step:3000/3090 val_loss:3.28438 train_time:959.998s step_avg:320.10ms
+step:3025/3090 val_loss:3.28190 train_time:968.000s step_avg:320.08ms
+step:3050/3090 val_loss:3.27991 train_time:976.001s step_avg:320.03ms
+step:3075/3090 val_loss:3.27812 train_time:983.997s step_avg:319.87ms
+step:3090/3090 val_loss:3.27721 train_time:988.798s step_avg:320.05ms
+trial:15/30 seed:14
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77730 train_time:40.317s step_avg:322.53ms
+step:250/3090 val_loss:4.22177 train_time:80.403s step_avg:320.69ms
+step:375/3090 val_loss:4.04904 train_time:120.419s step_avg:320.13ms
+step:500/3090 val_loss:3.93394 train_time:160.422s step_avg:320.02ms
+step:625/3090 val_loss:3.86406 train_time:200.448s step_avg:320.21ms
+step:750/3090 val_loss:3.80192 train_time:240.452s step_avg:320.03ms
+step:875/3090 val_loss:3.75166 train_time:280.439s step_avg:319.90ms
+step:1000/3090 val_loss:3.70302 train_time:320.416s step_avg:319.81ms
+step:1125/3090 val_loss:3.66796 train_time:360.415s step_avg:320.00ms
+step:1250/3090 val_loss:3.61952 train_time:400.391s step_avg:319.81ms
+step:1375/3090 val_loss:3.58255 train_time:440.346s step_avg:319.64ms
+step:1500/3090 val_loss:3.54196 train_time:480.289s step_avg:319.54ms
+step:1625/3090 val_loss:3.51526 train_time:520.206s step_avg:319.33ms
+step:1750/3090 val_loss:3.48245 train_time:560.131s step_avg:319.41ms
+step:1875/3090 val_loss:3.45563 train_time:600.229s step_avg:320.78ms
+step:2000/3090 val_loss:3.43029 train_time:640.319s step_avg:320.73ms
+step:2125/3090 val_loss:3.40641 train_time:680.313s step_avg:319.94ms
+step:2250/3090 val_loss:3.38428 train_time:720.208s step_avg:319.16ms
+step:2375/3090 val_loss:3.36476 train_time:760.130s step_avg:319.38ms
+step:2500/3090 val_loss:3.34579 train_time:800.035s step_avg:319.23ms
+step:2625/3090 val_loss:3.32810 train_time:839.931s step_avg:319.17ms
+step:2750/3090 val_loss:3.31250 train_time:879.945s step_avg:320.11ms
+step:2800/3090 val_loss:3.30600 train_time:895.926s step_avg:319.62ms
+step:2825/3090 val_loss:3.30369 train_time:903.915s step_avg:319.56ms
+step:2850/3090 val_loss:3.30125 train_time:911.892s step_avg:319.06ms
+step:2875/3090 val_loss:3.29852 train_time:919.892s step_avg:320.01ms
+step:2900/3090 val_loss:3.29614 train_time:927.868s step_avg:319.06ms
+step:2925/3090 val_loss:3.29300 train_time:935.856s step_avg:319.52ms
+step:2950/3090 val_loss:3.29063 train_time:943.856s step_avg:319.97ms
+step:2975/3090 val_loss:3.28865 train_time:951.849s step_avg:319.73ms
+step:3000/3090 val_loss:3.28621 train_time:959.840s step_avg:319.62ms
+step:3025/3090 val_loss:3.28364 train_time:967.821s step_avg:319.24ms
+step:3050/3090 val_loss:3.28169 train_time:975.806s step_avg:319.43ms
+step:3075/3090 val_loss:3.27984 train_time:983.808s step_avg:320.05ms
+step:3090/3090 val_loss:3.27887 train_time:988.608s step_avg:320.01ms
+trial:16/30 seed:15
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.81006 train_time:40.308s step_avg:322.46ms
+step:250/3090 val_loss:4.20525 train_time:80.336s step_avg:320.22ms
+step:375/3090 val_loss:4.04909 train_time:120.342s step_avg:320.04ms
+step:500/3090 val_loss:3.93272 train_time:160.338s step_avg:319.97ms
+step:625/3090 val_loss:3.86176 train_time:200.230s step_avg:319.14ms
+step:750/3090 val_loss:3.79901 train_time:240.137s step_avg:319.26ms
+step:875/3090 val_loss:3.75089 train_time:279.996s step_avg:318.87ms
+step:1000/3090 val_loss:3.70301 train_time:319.898s step_avg:319.22ms
+step:1125/3090 val_loss:3.66390 train_time:359.820s step_avg:319.37ms
+step:1250/3090 val_loss:3.61594 train_time:399.897s step_avg:320.61ms
+step:1375/3090 val_loss:3.57918 train_time:439.939s step_avg:320.34ms
+step:1500/3090 val_loss:3.54420 train_time:479.937s step_avg:319.98ms
+step:1625/3090 val_loss:3.51227 train_time:519.859s step_avg:319.38ms
+step:1750/3090 val_loss:3.48126 train_time:559.779s step_avg:319.36ms
+step:1875/3090 val_loss:3.45388 train_time:599.679s step_avg:319.20ms
+step:2000/3090 val_loss:3.42767 train_time:639.577s step_avg:319.19ms
+step:2125/3090 val_loss:3.40496 train_time:679.498s step_avg:319.37ms
+step:2250/3090 val_loss:3.38245 train_time:719.425s step_avg:319.42ms
+step:2375/3090 val_loss:3.36360 train_time:759.419s step_avg:319.95ms
+step:2500/3090 val_loss:3.34432 train_time:799.540s step_avg:320.97ms
+step:2625/3090 val_loss:3.32657 train_time:839.447s step_avg:319.25ms
+step:2750/3090 val_loss:3.31053 train_time:879.384s step_avg:319.50ms
+step:2800/3090 val_loss:3.30418 train_time:895.363s step_avg:319.59ms
+step:2825/3090 val_loss:3.30140 train_time:903.348s step_avg:319.40ms
+step:2850/3090 val_loss:3.29912 train_time:911.330s step_avg:319.27ms
+step:2875/3090 val_loss:3.29638 train_time:919.323s step_avg:319.72ms
+step:2900/3090 val_loss:3.29373 train_time:927.304s step_avg:319.25ms
+step:2925/3090 val_loss:3.29073 train_time:935.281s step_avg:319.06ms
+step:2950/3090 val_loss:3.28850 train_time:943.264s step_avg:319.32ms
+step:2975/3090 val_loss:3.28642 train_time:951.252s step_avg:319.52ms
+step:3000/3090 val_loss:3.28395 train_time:959.226s step_avg:318.97ms
+step:3025/3090 val_loss:3.28149 train_time:967.203s step_avg:319.10ms
+step:3050/3090 val_loss:3.27948 train_time:975.192s step_avg:319.53ms
+step:3075/3090 val_loss:3.27778 train_time:983.175s step_avg:319.33ms
+step:3090/3090 val_loss:3.27676 train_time:987.988s step_avg:320.90ms
+trial:17/30 seed:16
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78869 train_time:40.355s step_avg:322.84ms
+step:250/3090 val_loss:4.22092 train_time:80.381s step_avg:320.21ms
+step:375/3090 val_loss:4.04183 train_time:120.355s step_avg:319.79ms
+step:500/3090 val_loss:3.93873 train_time:160.297s step_avg:319.53ms
+step:625/3090 val_loss:3.85713 train_time:200.172s step_avg:319.01ms
+step:750/3090 val_loss:3.79829 train_time:240.089s step_avg:319.34ms
+step:875/3090 val_loss:3.75787 train_time:280.000s step_avg:319.29ms
+step:1000/3090 val_loss:3.70543 train_time:319.902s step_avg:319.22ms
+step:1125/3090 val_loss:3.66828 train_time:359.793s step_avg:319.12ms
+step:1250/3090 val_loss:3.62189 train_time:399.748s step_avg:319.64ms
+step:1375/3090 val_loss:3.58199 train_time:439.683s step_avg:319.48ms
+step:1500/3090 val_loss:3.54459 train_time:479.664s step_avg:319.85ms
+step:1625/3090 val_loss:3.51293 train_time:519.569s step_avg:319.24ms
+step:1750/3090 val_loss:3.48466 train_time:559.473s step_avg:319.24ms
+step:1875/3090 val_loss:3.45466 train_time:599.380s step_avg:319.25ms
+step:2000/3090 val_loss:3.42991 train_time:639.280s step_avg:319.20ms
+step:2125/3090 val_loss:3.40606 train_time:679.181s step_avg:319.21ms
+step:2250/3090 val_loss:3.38379 train_time:719.066s step_avg:319.07ms
+step:2375/3090 val_loss:3.36424 train_time:758.959s step_avg:319.15ms
+step:2500/3090 val_loss:3.34529 train_time:798.950s step_avg:319.93ms
+step:2625/3090 val_loss:3.32755 train_time:838.940s step_avg:319.92ms
+step:2750/3090 val_loss:3.31153 train_time:878.838s step_avg:319.18ms
+step:2800/3090 val_loss:3.30501 train_time:894.811s step_avg:319.46ms
+step:2825/3090 val_loss:3.30240 train_time:902.809s step_avg:319.91ms
+step:2850/3090 val_loss:3.30006 train_time:910.792s step_avg:319.35ms
+step:2875/3090 val_loss:3.29739 train_time:918.812s step_avg:320.77ms
+step:2900/3090 val_loss:3.29472 train_time:926.806s step_avg:319.77ms
+step:2925/3090 val_loss:3.29170 train_time:934.801s step_avg:319.79ms
+step:2950/3090 val_loss:3.28941 train_time:942.796s step_avg:319.79ms
+step:2975/3090 val_loss:3.28735 train_time:950.815s step_avg:320.78ms
+step:3000/3090 val_loss:3.28507 train_time:958.822s step_avg:320.29ms
+step:3025/3090 val_loss:3.28248 train_time:966.829s step_avg:320.26ms
+step:3050/3090 val_loss:3.28047 train_time:974.837s step_avg:320.32ms
+step:3075/3090 val_loss:3.27866 train_time:982.831s step_avg:319.78ms
+step:3090/3090 val_loss:3.27769 train_time:987.634s step_avg:320.19ms
+trial:18/30 seed:17
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77379 train_time:40.311s step_avg:322.49ms
+step:250/3090 val_loss:4.22027 train_time:80.393s step_avg:320.66ms
+step:375/3090 val_loss:4.03633 train_time:120.472s step_avg:320.63ms
+step:500/3090 val_loss:3.92742 train_time:160.477s step_avg:320.04ms
+step:625/3090 val_loss:3.85665 train_time:200.381s step_avg:319.23ms
+step:750/3090 val_loss:3.80803 train_time:240.317s step_avg:319.49ms
+step:875/3090 val_loss:3.76423 train_time:280.283s step_avg:319.73ms
+step:1000/3090 val_loss:3.71011 train_time:320.179s step_avg:319.17ms
+step:1125/3090 val_loss:3.66722 train_time:360.089s step_avg:319.27ms
+step:1250/3090 val_loss:3.62115 train_time:400.030s step_avg:319.53ms
+step:1375/3090 val_loss:3.58379 train_time:439.875s step_avg:318.76ms
+step:1500/3090 val_loss:3.54659 train_time:479.723s step_avg:318.79ms
+step:1625/3090 val_loss:3.51584 train_time:519.571s step_avg:318.78ms
+step:1750/3090 val_loss:3.48597 train_time:559.411s step_avg:318.72ms
+step:1875/3090 val_loss:3.45625 train_time:599.249s step_avg:318.71ms
+step:2000/3090 val_loss:3.43070 train_time:639.110s step_avg:318.88ms
+step:2125/3090 val_loss:3.40738 train_time:678.955s step_avg:318.76ms
+step:2250/3090 val_loss:3.38564 train_time:718.828s step_avg:318.99ms
+step:2375/3090 val_loss:3.36566 train_time:758.690s step_avg:318.90ms
+step:2500/3090 val_loss:3.34683 train_time:798.801s step_avg:320.88ms
+step:2625/3090 val_loss:3.32873 train_time:838.860s step_avg:320.47ms
+step:2750/3090 val_loss:3.31311 train_time:878.797s step_avg:319.50ms
+step:2800/3090 val_loss:3.30669 train_time:894.755s step_avg:319.15ms
+step:2825/3090 val_loss:3.30399 train_time:902.728s step_avg:318.92ms
+step:2850/3090 val_loss:3.30146 train_time:910.711s step_avg:319.30ms
+step:2875/3090 val_loss:3.29882 train_time:918.710s step_avg:319.97ms
+step:2900/3090 val_loss:3.29612 train_time:926.685s step_avg:319.00ms
+step:2925/3090 val_loss:3.29324 train_time:934.635s step_avg:317.99ms
+step:2950/3090 val_loss:3.29085 train_time:942.605s step_avg:318.80ms
+step:2975/3090 val_loss:3.28873 train_time:950.581s step_avg:319.07ms
+step:3000/3090 val_loss:3.28637 train_time:958.580s step_avg:319.96ms
+step:3025/3090 val_loss:3.28383 train_time:966.577s step_avg:319.87ms
+step:3050/3090 val_loss:3.28190 train_time:974.575s step_avg:319.89ms
+step:3075/3090 val_loss:3.28011 train_time:982.565s step_avg:319.61ms
+step:3090/3090 val_loss:3.27922 train_time:987.350s step_avg:319.05ms
+trial:19/30 seed:18
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.79783 train_time:40.265s step_avg:322.12ms
+step:250/3090 val_loss:4.22156 train_time:80.302s step_avg:320.29ms
+step:375/3090 val_loss:4.04827 train_time:120.274s step_avg:319.78ms
+step:500/3090 val_loss:3.93830 train_time:160.155s step_avg:319.04ms
+step:625/3090 val_loss:3.86948 train_time:200.032s step_avg:319.02ms
+step:750/3090 val_loss:3.80954 train_time:239.873s step_avg:318.73ms
+step:875/3090 val_loss:3.75338 train_time:279.743s step_avg:318.96ms
+step:1000/3090 val_loss:3.70852 train_time:319.588s step_avg:318.76ms
+step:1125/3090 val_loss:3.66191 train_time:359.394s step_avg:318.45ms
+step:1250/3090 val_loss:3.62107 train_time:399.267s step_avg:318.99ms
+step:1375/3090 val_loss:3.58756 train_time:439.130s step_avg:318.90ms
+step:1500/3090 val_loss:3.54889 train_time:478.961s step_avg:318.64ms
+step:1625/3090 val_loss:3.51330 train_time:519.058s step_avg:320.78ms
+step:1750/3090 val_loss:3.48322 train_time:559.006s step_avg:319.58ms
+step:1875/3090 val_loss:3.45467 train_time:598.919s step_avg:319.31ms
+step:2000/3090 val_loss:3.42889 train_time:638.825s step_avg:319.25ms
+step:2125/3090 val_loss:3.40687 train_time:678.715s step_avg:319.12ms
+step:2250/3090 val_loss:3.38475 train_time:718.574s step_avg:318.87ms
+step:2375/3090 val_loss:3.36504 train_time:758.541s step_avg:319.73ms
+step:2500/3090 val_loss:3.34614 train_time:798.534s step_avg:319.95ms
+step:2625/3090 val_loss:3.32799 train_time:838.538s step_avg:320.03ms
+step:2750/3090 val_loss:3.31216 train_time:878.519s step_avg:319.85ms
+step:2800/3090 val_loss:3.30573 train_time:894.510s step_avg:319.83ms
+step:2825/3090 val_loss:3.30311 train_time:902.514s step_avg:320.15ms
+step:2850/3090 val_loss:3.30073 train_time:910.522s step_avg:320.29ms
+step:2875/3090 val_loss:3.29810 train_time:918.540s step_avg:320.72ms
+step:2900/3090 val_loss:3.29538 train_time:926.520s step_avg:319.21ms
+step:2925/3090 val_loss:3.29238 train_time:934.507s step_avg:319.50ms
+step:2950/3090 val_loss:3.29000 train_time:942.509s step_avg:320.07ms
+step:2975/3090 val_loss:3.28788 train_time:950.509s step_avg:320.00ms
+step:3000/3090 val_loss:3.28553 train_time:958.505s step_avg:319.85ms
+step:3025/3090 val_loss:3.28301 train_time:966.512s step_avg:320.27ms
+step:3050/3090 val_loss:3.28111 train_time:974.508s step_avg:319.84ms
+step:3075/3090 val_loss:3.27932 train_time:982.506s step_avg:319.93ms
+step:3090/3090 val_loss:3.27835 train_time:987.308s step_avg:320.11ms
+trial:20/30 seed:19
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78912 train_time:40.307s step_avg:322.45ms
+step:250/3090 val_loss:4.21172 train_time:80.414s step_avg:320.86ms
+step:375/3090 val_loss:4.04082 train_time:120.436s step_avg:320.17ms
+step:500/3090 val_loss:3.92893 train_time:160.446s step_avg:320.08ms
+step:625/3090 val_loss:3.85142 train_time:200.433s step_avg:319.90ms
+step:750/3090 val_loss:3.80227 train_time:240.401s step_avg:319.75ms
+step:875/3090 val_loss:3.74946 train_time:280.378s step_avg:319.81ms
+step:1000/3090 val_loss:3.70424 train_time:320.377s step_avg:319.99ms
+step:1125/3090 val_loss:3.66489 train_time:360.295s step_avg:319.34ms
+step:1250/3090 val_loss:3.62405 train_time:400.237s step_avg:319.53ms
+step:1375/3090 val_loss:3.58254 train_time:440.197s step_avg:319.68ms
+step:1500/3090 val_loss:3.54332 train_time:480.109s step_avg:319.29ms
+step:1625/3090 val_loss:3.51565 train_time:520.085s step_avg:319.81ms
+step:1750/3090 val_loss:3.48229 train_time:560.068s step_avg:319.87ms
+step:1875/3090 val_loss:3.45363 train_time:600.081s step_avg:320.10ms
+step:2000/3090 val_loss:3.42865 train_time:640.129s step_avg:320.39ms
+step:2125/3090 val_loss:3.40561 train_time:680.135s step_avg:320.04ms
+step:2250/3090 val_loss:3.38364 train_time:720.129s step_avg:319.95ms
+step:2375/3090 val_loss:3.36359 train_time:760.122s step_avg:319.95ms
+step:2500/3090 val_loss:3.34525 train_time:800.144s step_avg:320.18ms
+step:2625/3090 val_loss:3.32737 train_time:840.144s step_avg:320.00ms
+step:2750/3090 val_loss:3.31139 train_time:880.146s step_avg:320.02ms
+step:2800/3090 val_loss:3.30502 train_time:896.139s step_avg:319.86ms
+step:2825/3090 val_loss:3.30243 train_time:904.142s step_avg:320.14ms
+step:2850/3090 val_loss:3.29995 train_time:912.141s step_avg:319.96ms
+step:2875/3090 val_loss:3.29742 train_time:920.159s step_avg:320.69ms
+step:2900/3090 val_loss:3.29466 train_time:928.148s step_avg:319.57ms
+step:2925/3090 val_loss:3.29172 train_time:936.148s step_avg:320.00ms
+step:2950/3090 val_loss:3.28938 train_time:944.143s step_avg:319.80ms
+step:2975/3090 val_loss:3.28728 train_time:952.144s step_avg:320.05ms
+step:3000/3090 val_loss:3.28485 train_time:960.150s step_avg:320.26ms
+step:3025/3090 val_loss:3.28230 train_time:968.150s step_avg:320.00ms
+step:3050/3090 val_loss:3.28038 train_time:976.163s step_avg:320.51ms
+step:3075/3090 val_loss:3.27856 train_time:984.166s step_avg:320.12ms
+step:3090/3090 val_loss:3.27758 train_time:988.961s step_avg:319.65ms
+trial:21/30 seed:20
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.74332 train_time:40.355s step_avg:322.84ms
+step:250/3090 val_loss:4.21526 train_time:80.538s step_avg:321.47ms
+step:375/3090 val_loss:4.03642 train_time:120.559s step_avg:320.17ms
+step:500/3090 val_loss:3.92815 train_time:160.588s step_avg:320.23ms
+step:625/3090 val_loss:3.86892 train_time:200.569s step_avg:319.84ms
+step:750/3090 val_loss:3.80302 train_time:240.537s step_avg:319.74ms
+step:875/3090 val_loss:3.75779 train_time:280.533s step_avg:319.97ms
+step:1000/3090 val_loss:3.70631 train_time:320.542s step_avg:320.07ms
+step:1125/3090 val_loss:3.66935 train_time:360.523s step_avg:319.85ms
+step:1250/3090 val_loss:3.61985 train_time:400.523s step_avg:320.00ms
+step:1375/3090 val_loss:3.58312 train_time:440.467s step_avg:319.55ms
+step:1500/3090 val_loss:3.54776 train_time:480.372s step_avg:319.24ms
+step:1625/3090 val_loss:3.51411 train_time:520.404s step_avg:320.26ms
+step:1750/3090 val_loss:3.48372 train_time:560.426s step_avg:320.18ms
+step:1875/3090 val_loss:3.45653 train_time:600.407s step_avg:319.84ms
+step:2000/3090 val_loss:3.42945 train_time:640.407s step_avg:320.01ms
+step:2125/3090 val_loss:3.40625 train_time:680.371s step_avg:319.71ms
+step:2250/3090 val_loss:3.38462 train_time:720.332s step_avg:319.69ms
+step:2375/3090 val_loss:3.36498 train_time:760.346s step_avg:320.11ms
+step:2500/3090 val_loss:3.34580 train_time:800.373s step_avg:320.22ms
+step:2625/3090 val_loss:3.32774 train_time:840.354s step_avg:319.85ms
+step:2750/3090 val_loss:3.31196 train_time:880.336s step_avg:319.86ms
+step:2800/3090 val_loss:3.30569 train_time:896.343s step_avg:320.13ms
+step:2825/3090 val_loss:3.30298 train_time:904.339s step_avg:319.84ms
+step:2850/3090 val_loss:3.30044 train_time:912.346s step_avg:320.29ms
+step:2875/3090 val_loss:3.29779 train_time:920.386s step_avg:321.58ms
+step:2900/3090 val_loss:3.29543 train_time:928.387s step_avg:320.07ms
+step:2925/3090 val_loss:3.29225 train_time:936.394s step_avg:320.25ms
+step:2950/3090 val_loss:3.28998 train_time:944.391s step_avg:319.88ms
+step:2975/3090 val_loss:3.28777 train_time:952.390s step_avg:319.98ms
+step:3000/3090 val_loss:3.28555 train_time:960.392s step_avg:320.09ms
+step:3025/3090 val_loss:3.28281 train_time:968.405s step_avg:320.50ms
+step:3050/3090 val_loss:3.28086 train_time:976.424s step_avg:320.74ms
+step:3075/3090 val_loss:3.27911 train_time:984.440s step_avg:320.67ms
+step:3090/3090 val_loss:3.27815 train_time:989.254s step_avg:320.93ms
+trial:22/30 seed:21
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78214 train_time:40.481s step_avg:323.85ms
+step:250/3090 val_loss:4.20654 train_time:80.683s step_avg:321.62ms
+step:375/3090 val_loss:4.04680 train_time:120.687s step_avg:320.02ms
+step:500/3090 val_loss:3.93480 train_time:160.685s step_avg:319.99ms
+step:625/3090 val_loss:3.85803 train_time:200.669s step_avg:319.87ms
+step:750/3090 val_loss:3.80786 train_time:240.618s step_avg:319.60ms
+step:875/3090 val_loss:3.75152 train_time:280.573s step_avg:319.64ms
+step:1000/3090 val_loss:3.70881 train_time:320.503s step_avg:319.44ms
+step:1125/3090 val_loss:3.66309 train_time:360.376s step_avg:318.98ms
+step:1250/3090 val_loss:3.61841 train_time:400.230s step_avg:318.84ms
+step:1375/3090 val_loss:3.58067 train_time:440.080s step_avg:318.80ms
+step:1500/3090 val_loss:3.54288 train_time:480.173s step_avg:320.75ms
+step:1625/3090 val_loss:3.51386 train_time:520.050s step_avg:319.01ms
+step:1750/3090 val_loss:3.48263 train_time:560.146s step_avg:320.77ms
+step:1875/3090 val_loss:3.45574 train_time:600.203s step_avg:320.45ms
+step:2000/3090 val_loss:3.42901 train_time:640.142s step_avg:319.52ms
+step:2125/3090 val_loss:3.40566 train_time:680.072s step_avg:319.44ms
+step:2250/3090 val_loss:3.38422 train_time:719.955s step_avg:319.07ms
+step:2375/3090 val_loss:3.36403 train_time:759.891s step_avg:319.48ms
+step:2500/3090 val_loss:3.34573 train_time:799.785s step_avg:319.15ms
+step:2625/3090 val_loss:3.32746 train_time:839.671s step_avg:319.09ms
+step:2750/3090 val_loss:3.31192 train_time:879.545s step_avg:318.99ms
+step:2800/3090 val_loss:3.30548 train_time:895.517s step_avg:319.45ms
+step:2825/3090 val_loss:3.30289 train_time:903.511s step_avg:319.76ms
+step:2850/3090 val_loss:3.30051 train_time:911.506s step_avg:319.81ms
+step:2875/3090 val_loss:3.29787 train_time:919.510s step_avg:320.13ms
+step:2900/3090 val_loss:3.29559 train_time:927.487s step_avg:319.09ms
+step:2925/3090 val_loss:3.29232 train_time:935.474s step_avg:319.48ms
+step:2950/3090 val_loss:3.29009 train_time:943.449s step_avg:319.01ms
+step:2975/3090 val_loss:3.28790 train_time:951.432s step_avg:319.31ms
+step:3000/3090 val_loss:3.28562 train_time:959.412s step_avg:319.21ms
+step:3025/3090 val_loss:3.28315 train_time:967.388s step_avg:319.02ms
+step:3050/3090 val_loss:3.28114 train_time:975.375s step_avg:319.49ms
+step:3075/3090 val_loss:3.27932 train_time:983.351s step_avg:319.05ms
+step:3090/3090 val_loss:3.27842 train_time:988.147s step_avg:319.69ms
+trial:23/30 seed:22
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77296 train_time:40.251s step_avg:322.01ms
+step:250/3090 val_loss:4.20962 train_time:80.338s step_avg:320.70ms
+step:375/3090 val_loss:4.04442 train_time:120.323s step_avg:319.88ms
+step:500/3090 val_loss:3.93105 train_time:160.337s step_avg:320.11ms
+step:625/3090 val_loss:3.86019 train_time:200.322s step_avg:319.88ms
+step:750/3090 val_loss:3.80925 train_time:240.284s step_avg:319.69ms
+step:875/3090 val_loss:3.74931 train_time:280.260s step_avg:319.81ms
+step:1000/3090 val_loss:3.70611 train_time:320.182s step_avg:319.38ms
+step:1125/3090 val_loss:3.66854 train_time:360.097s step_avg:319.32ms
+step:1250/3090 val_loss:3.62025 train_time:400.007s step_avg:319.27ms
+step:1375/3090 val_loss:3.57928 train_time:439.911s step_avg:319.24ms
+step:1500/3090 val_loss:3.54379 train_time:479.835s step_avg:319.39ms
+step:1625/3090 val_loss:3.51306 train_time:519.821s step_avg:319.89ms
+step:1750/3090 val_loss:3.48270 train_time:559.780s step_avg:319.67ms
+step:1875/3090 val_loss:3.45442 train_time:599.673s step_avg:319.15ms
+step:2000/3090 val_loss:3.42740 train_time:639.629s step_avg:319.65ms
+step:2125/3090 val_loss:3.40479 train_time:679.505s step_avg:319.01ms
+step:2250/3090 val_loss:3.38275 train_time:719.360s step_avg:318.83ms
+step:2375/3090 val_loss:3.36336 train_time:759.177s step_avg:318.53ms
+step:2500/3090 val_loss:3.34410 train_time:799.012s step_avg:318.68ms
+step:2625/3090 val_loss:3.32640 train_time:838.973s step_avg:319.69ms
+step:2750/3090 val_loss:3.31072 train_time:878.985s step_avg:320.09ms
+step:2800/3090 val_loss:3.30416 train_time:894.989s step_avg:320.08ms
+step:2825/3090 val_loss:3.30149 train_time:902.999s step_avg:320.38ms
+step:2850/3090 val_loss:3.29909 train_time:910.996s step_avg:319.88ms
+step:2875/3090 val_loss:3.29641 train_time:919.016s step_avg:320.83ms
+step:2900/3090 val_loss:3.29381 train_time:927.021s step_avg:320.17ms
+step:2925/3090 val_loss:3.29069 train_time:935.027s step_avg:320.28ms
+step:2950/3090 val_loss:3.28840 train_time:943.030s step_avg:320.10ms
+step:2975/3090 val_loss:3.28633 train_time:951.037s step_avg:320.27ms
+step:3000/3090 val_loss:3.28388 train_time:959.047s step_avg:320.41ms
+step:3025/3090 val_loss:3.28138 train_time:967.050s step_avg:320.11ms
+step:3050/3090 val_loss:3.27950 train_time:975.056s step_avg:320.24ms
+step:3075/3090 val_loss:3.27763 train_time:983.062s step_avg:320.24ms
+step:3090/3090 val_loss:3.27670 train_time:987.868s step_avg:320.39ms
+trial:24/30 seed:23
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78314 train_time:40.283s step_avg:322.27ms
+step:250/3090 val_loss:4.22541 train_time:80.405s step_avg:320.98ms
+step:375/3090 val_loss:4.04084 train_time:120.531s step_avg:321.01ms
+step:500/3090 val_loss:3.92801 train_time:160.566s step_avg:320.28ms
+step:625/3090 val_loss:3.86996 train_time:200.591s step_avg:320.20ms
+step:750/3090 val_loss:3.80937 train_time:240.602s step_avg:320.09ms
+step:875/3090 val_loss:3.75413 train_time:280.575s step_avg:319.78ms
+step:1000/3090 val_loss:3.70594 train_time:320.573s step_avg:319.99ms
+step:1125/3090 val_loss:3.66778 train_time:360.568s step_avg:319.96ms
+step:1250/3090 val_loss:3.62455 train_time:400.571s step_avg:320.02ms
+step:1375/3090 val_loss:3.58132 train_time:440.550s step_avg:319.83ms
+step:1500/3090 val_loss:3.54537 train_time:480.546s step_avg:319.97ms
+step:1625/3090 val_loss:3.51371 train_time:520.532s step_avg:319.89ms
+step:1750/3090 val_loss:3.48309 train_time:560.534s step_avg:320.02ms
+step:1875/3090 val_loss:3.45795 train_time:600.518s step_avg:319.87ms
+step:2000/3090 val_loss:3.42917 train_time:640.511s step_avg:319.94ms
+step:2125/3090 val_loss:3.40697 train_time:680.520s step_avg:320.07ms
+step:2250/3090 val_loss:3.38395 train_time:720.541s step_avg:320.17ms
+step:2375/3090 val_loss:3.36406 train_time:760.542s step_avg:320.00ms
+step:2500/3090 val_loss:3.34493 train_time:800.580s step_avg:320.30ms
+step:2625/3090 val_loss:3.32727 train_time:840.574s step_avg:319.96ms
+step:2750/3090 val_loss:3.31170 train_time:880.584s step_avg:320.08ms
+step:2800/3090 val_loss:3.30510 train_time:896.581s step_avg:319.93ms
+step:2825/3090 val_loss:3.30258 train_time:904.587s step_avg:320.23ms
+step:2850/3090 val_loss:3.29985 train_time:912.595s step_avg:320.32ms
+step:2875/3090 val_loss:3.29724 train_time:920.588s step_avg:319.75ms
+step:2900/3090 val_loss:3.29465 train_time:928.574s step_avg:319.41ms
+step:2925/3090 val_loss:3.29174 train_time:936.551s step_avg:319.08ms
+step:2950/3090 val_loss:3.28938 train_time:944.536s step_avg:319.40ms
+step:2975/3090 val_loss:3.28734 train_time:952.556s step_avg:320.82ms
+step:3000/3090 val_loss:3.28485 train_time:960.565s step_avg:320.36ms
+step:3025/3090 val_loss:3.28241 train_time:968.573s step_avg:320.30ms
+step:3050/3090 val_loss:3.28043 train_time:976.608s step_avg:321.43ms
+step:3075/3090 val_loss:3.27858 train_time:984.622s step_avg:320.54ms
+step:3090/3090 val_loss:3.27762 train_time:989.424s step_avg:320.12ms
+trial:25/30 seed:24
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.79853 train_time:40.347s step_avg:322.77ms
+step:250/3090 val_loss:4.21017 train_time:80.490s step_avg:321.14ms
+step:375/3090 val_loss:4.03597 train_time:120.486s step_avg:319.97ms
+step:500/3090 val_loss:3.93324 train_time:160.459s step_avg:319.79ms
+step:625/3090 val_loss:3.86383 train_time:200.432s step_avg:319.79ms
+step:750/3090 val_loss:3.80298 train_time:240.413s step_avg:319.84ms
+step:875/3090 val_loss:3.75583 train_time:280.417s step_avg:320.04ms
+step:1000/3090 val_loss:3.70536 train_time:320.427s step_avg:320.07ms
+step:1125/3090 val_loss:3.66527 train_time:360.526s step_avg:320.79ms
+step:1250/3090 val_loss:3.62119 train_time:400.565s step_avg:320.32ms
+step:1375/3090 val_loss:3.58340 train_time:440.583s step_avg:320.14ms
+step:1500/3090 val_loss:3.54727 train_time:480.595s step_avg:320.10ms
+step:1625/3090 val_loss:3.51326 train_time:520.628s step_avg:320.26ms
+step:1750/3090 val_loss:3.48163 train_time:560.647s step_avg:320.15ms
+step:1875/3090 val_loss:3.45491 train_time:600.621s step_avg:319.80ms
+step:2000/3090 val_loss:3.42914 train_time:640.614s step_avg:319.94ms
+step:2125/3090 val_loss:3.40653 train_time:680.613s step_avg:319.99ms
+step:2250/3090 val_loss:3.38437 train_time:720.611s step_avg:319.99ms
+step:2375/3090 val_loss:3.36463 train_time:760.694s step_avg:320.66ms
+step:2500/3090 val_loss:3.34554 train_time:800.723s step_avg:320.23ms
+step:2625/3090 val_loss:3.32781 train_time:840.725s step_avg:320.02ms
+step:2750/3090 val_loss:3.31178 train_time:880.733s step_avg:320.06ms
+step:2800/3090 val_loss:3.30549 train_time:896.739s step_avg:320.12ms
+step:2825/3090 val_loss:3.30291 train_time:904.732s step_avg:319.71ms
+step:2850/3090 val_loss:3.30033 train_time:912.724s step_avg:319.68ms
+step:2875/3090 val_loss:3.29770 train_time:920.771s step_avg:321.88ms
+step:2900/3090 val_loss:3.29521 train_time:928.771s step_avg:320.00ms
+step:2925/3090 val_loss:3.29217 train_time:936.770s step_avg:319.96ms
+step:2950/3090 val_loss:3.28982 train_time:944.778s step_avg:320.33ms
+step:2975/3090 val_loss:3.28759 train_time:952.776s step_avg:319.94ms
+step:3000/3090 val_loss:3.28533 train_time:960.780s step_avg:320.15ms
+step:3025/3090 val_loss:3.28281 train_time:968.787s step_avg:320.25ms
+step:3050/3090 val_loss:3.28093 train_time:976.804s step_avg:320.68ms
+step:3075/3090 val_loss:3.27911 train_time:984.801s step_avg:319.90ms
+step:3090/3090 val_loss:3.27812 train_time:989.599s step_avg:319.82ms
+trial:26/30 seed:25
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.81494 train_time:40.320s step_avg:322.56ms
+step:250/3090 val_loss:4.21709 train_time:80.450s step_avg:321.04ms
+step:375/3090 val_loss:4.03751 train_time:120.622s step_avg:321.37ms
+step:500/3090 val_loss:3.92334 train_time:160.961s step_avg:322.71ms
+step:625/3090 val_loss:3.84879 train_time:201.079s step_avg:320.95ms
+step:750/3090 val_loss:3.80588 train_time:241.078s step_avg:319.99ms
+step:875/3090 val_loss:3.75462 train_time:281.115s step_avg:320.30ms
+step:1000/3090 val_loss:3.70930 train_time:321.134s step_avg:320.15ms
+step:1125/3090 val_loss:3.66683 train_time:361.147s step_avg:320.11ms
+step:1250/3090 val_loss:3.62293 train_time:401.186s step_avg:320.31ms
+step:1375/3090 val_loss:3.57970 train_time:441.183s step_avg:319.97ms
+step:1500/3090 val_loss:3.54481 train_time:481.179s step_avg:319.97ms
+step:1625/3090 val_loss:3.51644 train_time:521.166s step_avg:319.89ms
+step:1750/3090 val_loss:3.48211 train_time:561.163s step_avg:319.97ms
+step:1875/3090 val_loss:3.45457 train_time:601.172s step_avg:320.07ms
+step:2000/3090 val_loss:3.42771 train_time:641.177s step_avg:320.04ms
+step:2125/3090 val_loss:3.40506 train_time:681.205s step_avg:320.22ms
+step:2250/3090 val_loss:3.38259 train_time:721.207s step_avg:320.02ms
+step:2375/3090 val_loss:3.36292 train_time:761.216s step_avg:320.07ms
+step:2500/3090 val_loss:3.34384 train_time:801.219s step_avg:320.03ms
+step:2625/3090 val_loss:3.32604 train_time:841.223s step_avg:320.03ms
+step:2750/3090 val_loss:3.31023 train_time:881.232s step_avg:320.07ms
+step:2800/3090 val_loss:3.30391 train_time:897.239s step_avg:320.14ms
+step:2825/3090 val_loss:3.30127 train_time:905.244s step_avg:320.20ms
+step:2850/3090 val_loss:3.29866 train_time:913.243s step_avg:319.96ms
+step:2875/3090 val_loss:3.29594 train_time:921.252s step_avg:320.33ms
+step:2900/3090 val_loss:3.29338 train_time:929.252s step_avg:320.04ms
+step:2925/3090 val_loss:3.29043 train_time:937.238s step_avg:319.41ms
+step:2950/3090 val_loss:3.28801 train_time:945.237s step_avg:319.97ms
+step:2975/3090 val_loss:3.28587 train_time:953.242s step_avg:320.21ms
+step:3000/3090 val_loss:3.28358 train_time:961.239s step_avg:319.88ms
+step:3025/3090 val_loss:3.28106 train_time:969.250s step_avg:320.41ms
+step:3050/3090 val_loss:3.27910 train_time:977.264s step_avg:320.56ms
+step:3075/3090 val_loss:3.27728 train_time:985.261s step_avg:319.88ms
+step:3090/3090 val_loss:3.27632 train_time:990.067s step_avg:320.41ms
+trial:27/30 seed:26
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78753 train_time:40.302s step_avg:322.41ms
+step:250/3090 val_loss:4.21442 train_time:80.408s step_avg:320.85ms
+step:375/3090 val_loss:4.06479 train_time:120.424s step_avg:320.13ms
+step:500/3090 val_loss:3.93026 train_time:160.419s step_avg:319.96ms
+step:625/3090 val_loss:3.86094 train_time:200.426s step_avg:320.06ms
+step:750/3090 val_loss:3.80544 train_time:240.372s step_avg:319.57ms
+step:875/3090 val_loss:3.75073 train_time:280.341s step_avg:319.75ms
+step:1000/3090 val_loss:3.70452 train_time:320.326s step_avg:319.88ms
+step:1125/3090 val_loss:3.66664 train_time:360.300s step_avg:319.80ms
+step:1250/3090 val_loss:3.62178 train_time:400.299s step_avg:319.99ms
+step:1375/3090 val_loss:3.58319 train_time:440.303s step_avg:320.03ms
+step:1500/3090 val_loss:3.54333 train_time:480.253s step_avg:319.60ms
+step:1625/3090 val_loss:3.51325 train_time:520.209s step_avg:319.65ms
+step:1750/3090 val_loss:3.48248 train_time:560.175s step_avg:319.73ms
+step:1875/3090 val_loss:3.45665 train_time:600.150s step_avg:319.80ms
+step:2000/3090 val_loss:3.42945 train_time:640.145s step_avg:319.96ms
+step:2125/3090 val_loss:3.40609 train_time:680.125s step_avg:319.84ms
+step:2250/3090 val_loss:3.38461 train_time:720.032s step_avg:319.25ms
+step:2375/3090 val_loss:3.36450 train_time:760.024s step_avg:319.94ms
+step:2500/3090 val_loss:3.34588 train_time:799.996s step_avg:319.77ms
+step:2625/3090 val_loss:3.32785 train_time:839.969s step_avg:319.79ms
+step:2750/3090 val_loss:3.31209 train_time:879.961s step_avg:319.93ms
+step:2800/3090 val_loss:3.30578 train_time:895.958s step_avg:319.94ms
+step:2825/3090 val_loss:3.30320 train_time:903.967s step_avg:320.36ms
+step:2850/3090 val_loss:3.30079 train_time:911.973s step_avg:320.26ms
+step:2875/3090 val_loss:3.29824 train_time:919.981s step_avg:320.30ms
+step:2900/3090 val_loss:3.29551 train_time:927.985s step_avg:320.17ms
+step:2925/3090 val_loss:3.29251 train_time:935.987s step_avg:320.09ms
+step:2950/3090 val_loss:3.29011 train_time:943.991s step_avg:320.14ms
+step:2975/3090 val_loss:3.28799 train_time:951.998s step_avg:320.28ms
+step:3000/3090 val_loss:3.28559 train_time:959.996s step_avg:319.93ms
+step:3025/3090 val_loss:3.28310 train_time:968.000s step_avg:320.17ms
+step:3050/3090 val_loss:3.28124 train_time:976.026s step_avg:321.04ms
+step:3075/3090 val_loss:3.27945 train_time:984.018s step_avg:319.67ms
+step:3090/3090 val_loss:3.27848 train_time:988.828s step_avg:320.64ms
+trial:28/30 seed:27
+step:0/3090 val_loss:10.82584 train_time:0.002s step_avg:nanms
+step:125/3090 val_loss:4.77063 train_time:40.379s step_avg:323.02ms
+step:250/3090 val_loss:4.20968 train_time:80.540s step_avg:321.29ms
+step:375/3090 val_loss:4.04188 train_time:120.621s step_avg:320.64ms
+step:500/3090 val_loss:3.93451 train_time:160.749s step_avg:321.03ms
+step:625/3090 val_loss:3.86317 train_time:200.944s step_avg:321.56ms
+step:750/3090 val_loss:3.80759 train_time:241.163s step_avg:321.75ms
+step:875/3090 val_loss:3.75825 train_time:281.161s step_avg:319.98ms
+step:1000/3090 val_loss:3.70465 train_time:321.171s step_avg:320.08ms
+step:1125/3090 val_loss:3.67198 train_time:361.156s step_avg:319.88ms
+step:1250/3090 val_loss:3.62306 train_time:401.170s step_avg:320.11ms
+step:1375/3090 val_loss:3.58785 train_time:441.135s step_avg:319.72ms
+step:1500/3090 val_loss:3.54732 train_time:481.134s step_avg:319.99ms
+step:1625/3090 val_loss:3.51658 train_time:521.125s step_avg:319.93ms
+step:1750/3090 val_loss:3.48526 train_time:561.103s step_avg:319.83ms
+step:1875/3090 val_loss:3.45626 train_time:601.060s step_avg:319.65ms
+step:2000/3090 val_loss:3.43092 train_time:641.057s step_avg:319.98ms
+step:2125/3090 val_loss:3.40890 train_time:681.184s step_avg:321.02ms
+step:2250/3090 val_loss:3.38564 train_time:721.241s step_avg:320.46ms
+step:2375/3090 val_loss:3.36616 train_time:761.412s step_avg:321.37ms
+step:2500/3090 val_loss:3.34722 train_time:801.523s step_avg:320.88ms
+step:2625/3090 val_loss:3.32950 train_time:841.659s step_avg:321.09ms
+step:2750/3090 val_loss:3.31366 train_time:881.732s step_avg:320.58ms
+step:2800/3090 val_loss:3.30713 train_time:897.732s step_avg:320.00ms
+step:2825/3090 val_loss:3.30480 train_time:905.738s step_avg:320.24ms
+step:2850/3090 val_loss:3.30239 train_time:913.737s step_avg:319.95ms
+step:2875/3090 val_loss:3.29954 train_time:921.755s step_avg:320.73ms
+step:2900/3090 val_loss:3.29684 train_time:929.773s step_avg:320.74ms
+step:2925/3090 val_loss:3.29409 train_time:937.809s step_avg:321.43ms
+step:2950/3090 val_loss:3.29173 train_time:945.883s step_avg:322.98ms
+step:2975/3090 val_loss:3.28966 train_time:953.955s step_avg:322.87ms
+step:3000/3090 val_loss:3.28722 train_time:962.000s step_avg:321.80ms
+step:3025/3090 val_loss:3.28464 train_time:970.061s step_avg:322.43ms
+step:3050/3090 val_loss:3.28271 train_time:978.129s step_avg:322.70ms
+step:3075/3090 val_loss:3.28089 train_time:986.161s step_avg:321.30ms
+step:3090/3090 val_loss:3.27994 train_time:990.981s step_avg:321.31ms
+trial:29/30 seed:28
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.78365 train_time:40.483s step_avg:323.86ms
+step:250/3090 val_loss:4.21823 train_time:80.731s step_avg:321.98ms
+step:375/3090 val_loss:4.04307 train_time:120.790s step_avg:320.48ms
+step:500/3090 val_loss:3.92937 train_time:160.834s step_avg:320.35ms
+step:625/3090 val_loss:3.86489 train_time:201.007s step_avg:321.38ms
+step:750/3090 val_loss:3.81101 train_time:241.185s step_avg:321.43ms
+step:875/3090 val_loss:3.75766 train_time:281.362s step_avg:321.42ms
+step:1000/3090 val_loss:3.71217 train_time:321.571s step_avg:321.67ms
+step:1125/3090 val_loss:3.66879 train_time:361.581s step_avg:320.08ms
+step:1250/3090 val_loss:3.62167 train_time:401.630s step_avg:320.39ms
+step:1375/3090 val_loss:3.58112 train_time:441.699s step_avg:320.55ms
+step:1500/3090 val_loss:3.54272 train_time:481.706s step_avg:320.06ms
+step:1625/3090 val_loss:3.51365 train_time:521.704s step_avg:319.99ms
+step:1750/3090 val_loss:3.48234 train_time:561.708s step_avg:320.03ms
+step:1875/3090 val_loss:3.45534 train_time:601.714s step_avg:320.04ms
+step:2000/3090 val_loss:3.42973 train_time:641.719s step_avg:320.04ms
+step:2125/3090 val_loss:3.40749 train_time:681.764s step_avg:320.36ms
+step:2250/3090 val_loss:3.38443 train_time:721.785s step_avg:320.17ms
+step:2375/3090 val_loss:3.36482 train_time:761.821s step_avg:320.29ms
+step:2500/3090 val_loss:3.34555 train_time:801.880s step_avg:320.47ms
+step:2625/3090 val_loss:3.32747 train_time:841.889s step_avg:320.07ms
+step:2750/3090 val_loss:3.31213 train_time:881.911s step_avg:320.18ms
+step:2800/3090 val_loss:3.30552 train_time:897.920s step_avg:320.17ms
+step:2825/3090 val_loss:3.30313 train_time:905.923s step_avg:320.15ms
+step:2850/3090 val_loss:3.30076 train_time:913.941s step_avg:320.72ms
+step:2875/3090 val_loss:3.29784 train_time:921.994s step_avg:322.11ms
+step:2900/3090 val_loss:3.29522 train_time:930.000s step_avg:320.25ms
+step:2925/3090 val_loss:3.29224 train_time:938.010s step_avg:320.37ms
+step:2950/3090 val_loss:3.28991 train_time:946.011s step_avg:320.05ms
+step:2975/3090 val_loss:3.28779 train_time:954.009s step_avg:319.93ms
+step:3000/3090 val_loss:3.28529 train_time:962.020s step_avg:320.45ms
+step:3025/3090 val_loss:3.28285 train_time:970.086s step_avg:322.61ms
+step:3050/3090 val_loss:3.28099 train_time:978.167s step_avg:323.25ms
+step:3075/3090 val_loss:3.27909 train_time:986.223s step_avg:322.26ms
+step:3090/3090 val_loss:3.27816 train_time:991.055s step_avg:322.09ms
+trial:30/30 seed:29
+step:0/3090 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3090 val_loss:4.77777 train_time:40.459s step_avg:323.67ms
+step:250/3090 val_loss:4.20386 train_time:80.568s step_avg:320.87ms
+step:375/3090 val_loss:4.04531 train_time:120.565s step_avg:319.98ms
+step:500/3090 val_loss:3.93708 train_time:160.588s step_avg:320.19ms
+step:625/3090 val_loss:3.85943 train_time:200.592s step_avg:320.03ms
+step:750/3090 val_loss:3.81311 train_time:240.891s step_avg:322.39ms
+step:875/3090 val_loss:3.75580 train_time:280.955s step_avg:320.51ms
+step:1000/3090 val_loss:3.70523 train_time:320.957s step_avg:320.02ms
+step:1125/3090 val_loss:3.66514 train_time:360.964s step_avg:320.05ms
+step:1250/3090 val_loss:3.62434 train_time:401.000s step_avg:320.30ms
+step:1375/3090 val_loss:3.58446 train_time:441.039s step_avg:320.31ms
+step:1500/3090 val_loss:3.54560 train_time:481.038s step_avg:319.99ms
+step:1625/3090 val_loss:3.51589 train_time:521.027s step_avg:319.91ms
+step:1750/3090 val_loss:3.48438 train_time:561.058s step_avg:320.25ms
+step:1875/3090 val_loss:3.45684 train_time:601.030s step_avg:319.78ms
+step:2000/3090 val_loss:3.43194 train_time:641.029s step_avg:319.99ms
+step:2125/3090 val_loss:3.40936 train_time:681.028s step_avg:319.99ms
+step:2250/3090 val_loss:3.38629 train_time:721.013s step_avg:319.88ms
+step:2375/3090 val_loss:3.36633 train_time:760.973s step_avg:319.68ms
+step:2500/3090 val_loss:3.34759 train_time:800.983s step_avg:320.07ms
+step:2625/3090 val_loss:3.33013 train_time:841.011s step_avg:320.23ms
+step:2750/3090 val_loss:3.31426 train_time:881.018s step_avg:320.06ms
+step:2800/3090 val_loss:3.30766 train_time:897.049s step_avg:320.62ms
+step:2825/3090 val_loss:3.30520 train_time:905.053s step_avg:320.19ms
+step:2850/3090 val_loss:3.30257 train_time:913.061s step_avg:320.29ms
+step:2875/3090 val_loss:3.30010 train_time:921.081s step_avg:320.82ms
+step:2900/3090 val_loss:3.29748 train_time:929.098s step_avg:320.66ms
+step:2925/3090 val_loss:3.29452 train_time:937.115s step_avg:320.69ms
+step:2950/3090 val_loss:3.29220 train_time:945.132s step_avg:320.67ms
+step:2975/3090 val_loss:3.28998 train_time:953.142s step_avg:320.42ms
+step:3000/3090 val_loss:3.28762 train_time:961.134s step_avg:319.69ms
+step:3025/3090 val_loss:3.28517 train_time:969.141s step_avg:320.25ms
+step:3050/3090 val_loss:3.28315 train_time:977.153s step_avg:320.50ms
+step:3075/3090 val_loss:3.28135 train_time:985.162s step_avg:320.34ms
+step:3090/3090 val_loss:3.28038 train_time:989.965s step_avg:320.25ms


### PR DESCRIPTION
# Track 3: Muown — 3075 Steps

> PR authored by: fhueb, kcc-lion

[arXiv link](https://arxiv.org/abs/2605.10797)

Muown decomposes every 2-D weight matrix _internally_ into a per-row gain `g` and a
direction vector `v` via weight normalization (`W = g * v / ||v||`), then
updates the two factors with different geometries. The implementation is architecture agnostic and only implemented in the optimizer.

* **Direction (`v`):** Nesterov-style momentum followed by Newton-Schulz
  orthogonalization (Polar Express, 12 iterations) of the update.  The
  orthogonalized update is applied to `v` with a scale proportional to
  `sqrt(max(m, n))`, gated by `direction_scale=0.2`.
* **Gain (`g`):** Adam with bias correction (`betas=(0.9, 0.95)`).
* **V-Norm schedule (angular step-size attenuation):** After each step, the
  stored `||v||` is smoothstep-interpolated from its initial value toward a
  fixed `v_norm_target_scale`.  Because the weight-norm recomposition
  normalizes `v` before multiplying by `g`, growing `||v||` relative to the
  actual update magnitude shrinks the effective angular displacement on the
  unit sphere, attenuating the angular step size as training progresses.
  The target scale is layer-family-dependent (`mlp.proj` receives a 3.33x
  multiplier; all other families use 1x). The `v_norm_target_scale` parameter is 
  tuned around the typical value of `v_norm` when running without a scheduler.  

## Hyperparameters

| Parameter | Value |
| - | - |
| `lr_muown` | 0.0035 |
| `momentum` | 0.95 |
| `ns_steps` | 12 |
| `direction_scale` | 0.2 |
| `v_norm_target_scale` | 2.688 (x family mult) |
| `lr_cooldown_frac` (both) | 0.7 |
| `lr_embed` / `lr_head` / `lr_1d` | 0.9 / 0.009375 / 0.03 |
| `batch_size` | 524288 |
| `train_steps` | 3200 |

We used 4 NVIDIA GH200 devices.

## Statistical significance

The benchmark requires `(3.28 - mu) * sqrt(n) >= 0.004`.  For n=10, this yields a threshold of
`mu < 3.28 - 0.004/sqrt(10) = 3.27874`.

Ten non-cherry-picked seeds (1-10) were run for 3200 steps.  The
significance condition is first satisfied at **step 3125**:

| Step | Mean | Std | Min | Max | (3.28-mu)*sqrt(10) |
| -: | -: | -: | -: | -: | -: |
| 3100 | 3.27877 | 0.00080 | 3.27754 | 3.27979 | 0.00390 |
| **3125** | **3.27752** | **0.00080** | **3.27636** | **3.27859** | **0.00784** |
| 3150 | 3.27641 | 0.00081 | 3.27525 | 3.27748 | 0.01135 |
| 3175 | 3.27569 | 0.00081 | 3.27451 | 3.27676 | 0.01362 |
| 3200 | 3.27534 | 0.00081 | 3.27415 | 3.27642 | 0.01474 |

At step **3125**, `(3.28 - 3.27752) * sqrt(10) = 0.00784 >= 0.004`.

## EDIT: Updated to obtain loss in 3075 steps.
We changed lr_embed from 0.9 to 0.6 and adopted @yash-oai's power-law cooldown. The mean over 30 seeds at step 3075 is 3.27896, giving us `(3.28 - 3.27896) * sqrt(30) = 0.0057 >= 0.004`. The results are in [a26c8aa2-993d-443f-b931-845724d07015.txt](https://github.com/KellerJordan/modded-nanogpt/pull/288/changes/6dd36f45b607e095f7fc8301df0ae246dfd3af98#diff-eca8a8e4de0ca252ee6934689932fc9f3de7a8ec2802e7c8dbbd11883f70f265)
