### PR TITLE
Track3: Add SinkSOAP optimizer result: 3090 steps

### DIFF
--- a/records/track_3_optimization/results/20260514_sinksoap/d0155dd0-f77d-48a9-8eb4-453f894b9476.txt
+++ b/records/track_3_optimization/results/20260514_sinksoap/d0155dd0-f77d-48a9-8eb4-453f894b9476.txt
@@ -1,0 +1,1088 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+
+
+
+
+def gram_eigenbasis(C: Tensor, eps: float = 1e-6) -> Tensor:
+    """
+    Eigenbasis for symmetric PSD Gram matrix.
+    Returns eigenvectors sorted by descending eigenvalue.
+    """
+    C = C.float()
+    C = 0.5 * (C + C.T)
+
+    if eps > 0:
+        eye = torch.eye(C.shape[0], device=C.device, dtype=C.dtype)
+        C = C + eps * eye
+
+    evals, evecs = torch.linalg.eigh(C)
+    idx = torch.argsort(evals, descending=True)
+    return evecs[:, idx]
+
+
+def sinkhorn_energy_balance_rect_no_scale(
+    A: Tensor,
+    steps: int = 10,
+    eps: float = 1e-8,
+) -> Tensor:
+    """
+    Sinkhorn-balance elementwise energy A^2.
+
+    For A in R^{m x n}:
+
+        B = A^2 + eps
+        Pi = Dr B Dc
+
+    target rectangular marginals:
+
+        Pi 1_n ~= (1/m) 1_m
+        Pi^T 1_m ~= (1/n) 1_n
+
+    Lift back:
+
+        A_bal = Dr^{1/2} A Dc^{1/2}
+
+    No RMS/Frobenius scaling here.
+    """
+    assert A.ndim == 2
+
+    out_dtype = A.dtype
+    A = A.float()
+
+    m, n = A.shape
+    B = A.square() + eps
+
+    target_r = torch.full(
+        (m,),
+        1.0 / m,
+        device=A.device,
+        dtype=torch.float32,
+    )
+    target_c = torch.full(
+        (n,),
+        1.0 / n,
+        device=A.device,
+        dtype=torch.float32,
+    )
+
+    r = torch.ones(m, device=A.device, dtype=torch.float32)
+    c = torch.ones(n, device=A.device, dtype=torch.float32)
+
+    for _ in range(steps):
+        r = target_r / (B @ c + eps)
+        c = target_c / (B.T @ r + eps)
+
+    A_bal = r.sqrt()[:, None] * A * c.sqrt()[None, :]
+
+    return A_bal.to(out_dtype)
+
+
+def scale_update_like_muon(update: Tensor, eps: float = 1e-8) -> Tensor:
+    """
+    Match original Muon's final Frobenius norm:
+
+        ||update||_F ~= sqrt(min(m, n)) * sqrt(max(1, m / n))
+
+    This equals sqrt(m), but we keep the Muon expression.
+    """
+    assert update.ndim == 2
+
+    m, n = update.shape
+
+    target_norm = (min(m, n) ** 0.5) * (max(1.0, m / n) ** 0.5)
+
+    update_norm = update.float().norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+
+    return update * (target_norm / update_norm).to(update.dtype)
+
+
+def normuon_postcondition_update(
+    update: Tensor,
+    second_momentum: Tensor,
+    beta: float = 0.95,
+    eps: float = 1e-10,
+) -> Tensor:
+    """
+    NorMuon-style postconditioner applied to an already preconditioned update.
+
+    Important:
+    - This does NOT call zeropower again.
+    - It preserves the incoming Frobenius norm.
+    - Therefore call this AFTER scale_update_like_muon(update).
+
+    For m >= n:
+        v_mean shape [m, 1], row-wise energy.
+
+    For m < n:
+        v_mean shape [1, n], column-wise energy.
+    """
+    assert update.ndim == 2
+
+    out_dtype = update.dtype
+    X = update.float()
+
+    m, n = X.shape
+
+    norm = X.norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+
+    if m >= n:
+        v_mean = torch.mean(X * X, dim=-1, keepdim=True)  # [m, 1]
+    else:
+        v_mean = torch.mean(X * X, dim=-2, keepdim=True)  # [1, n]
+
+    second_momentum.lerp_(v_mean.to(second_momentum.dtype), 1.0 - beta)
+
+    step_size = 1.0 / second_momentum.float().sqrt().clamp_min(eps)
+
+    X = X * step_size
+
+    norm_new = X.norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+    X = X * (norm / norm_new)
+
+    return X.to(out_dtype)
+
+
+def gram_sinkhorn_normuon_update(
+    grad: Tensor,
+    momentum: Tensor,
+    left_gram: Tensor,
+    right_gram: Tensor,
+    second_momentum: Tensor,
+    mu: float = 0.95,
+    gram_beta: float = 0.95,
+    normuon_beta: float = 0.95,
+    nesterov: bool = True,
+    sinkhorn_steps: int = 10,
+    eps: float = 1e-8,
+    normuon_eps: float = 1e-10,
+    apply_normuon: bool = True,
+) -> Tensor:
+    """
+    Gram-Sinkhorn update + NorMuon postconditioner.
+
+    Order:
+
+        1. momentum
+        2. EMA GG^T and G^T G
+        3. U, V from Gram eigenspaces
+        4. A = U^T M V
+        5. Sinkhorn on A^2
+        6. update = U A_bal V^T
+        7. scale update to Muon Frobenius norm
+        8. NorMuon postconditioner, preserving that norm
+    """
+    assert grad.ndim == 2
+    assert momentum.shape == grad.shape
+
+    G = grad.float()
+    m, n = G.shape
+
+    # Momentum EMA.
+    momentum.lerp_(grad, 1.0 - mu)
+
+    if nesterov:
+        M = grad.float().lerp(momentum.float(), mu)
+    else:
+        M = momentum.float()
+
+    # EMA Gram matrices.
+    left_gram.lerp_(G @ G.T, 1.0 - gram_beta)
+    right_gram.lerp_(G.T @ G, 1.0 - gram_beta)
+
+    # Bases from EMA Grams.
+    U = gram_eigenbasis(left_gram, eps=eps)
+    V = gram_eigenbasis(right_gram, eps=eps)
+
+    # Project momentum/update into Gram feature basis.
+    A = U.T @ M @ V
+
+    # Sinkhorn energy balancing, no scale restoration.
+    A_bal = sinkhorn_energy_balance_rect_no_scale(
+        A,
+        steps=sinkhorn_steps,
+        eps=eps,
+    ).float()
+
+    # Reconstruct matrix update.
+    update = U @ A_bal @ V.T
+
+    # First align final matrix update scale to Muon.
+    update = scale_update_like_muon(update, eps=eps)
+
+    # Then apply NorMuon-style postconditioner.
+    # It preserves the norm, so final scale remains Muon-aligned.
+    if apply_normuon and (m != n):
+        update = normuon_postcondition_update(
+            update,
+            second_momentum=second_momentum,
+            beta=normuon_beta,
+            eps=normuon_eps,
+        )
+
+    return update.to(grad.dtype)
+
+
+class SinkSOAP(torch.optim.Optimizer):
+    """
+    Gram-Sinkhorn-Muon + NorMuon postconditioner.
+
+    State per 2D parameter:
+
+        momentum:        [m, n]
+        left_gram:       [m, m]
+        right_gram:      [n, n]
+        second_momentum: [m, 1] if m >= n else [1, n]
+
+    Final update scale is aligned to original Muon Frobenius norm before
+    NorMuon postconditioning.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 0.02,
+        weight_decay: float = 0.0,
+        mu: float = 0.95,
+        gram_beta: float = 0.95,
+        normuon_beta: float = 0.95,
+        sinkhorn_steps: int = 10,
+        nesterov: bool = True,
+        eps: float = 1e-8,
+        normuon_eps: float = 1e-10,
+        apply_normuon: bool =True,
+    ):
+        assert isinstance(params, list)
+        assert len(params) >= 1
+        assert isinstance(params[0], torch.nn.Parameter)
+
+        params = sorted(params, key=lambda x: x.size(), reverse=True)
+
+        defaults = dict(
+            lr=lr,
+            weight_decay=weight_decay,
+            mu=mu,
+            gram_beta=gram_beta,
+            normuon_beta=normuon_beta,
+            sinkhorn_steps=sinkhorn_steps,
+            nesterov=nesterov,
+            eps=eps,
+            normuon_eps=normuon_eps,
+            apply_normuon=apply_normuon,
+        )
+
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        rank = dist.get_rank() if dist.is_initialized() else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+
+            if world_size > 1:
+                pad_len = (world_size - len(params) % world_size) % world_size
+                params_pad = params + [torch.empty_like(params[-1])] * pad_len
+            else:
+                params_pad = params
+
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+
+                    if p.grad is None:
+                        continue
+
+                    if p.grad.ndim != 2:
+                        raise ValueError(
+                            "GramSinkhornNorMuon currently only supports 2D parameters. "
+                            f"Got parameter with shape {tuple(p.shape)}."
+                        )
+
+                    state = self.state[p]
+                    m, n = p.shape
+
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+
+                        state["left_gram"] = torch.zeros(
+                            (m, m),
+                            device=p.device,
+                            dtype=torch.float32,
+                        )
+
+                        state["right_gram"] = torch.zeros(
+                            (n, n),
+                            device=p.device,
+                            dtype=torch.float32,
+                        )
+
+                        if m >= n:
+                            state["second_momentum"] = torch.zeros(
+                                (m, 1),
+                                device=p.device,
+                                dtype=torch.float32,
+                            )
+                        else:
+                            state["second_momentum"] = torch.zeros(
+                                (1, n),
+                                device=p.device,
+                                dtype=torch.float32,
+                            )
+
+                    update = gram_sinkhorn_normuon_update(
+                        grad=p.grad,
+                        momentum=state["momentum"],
+                        left_gram=state["left_gram"],
+                        right_gram=state["right_gram"],
+                        second_momentum=state["second_momentum"],
+                        mu=group["mu"],
+                        gram_beta=group["gram_beta"],
+                        normuon_beta=group["normuon_beta"],
+                        nesterov=group["nesterov"],
+                        sinkhorn_steps=group["sinkhorn_steps"],
+                        eps=group["eps"],
+                        normuon_eps=group["normuon_eps"],
+                        apply_normuon=group["apply_normuon"],
+                    )
+
+                    p.mul_(1.0 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+
+                if world_size > 1:
+                    dist.all_gather(
+                        params_pad[base_i : base_i + world_size],
+                        params_pad[base_i + rank],
+                    )
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3125
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    optimizer2 = SinkSOAP([p for p in model.blocks.parameters() if p.ndim >= 2],
+                      lr=0.04, weight_decay=0.025)
+    optimizers = [optimizer1, optimizer2]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters())
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.94 else 25
+        if step == train_steps or step % val_step_freq == 0 or step == 3080 or step == 3085 or step == 3090:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H200 with world_size 8
+====================================================================================================
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.59955 train_time:94.547s step_avg:756.38ms
+step:250/3125 val_loss:4.07528 train_time:154.217s step_avg:477.35ms
+step:375/3125 val_loss:3.90445 train_time:214.175s step_avg:479.67ms
+step:500/3125 val_loss:3.80552 train_time:276.494s step_avg:498.55ms
+step:625/3125 val_loss:3.74093 train_time:338.951s step_avg:499.66ms
+step:750/3125 val_loss:3.69793 train_time:399.593s step_avg:485.14ms
+step:875/3125 val_loss:3.66026 train_time:462.736s step_avg:505.14ms
+step:1000/3125 val_loss:3.62387 train_time:525.387s step_avg:501.21ms
+step:1125/3125 val_loss:3.59523 train_time:586.455s step_avg:488.54ms
+step:1250/3125 val_loss:3.56254 train_time:649.460s step_avg:504.05ms
+step:1375/3125 val_loss:3.53717 train_time:710.907s step_avg:491.57ms
+step:1500/3125 val_loss:3.50959 train_time:772.299s step_avg:491.13ms
+step:1625/3125 val_loss:3.49052 train_time:835.993s step_avg:509.56ms
+step:1750/3125 val_loss:3.46670 train_time:899.899s step_avg:511.25ms
+step:1875/3125 val_loss:3.44684 train_time:961.660s step_avg:494.09ms
+step:2000/3125 val_loss:3.42625 train_time:1025.453s step_avg:510.35ms
+step:2125/3125 val_loss:3.40752 train_time:1089.086s step_avg:509.06ms
+step:2250/3125 val_loss:3.38897 train_time:1150.889s step_avg:494.42ms
+step:2375/3125 val_loss:3.37118 train_time:1214.381s step_avg:507.93ms
+step:2500/3125 val_loss:3.35307 train_time:1277.798s step_avg:507.34ms
+step:2625/3125 val_loss:3.33487 train_time:1339.499s step_avg:493.61ms
+step:2750/3125 val_loss:3.31714 train_time:1403.414s step_avg:511.32ms
+step:2875/3125 val_loss:3.30076 train_time:1466.729s step_avg:506.53ms
+step:2950/3125 val_loss:3.29142 train_time:1503.542s step_avg:490.84ms
+step:2975/3125 val_loss:3.28876 train_time:1515.804s step_avg:490.46ms
+step:3000/3125 val_loss:3.28622 train_time:1528.072s step_avg:490.73ms
+step:3025/3125 val_loss:3.28352 train_time:1540.384s step_avg:492.49ms
+step:3050/3125 val_loss:3.28124 train_time:1555.045s step_avg:586.43ms
+step:3075/3125 val_loss:3.27947 train_time:1567.409s step_avg:494.54ms
+step:3080/3125 val_loss:3.27915 train_time:1569.887s step_avg:495.67ms
+step:3085/3125 val_loss:3.27884 train_time:1572.363s step_avg:495.22ms
+step:3090/3125 val_loss:3.27856 train_time:1574.834s step_avg:494.24ms
+step:3100/3125 val_loss:3.27813 train_time:1579.764s step_avg:492.96ms
+step:3125/3125 val_loss:3.27748 train_time:1592.078s step_avg:492.56ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.59713 train_time:55.175s step_avg:441.40ms
+step:250/3125 val_loss:4.06824 train_time:114.741s step_avg:476.53ms
+step:375/3125 val_loss:3.90042 train_time:174.819s step_avg:480.63ms
+step:500/3125 val_loss:3.80606 train_time:235.285s step_avg:483.73ms
+step:625/3125 val_loss:3.74113 train_time:296.021s step_avg:485.88ms
+step:750/3125 val_loss:3.69627 train_time:356.819s step_avg:486.39ms
+step:875/3125 val_loss:3.65911 train_time:417.737s step_avg:487.34ms
+step:1000/3125 val_loss:3.62324 train_time:478.798s step_avg:488.48ms
+step:1125/3125 val_loss:3.59498 train_time:539.931s step_avg:489.06ms
+step:1250/3125 val_loss:3.56382 train_time:601.250s step_avg:490.55ms
+step:1375/3125 val_loss:3.53797 train_time:662.761s step_avg:492.09ms
+step:1500/3125 val_loss:3.51037 train_time:724.318s step_avg:492.45ms
+step:1625/3125 val_loss:3.49026 train_time:786.028s step_avg:493.68ms
+step:1750/3125 val_loss:3.46763 train_time:847.812s step_avg:494.27ms
+step:1875/3125 val_loss:3.44809 train_time:909.656s step_avg:494.75ms
+step:2000/3125 val_loss:3.42756 train_time:971.596s step_avg:495.52ms
+step:2125/3125 val_loss:3.40844 train_time:1033.642s step_avg:496.38ms
+step:2250/3125 val_loss:3.39019 train_time:1095.663s step_avg:496.16ms
+step:2375/3125 val_loss:3.37302 train_time:1157.736s step_avg:496.59ms
+step:2500/3125 val_loss:3.35484 train_time:1219.778s step_avg:496.33ms
+step:2625/3125 val_loss:3.33626 train_time:1281.779s step_avg:496.01ms
+step:2750/3125 val_loss:3.31877 train_time:1343.772s step_avg:495.94ms
+step:2875/3125 val_loss:3.30228 train_time:1405.415s step_avg:493.14ms
+step:2950/3125 val_loss:3.29305 train_time:1442.354s step_avg:492.52ms
+step:2975/3125 val_loss:3.29028 train_time:1454.670s step_avg:492.64ms
+step:3000/3125 val_loss:3.28786 train_time:1466.963s step_avg:491.73ms
+step:3025/3125 val_loss:3.28511 train_time:1479.266s step_avg:492.13ms
+step:3050/3125 val_loss:3.28281 train_time:1491.659s step_avg:495.70ms
+step:3075/3125 val_loss:3.28107 train_time:1504.002s step_avg:493.71ms
+step:3080/3125 val_loss:3.28075 train_time:1506.477s step_avg:495.16ms
+step:3085/3125 val_loss:3.28042 train_time:1508.955s step_avg:495.44ms
+step:3090/3125 val_loss:3.28014 train_time:1511.434s step_avg:495.87ms
+step:3100/3125 val_loss:3.27970 train_time:1516.374s step_avg:493.97ms
+step:3125/3125 val_loss:3.27909 train_time:1528.732s step_avg:494.35ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.56169 train_time:55.327s step_avg:442.62ms
+step:250/3125 val_loss:4.05824 train_time:114.918s step_avg:476.73ms
+step:375/3125 val_loss:3.89435 train_time:175.006s step_avg:480.70ms
+step:500/3125 val_loss:3.80067 train_time:235.426s step_avg:483.35ms
+step:625/3125 val_loss:3.73884 train_time:296.135s step_avg:485.67ms
+step:750/3125 val_loss:3.69537 train_time:356.872s step_avg:485.90ms
+step:875/3125 val_loss:3.65678 train_time:417.774s step_avg:487.22ms
+step:1000/3125 val_loss:3.62176 train_time:478.680s step_avg:487.25ms
+step:1125/3125 val_loss:3.59210 train_time:539.763s step_avg:488.66ms
+step:1250/3125 val_loss:3.56062 train_time:601.180s step_avg:491.34ms
+step:1375/3125 val_loss:3.53503 train_time:662.691s step_avg:492.08ms
+step:1500/3125 val_loss:3.50725 train_time:724.231s step_avg:492.32ms
+step:1625/3125 val_loss:3.48741 train_time:786.008s step_avg:494.22ms
+step:1750/3125 val_loss:3.46592 train_time:847.868s step_avg:494.88ms
+step:1875/3125 val_loss:3.44529 train_time:909.735s step_avg:494.93ms
+step:2000/3125 val_loss:3.42511 train_time:971.732s step_avg:495.98ms
+step:2125/3125 val_loss:3.40634 train_time:1033.745s step_avg:496.10ms
+step:2250/3125 val_loss:3.38785 train_time:1095.613s step_avg:494.95ms
+step:2375/3125 val_loss:3.37017 train_time:1157.459s step_avg:494.76ms
+step:2500/3125 val_loss:3.35195 train_time:1219.135s step_avg:493.41ms
+step:2625/3125 val_loss:3.33356 train_time:1280.753s step_avg:492.94ms
+step:2750/3125 val_loss:3.31615 train_time:1342.375s step_avg:492.97ms
+step:2875/3125 val_loss:3.29973 train_time:1403.948s step_avg:492.59ms
+step:2950/3125 val_loss:3.29053 train_time:1440.819s step_avg:491.61ms
+step:2975/3125 val_loss:3.28782 train_time:1453.084s step_avg:490.59ms
+step:3000/3125 val_loss:3.28536 train_time:1465.356s step_avg:490.89ms
+step:3025/3125 val_loss:3.28273 train_time:1477.628s step_avg:490.87ms
+step:3050/3125 val_loss:3.28042 train_time:1489.977s step_avg:493.95ms
+step:3075/3125 val_loss:3.27868 train_time:1502.296s step_avg:492.79ms
+step:3080/3125 val_loss:3.27834 train_time:1504.770s step_avg:494.70ms
+step:3085/3125 val_loss:3.27800 train_time:1507.243s step_avg:494.68ms
+step:3090/3125 val_loss:3.27774 train_time:1509.727s step_avg:496.71ms
+step:3100/3125 val_loss:3.27733 train_time:1514.665s step_avg:493.82ms
+step:3125/3125 val_loss:3.27670 train_time:1527.058s step_avg:495.73ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.56700 train_time:55.390s step_avg:443.12ms
+step:250/3125 val_loss:4.06188 train_time:114.949s step_avg:476.47ms
+step:375/3125 val_loss:3.89510 train_time:174.905s step_avg:479.65ms
+step:500/3125 val_loss:3.80093 train_time:235.245s step_avg:482.72ms
+step:625/3125 val_loss:3.73645 train_time:295.701s step_avg:483.65ms
+step:750/3125 val_loss:3.69547 train_time:356.383s step_avg:485.46ms
+step:875/3125 val_loss:3.65569 train_time:417.113s step_avg:485.84ms
+step:1000/3125 val_loss:3.62120 train_time:478.027s step_avg:487.31ms
+step:1125/3125 val_loss:3.59313 train_time:539.138s step_avg:488.88ms
+step:1250/3125 val_loss:3.56297 train_time:600.398s step_avg:490.08ms
+step:1375/3125 val_loss:3.53587 train_time:661.795s step_avg:491.17ms
+step:1500/3125 val_loss:3.50762 train_time:723.228s step_avg:491.47ms
+step:1625/3125 val_loss:3.48872 train_time:784.902s step_avg:493.39ms
+step:1750/3125 val_loss:3.46535 train_time:846.607s step_avg:493.64ms
+step:1875/3125 val_loss:3.44517 train_time:908.342s step_avg:493.88ms
+step:2000/3125 val_loss:3.42584 train_time:970.153s step_avg:494.50ms
+step:2125/3125 val_loss:3.40697 train_time:1031.985s step_avg:494.65ms
+step:2250/3125 val_loss:3.38825 train_time:1093.779s step_avg:494.35ms
+step:2375/3125 val_loss:3.37070 train_time:1155.433s step_avg:493.23ms
+step:2500/3125 val_loss:3.35250 train_time:1216.913s step_avg:491.84ms
+step:2625/3125 val_loss:3.33422 train_time:1278.638s step_avg:493.81ms
+step:2750/3125 val_loss:3.31645 train_time:1340.431s step_avg:494.34ms
+step:2875/3125 val_loss:3.30026 train_time:1402.115s step_avg:493.47ms
+step:2950/3125 val_loss:3.29109 train_time:1439.033s step_avg:492.24ms
+step:2975/3125 val_loss:3.28839 train_time:1451.335s step_avg:492.08ms
+step:3000/3125 val_loss:3.28583 train_time:1463.616s step_avg:491.27ms
+step:3025/3125 val_loss:3.28319 train_time:1475.906s step_avg:491.58ms
+step:3050/3125 val_loss:3.28089 train_time:1488.284s step_avg:495.12ms
+step:3075/3125 val_loss:3.27919 train_time:1500.631s step_avg:493.88ms
+step:3080/3125 val_loss:3.27886 train_time:1503.103s step_avg:494.49ms
+step:3085/3125 val_loss:3.27853 train_time:1505.577s step_avg:494.79ms
+step:3090/3125 val_loss:3.27828 train_time:1508.051s step_avg:494.75ms
+step:3100/3125 val_loss:3.27784 train_time:1513.007s step_avg:495.61ms
+step:3125/3125 val_loss:3.27722 train_time:1525.358s step_avg:494.05ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.58767 train_time:55.042s step_avg:440.34ms
+step:250/3125 val_loss:4.06263 train_time:114.673s step_avg:477.05ms
+step:375/3125 val_loss:3.89844 train_time:174.732s step_avg:480.47ms
+step:500/3125 val_loss:3.80635 train_time:235.195s step_avg:483.71ms
+step:625/3125 val_loss:3.73895 train_time:295.830s step_avg:485.08ms
+step:750/3125 val_loss:3.69575 train_time:356.583s step_avg:486.03ms
+step:875/3125 val_loss:3.65584 train_time:417.559s step_avg:487.81ms
+step:1000/3125 val_loss:3.62263 train_time:478.665s step_avg:488.85ms
+step:1125/3125 val_loss:3.59256 train_time:539.815s step_avg:489.20ms
+step:1250/3125 val_loss:3.56021 train_time:601.194s step_avg:491.03ms
+step:1375/3125 val_loss:3.53508 train_time:662.675s step_avg:491.84ms
+step:1500/3125 val_loss:3.50730 train_time:724.950s step_avg:498.20ms
+step:1625/3125 val_loss:3.48731 train_time:786.685s step_avg:493.88ms
+step:1750/3125 val_loss:3.46478 train_time:848.541s step_avg:494.85ms
+step:1875/3125 val_loss:3.44483 train_time:910.380s step_avg:494.71ms
+step:2000/3125 val_loss:3.42469 train_time:972.329s step_avg:495.59ms
+step:2125/3125 val_loss:3.40608 train_time:1034.303s step_avg:495.79ms
+step:2250/3125 val_loss:3.38712 train_time:1096.216s step_avg:495.30ms
+step:2375/3125 val_loss:3.36938 train_time:1158.022s step_avg:494.45ms
+step:2500/3125 val_loss:3.35139 train_time:1219.732s step_avg:493.68ms
+step:2625/3125 val_loss:3.33298 train_time:1281.550s step_avg:494.55ms
+step:2750/3125 val_loss:3.31560 train_time:1343.239s step_avg:493.51ms
+step:2875/3125 val_loss:3.29942 train_time:1404.932s step_avg:493.55ms
+step:2950/3125 val_loss:3.29022 train_time:1441.873s step_avg:492.55ms
+step:2975/3125 val_loss:3.28751 train_time:1454.188s step_avg:492.60ms
+step:3000/3125 val_loss:3.28506 train_time:1466.514s step_avg:493.05ms
+step:3025/3125 val_loss:3.28245 train_time:1478.830s step_avg:492.63ms
+step:3050/3125 val_loss:3.28015 train_time:1491.237s step_avg:496.26ms
+step:3075/3125 val_loss:3.27840 train_time:1503.585s step_avg:493.95ms
+step:3080/3125 val_loss:3.27806 train_time:1506.067s step_avg:496.43ms
+step:3085/3125 val_loss:3.27775 train_time:1508.542s step_avg:494.95ms
+step:3090/3125 val_loss:3.27746 train_time:1511.019s step_avg:495.37ms
+step:3100/3125 val_loss:3.27703 train_time:1515.956s step_avg:493.72ms
+step:3125/3125 val_loss:3.27640 train_time:1528.304s step_avg:493.91ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.58795 train_time:55.455s step_avg:443.64ms
+step:250/3125 val_loss:4.07171 train_time:115.094s step_avg:477.11ms
+step:375/3125 val_loss:3.90282 train_time:175.124s step_avg:480.24ms
+step:500/3125 val_loss:3.80595 train_time:235.613s step_avg:483.91ms
+step:625/3125 val_loss:3.73995 train_time:296.273s step_avg:485.28ms
+step:750/3125 val_loss:3.69582 train_time:356.969s step_avg:485.57ms
+step:875/3125 val_loss:3.65963 train_time:417.924s step_avg:487.64ms
+step:1000/3125 val_loss:3.62218 train_time:478.888s step_avg:487.71ms
+step:1125/3125 val_loss:3.59159 train_time:540.032s step_avg:489.15ms
+step:1250/3125 val_loss:3.56242 train_time:601.428s step_avg:491.17ms
+step:1375/3125 val_loss:3.53525 train_time:662.896s step_avg:491.74ms
+step:1500/3125 val_loss:3.50875 train_time:724.445s step_avg:492.40ms
+step:1625/3125 val_loss:3.48890 train_time:786.178s step_avg:493.86ms
+step:1750/3125 val_loss:3.46585 train_time:847.990s step_avg:494.49ms
+step:1875/3125 val_loss:3.44501 train_time:909.828s step_avg:494.70ms
+step:2000/3125 val_loss:3.42579 train_time:971.769s step_avg:495.53ms
+step:2125/3125 val_loss:3.40719 train_time:1033.718s step_avg:495.59ms
+step:2250/3125 val_loss:3.38864 train_time:1095.577s step_avg:494.88ms
+step:2375/3125 val_loss:3.37079 train_time:1157.292s step_avg:493.72ms
+step:2500/3125 val_loss:3.35295 train_time:1218.921s step_avg:493.04ms
+step:2625/3125 val_loss:3.33453 train_time:1280.666s step_avg:493.95ms
+step:2750/3125 val_loss:3.31693 train_time:1342.389s step_avg:493.79ms
+step:2875/3125 val_loss:3.30056 train_time:1403.997s step_avg:492.87ms
+step:2950/3125 val_loss:3.29129 train_time:1440.904s step_avg:492.10ms
+step:2975/3125 val_loss:3.28868 train_time:1453.189s step_avg:491.38ms
+step:3000/3125 val_loss:3.28603 train_time:1465.484s step_avg:491.81ms
+step:3025/3125 val_loss:3.28345 train_time:1477.797s step_avg:492.53ms
+step:3050/3125 val_loss:3.28122 train_time:1490.229s step_avg:497.25ms
+step:3075/3125 val_loss:3.27943 train_time:1502.613s step_avg:495.37ms
+step:3080/3125 val_loss:3.27910 train_time:1505.102s step_avg:497.80ms
+step:3085/3125 val_loss:3.27875 train_time:1507.583s step_avg:496.30ms
+step:3090/3125 val_loss:3.27847 train_time:1510.065s step_avg:496.26ms
+step:3100/3125 val_loss:3.27802 train_time:1515.002s step_avg:493.77ms
+step:3125/3125 val_loss:3.27738 train_time:1527.320s step_avg:492.70ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.58910 train_time:55.190s step_avg:441.52ms
+step:250/3125 val_loss:4.06914 train_time:114.884s step_avg:477.55ms
+step:375/3125 val_loss:3.90146 train_time:174.911s step_avg:480.22ms
+step:500/3125 val_loss:3.80577 train_time:235.361s step_avg:483.59ms
+step:625/3125 val_loss:3.73924 train_time:296.074s step_avg:485.71ms
+step:750/3125 val_loss:3.69766 train_time:356.872s step_avg:486.38ms
+step:875/3125 val_loss:3.65927 train_time:417.893s step_avg:488.16ms
+step:1000/3125 val_loss:3.62331 train_time:478.869s step_avg:487.81ms
+step:1125/3125 val_loss:3.59448 train_time:540.064s step_avg:489.56ms
+step:1250/3125 val_loss:3.56272 train_time:601.494s step_avg:491.44ms
+step:1375/3125 val_loss:3.53692 train_time:663.009s step_avg:492.13ms
+step:1500/3125 val_loss:3.51033 train_time:724.611s step_avg:492.81ms
+step:1625/3125 val_loss:3.48919 train_time:786.384s step_avg:494.18ms
+step:1750/3125 val_loss:3.46652 train_time:848.274s step_avg:495.12ms
+step:1875/3125 val_loss:3.44639 train_time:910.109s step_avg:494.68ms
+step:2000/3125 val_loss:3.42623 train_time:972.089s step_avg:495.84ms
+step:2125/3125 val_loss:3.40815 train_time:1034.063s step_avg:495.80ms
+step:2250/3125 val_loss:3.38964 train_time:1095.901s step_avg:494.71ms
+step:2375/3125 val_loss:3.37216 train_time:1157.713s step_avg:494.49ms
+step:2500/3125 val_loss:3.35416 train_time:1219.375s step_avg:493.30ms
+step:2625/3125 val_loss:3.33585 train_time:1281.120s step_avg:493.97ms
+step:2750/3125 val_loss:3.31795 train_time:1342.837s step_avg:493.74ms
+step:2875/3125 val_loss:3.30160 train_time:1404.475s step_avg:493.10ms
+step:2950/3125 val_loss:3.29253 train_time:1441.371s step_avg:491.96ms
+step:2975/3125 val_loss:3.28985 train_time:1453.653s step_avg:491.28ms
+step:3000/3125 val_loss:3.28726 train_time:1465.938s step_avg:491.38ms
+step:3025/3125 val_loss:3.28467 train_time:1478.219s step_avg:491.25ms
+step:3050/3125 val_loss:3.28233 train_time:1490.599s step_avg:495.18ms
+step:3075/3125 val_loss:3.28060 train_time:1502.939s step_avg:493.61ms
+step:3080/3125 val_loss:3.28027 train_time:1505.416s step_avg:495.43ms
+step:3085/3125 val_loss:3.27996 train_time:1507.889s step_avg:494.59ms
+step:3090/3125 val_loss:3.27970 train_time:1510.372s step_avg:496.50ms
+step:3100/3125 val_loss:3.27925 train_time:1515.295s step_avg:492.39ms
+step:3125/3125 val_loss:3.27864 train_time:1527.611s step_avg:492.61ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.56733 train_time:55.459s step_avg:443.68ms
+step:250/3125 val_loss:4.06515 train_time:115.019s step_avg:476.48ms
+step:375/3125 val_loss:3.89913 train_time:175.023s step_avg:480.03ms
+step:500/3125 val_loss:3.80228 train_time:235.454s step_avg:483.45ms
+step:625/3125 val_loss:3.73879 train_time:296.072s step_avg:484.95ms
+step:750/3125 val_loss:3.69506 train_time:356.873s step_avg:486.41ms
+step:875/3125 val_loss:3.65878 train_time:417.812s step_avg:487.51ms
+step:1000/3125 val_loss:3.62379 train_time:478.822s step_avg:488.08ms
+step:1125/3125 val_loss:3.59327 train_time:540.003s step_avg:489.45ms
+step:1250/3125 val_loss:3.56209 train_time:601.375s step_avg:490.98ms
+step:1375/3125 val_loss:3.53676 train_time:662.803s step_avg:491.42ms
+step:1500/3125 val_loss:3.50838 train_time:724.317s step_avg:492.12ms
+step:1625/3125 val_loss:3.48864 train_time:786.004s step_avg:493.49ms
+step:1750/3125 val_loss:3.46546 train_time:847.760s step_avg:494.06ms
+step:1875/3125 val_loss:3.44596 train_time:909.519s step_avg:494.07ms
+step:2000/3125 val_loss:3.42573 train_time:971.409s step_avg:495.11ms
+step:2125/3125 val_loss:3.40709 train_time:1033.373s step_avg:495.72ms
+step:2250/3125 val_loss:3.38804 train_time:1095.276s step_avg:495.22ms
+step:2375/3125 val_loss:3.37028 train_time:1157.176s step_avg:495.20ms
+step:2500/3125 val_loss:3.35227 train_time:1219.000s step_avg:494.59ms
+step:2625/3125 val_loss:3.33393 train_time:1280.696s step_avg:493.56ms
+step:2750/3125 val_loss:3.31647 train_time:1342.335s step_avg:493.11ms
+step:2875/3125 val_loss:3.29988 train_time:1403.992s step_avg:493.25ms
+step:2950/3125 val_loss:3.29066 train_time:1440.952s step_avg:492.81ms
+step:2975/3125 val_loss:3.28807 train_time:1453.264s step_avg:492.47ms
+step:3000/3125 val_loss:3.28560 train_time:1465.574s step_avg:492.40ms
+step:3025/3125 val_loss:3.28295 train_time:1477.899s step_avg:493.00ms
+step:3050/3125 val_loss:3.28059 train_time:1490.304s step_avg:496.19ms
+step:3075/3125 val_loss:3.27888 train_time:1502.658s step_avg:494.15ms
+step:3080/3125 val_loss:3.27854 train_time:1505.138s step_avg:496.07ms
+step:3085/3125 val_loss:3.27823 train_time:1507.622s step_avg:496.79ms
+step:3090/3125 val_loss:3.27795 train_time:1510.108s step_avg:497.22ms
+step:3100/3125 val_loss:3.27752 train_time:1515.046s step_avg:493.83ms
+step:3125/3125 val_loss:3.27690 train_time:1527.388s step_avg:493.67ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.58528 train_time:55.123s step_avg:440.99ms
+step:250/3125 val_loss:4.06218 train_time:114.678s step_avg:476.44ms
+step:375/3125 val_loss:3.89564 train_time:174.671s step_avg:479.94ms
+step:500/3125 val_loss:3.80142 train_time:234.909s step_avg:481.91ms
+step:625/3125 val_loss:3.73734 train_time:295.460s step_avg:484.41ms
+step:750/3125 val_loss:3.69725 train_time:356.038s step_avg:484.62ms
+step:875/3125 val_loss:3.65729 train_time:416.797s step_avg:486.07ms
+step:1000/3125 val_loss:3.62116 train_time:477.715s step_avg:487.34ms
+step:1125/3125 val_loss:3.59314 train_time:538.759s step_avg:488.36ms
+step:1250/3125 val_loss:3.56177 train_time:600.082s step_avg:490.59ms
+step:1375/3125 val_loss:3.53470 train_time:661.548s step_avg:491.73ms
+step:1500/3125 val_loss:3.50951 train_time:723.010s step_avg:491.69ms
+step:1625/3125 val_loss:3.48750 train_time:784.699s step_avg:493.51ms
+step:1750/3125 val_loss:3.46563 train_time:846.405s step_avg:493.65ms
+step:1875/3125 val_loss:3.44519 train_time:908.166s step_avg:494.09ms
+step:2000/3125 val_loss:3.42577 train_time:970.055s step_avg:495.11ms
+step:2125/3125 val_loss:3.40734 train_time:1031.971s step_avg:495.32ms
+step:2250/3125 val_loss:3.38858 train_time:1093.830s step_avg:494.88ms
+step:2375/3125 val_loss:3.37101 train_time:1155.646s step_avg:494.52ms
+step:2500/3125 val_loss:3.35257 train_time:1217.489s step_avg:494.75ms
+step:2625/3125 val_loss:3.33425 train_time:1279.162s step_avg:493.38ms
+step:2750/3125 val_loss:3.31708 train_time:1340.898s step_avg:493.89ms
+step:2875/3125 val_loss:3.30056 train_time:1402.522s step_avg:492.99ms
+step:2950/3125 val_loss:3.29147 train_time:1439.441s step_avg:492.26ms
+step:2975/3125 val_loss:3.28874 train_time:1451.726s step_avg:491.40ms
+step:3000/3125 val_loss:3.28617 train_time:1464.031s step_avg:492.17ms
+step:3025/3125 val_loss:3.28355 train_time:1476.354s step_avg:492.93ms
+step:3050/3125 val_loss:3.28125 train_time:1488.789s step_avg:497.40ms
+step:3075/3125 val_loss:3.27949 train_time:1501.139s step_avg:494.00ms
+step:3080/3125 val_loss:3.27917 train_time:1503.616s step_avg:495.48ms
+step:3085/3125 val_loss:3.27884 train_time:1506.095s step_avg:495.68ms
+step:3090/3125 val_loss:3.27855 train_time:1508.580s step_avg:497.07ms
+step:3100/3125 val_loss:3.27809 train_time:1513.528s step_avg:494.77ms
+step:3125/3125 val_loss:3.27749 train_time:1525.869s step_avg:493.67ms
+step:0/3125 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3125 val_loss:4.59315 train_time:55.141s step_avg:441.12ms
+step:250/3125 val_loss:4.06798 train_time:114.733s step_avg:476.74ms
+step:375/3125 val_loss:3.90325 train_time:174.748s step_avg:480.12ms
+step:500/3125 val_loss:3.80482 train_time:235.134s step_avg:483.08ms
+step:625/3125 val_loss:3.73954 train_time:295.872s step_avg:485.91ms
+step:750/3125 val_loss:3.69497 train_time:356.576s step_avg:485.63ms
+step:875/3125 val_loss:3.65797 train_time:417.499s step_avg:487.38ms
+step:1000/3125 val_loss:3.62259 train_time:478.547s step_avg:488.38ms
+step:1125/3125 val_loss:3.59410 train_time:539.649s step_avg:488.82ms
+step:1250/3125 val_loss:3.56040 train_time:600.998s step_avg:490.79ms
+step:1375/3125 val_loss:3.53596 train_time:662.367s step_avg:490.96ms
+step:1500/3125 val_loss:3.50853 train_time:723.842s step_avg:491.80ms
+step:1625/3125 val_loss:3.48813 train_time:785.531s step_avg:493.51ms
+step:1750/3125 val_loss:3.46451 train_time:847.274s step_avg:493.94ms
+step:1875/3125 val_loss:3.44478 train_time:909.036s step_avg:494.10ms
+step:2000/3125 val_loss:3.42483 train_time:970.937s step_avg:495.21ms
+step:2125/3125 val_loss:3.40633 train_time:1032.943s step_avg:496.05ms
+step:2250/3125 val_loss:3.38772 train_time:1094.890s step_avg:495.57ms
+step:2375/3125 val_loss:3.37031 train_time:1156.919s step_avg:496.23ms
+step:2500/3125 val_loss:3.35182 train_time:1218.968s step_avg:496.39ms
+step:2625/3125 val_loss:3.33383 train_time:1280.888s step_avg:495.36ms
+step:2750/3125 val_loss:3.31633 train_time:1342.893s step_avg:496.04ms
+step:2875/3125 val_loss:3.29973 train_time:1404.650s step_avg:494.06ms
+step:2950/3125 val_loss:3.29055 train_time:1441.542s step_avg:491.89ms
+step:2975/3125 val_loss:3.28792 train_time:1453.796s step_avg:490.14ms
+step:3000/3125 val_loss:3.28536 train_time:1466.099s step_avg:492.12ms
+step:3025/3125 val_loss:3.28271 train_time:1478.386s step_avg:491.49ms
+step:3050/3125 val_loss:3.28045 train_time:1490.798s step_avg:496.47ms
+step:3075/3125 val_loss:3.27870 train_time:1503.125s step_avg:493.11ms
+step:3080/3125 val_loss:3.27840 train_time:1505.593s step_avg:493.48ms
+step:3085/3125 val_loss:3.27808 train_time:1508.058s step_avg:492.99ms
+step:3090/3125 val_loss:3.27779 train_time:1510.530s step_avg:494.38ms
+step:3100/3125 val_loss:3.27735 train_time:1515.462s step_avg:493.21ms
+step:3125/3125 val_loss:3.27672 train_time:1527.766s step_avg:492.18ms

--- a/records/track_3_optimization/train_gpt_simple.py
+++ b/records/track_3_optimization/train_gpt_simple.py
@@ -213,6 +213,368 @@ class Muon(torch.optim.Optimizer):
                 dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
 
 
+
+
+
+
+def gram_eigenbasis(C: Tensor, eps: float = 1e-6) -> Tensor:
+    """
+    Eigenbasis for symmetric PSD Gram matrix.
+    Returns eigenvectors sorted by descending eigenvalue.
+    """
+    C = C.float()
+    C = 0.5 * (C + C.T)
+
+    if eps > 0:
+        eye = torch.eye(C.shape[0], device=C.device, dtype=C.dtype)
+        C = C + eps * eye
+
+    evals, evecs = torch.linalg.eigh(C)
+    idx = torch.argsort(evals, descending=True)
+    return evecs[:, idx]
+
+
+def sinkhorn_energy_balance_rect_no_scale(
+    A: Tensor,
+    steps: int = 10,
+    eps: float = 1e-8,
+) -> Tensor:
+    """
+    Sinkhorn-balance elementwise energy A^2.
+
+    For A in R^{m x n}:
+
+        B = A^2 + eps
+        Pi = Dr B Dc
+
+    target rectangular marginals:
+
+        Pi 1_n ~= (1/m) 1_m
+        Pi^T 1_m ~= (1/n) 1_n
+
+    Lift back:
+
+        A_bal = Dr^{1/2} A Dc^{1/2}
+
+    No RMS/Frobenius scaling here.
+    """
+    assert A.ndim == 2
+
+    out_dtype = A.dtype
+    A = A.float()
+
+    m, n = A.shape
+    B = A.square() + eps
+
+    target_r = torch.full(
+        (m,),
+        1.0 / m,
+        device=A.device,
+        dtype=torch.float32,
+    )
+    target_c = torch.full(
+        (n,),
+        1.0 / n,
+        device=A.device,
+        dtype=torch.float32,
+    )
+
+    r = torch.ones(m, device=A.device, dtype=torch.float32)
+    c = torch.ones(n, device=A.device, dtype=torch.float32)
+
+    for _ in range(steps):
+        r = target_r / (B @ c + eps)
+        c = target_c / (B.T @ r + eps)
+
+    A_bal = r.sqrt()[:, None] * A * c.sqrt()[None, :]
+
+    return A_bal.to(out_dtype)
+
+
+def scale_update_like_muon(update: Tensor, eps: float = 1e-8) -> Tensor:
+    """
+    Match original Muon's final Frobenius norm:
+
+        ||update||_F ~= sqrt(min(m, n)) * sqrt(max(1, m / n))
+
+    This equals sqrt(m), but we keep the Muon expression.
+    """
+    assert update.ndim == 2
+
+    m, n = update.shape
+
+    target_norm = (min(m, n) ** 0.5) * (max(1.0, m / n) ** 0.5)
+
+    update_norm = update.float().norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+
+    return update * (target_norm / update_norm).to(update.dtype)
+
+
+def normuon_postcondition_update(
+    update: Tensor,
+    second_momentum: Tensor,
+    beta: float = 0.95,
+    eps: float = 1e-10,
+) -> Tensor:
+    """
+    NorMuon-style postconditioner applied to an already preconditioned update.
+
+    Important:
+    - This does NOT call zeropower again.
+    - It preserves the incoming Frobenius norm.
+    - Therefore call this AFTER scale_update_like_muon(update).
+
+    For m >= n:
+        v_mean shape [m, 1], row-wise energy.
+
+    For m < n:
+        v_mean shape [1, n], column-wise energy.
+    """
+    assert update.ndim == 2
+
+    out_dtype = update.dtype
+    X = update.float()
+
+    m, n = X.shape
+
+    norm = X.norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+
+    if m >= n:
+        v_mean = torch.mean(X * X, dim=-1, keepdim=True)  # [m, 1]
+    else:
+        v_mean = torch.mean(X * X, dim=-2, keepdim=True)  # [1, n]
+
+    second_momentum.lerp_(v_mean.to(second_momentum.dtype), 1.0 - beta)
+
+    step_size = 1.0 / second_momentum.float().sqrt().clamp_min(eps)
+
+    X = X * step_size
+
+    norm_new = X.norm(dim=(-2, -1), keepdim=True).clamp_min(eps)
+    X = X * (norm / norm_new)
+
+    return X.to(out_dtype)
+
+
+def gram_sinkhorn_normuon_update(
+    grad: Tensor,
+    momentum: Tensor,
+    left_gram: Tensor,
+    right_gram: Tensor,
+    second_momentum: Tensor,
+    mu: float = 0.95,
+    gram_beta: float = 0.95,
+    normuon_beta: float = 0.95,
+    nesterov: bool = True,
+    sinkhorn_steps: int = 10,
+    eps: float = 1e-8,
+    normuon_eps: float = 1e-10,
+    apply_normuon: bool = True,
+) -> Tensor:
+    """
+    Gram-Sinkhorn update + NorMuon postconditioner.
+
+    Order:
+
+        1. momentum
+        2. EMA GG^T and G^T G
+        3. U, V from Gram eigenspaces
+        4. A = U^T M V
+        5. Sinkhorn on A^2
+        6. update = U A_bal V^T
+        7. scale update to Muon Frobenius norm
+        8. NorMuon postconditioner, preserving that norm
+    """
+    assert grad.ndim == 2
+    assert momentum.shape == grad.shape
+
+    G = grad.float()
+    m, n = G.shape
+
+    # Momentum EMA.
+    momentum.lerp_(grad, 1.0 - mu)
+
+    if nesterov:
+        M = grad.float().lerp(momentum.float(), mu)
+    else:
+        M = momentum.float()
+
+    # EMA Gram matrices.
+    left_gram.lerp_(G @ G.T, 1.0 - gram_beta)
+    right_gram.lerp_(G.T @ G, 1.0 - gram_beta)
+
+    # Bases from EMA Grams.
+    U = gram_eigenbasis(left_gram, eps=eps)
+    V = gram_eigenbasis(right_gram, eps=eps)
+
+    # Project momentum/update into Gram feature basis.
+    A = U.T @ M @ V
+
+    # Sinkhorn energy balancing, no scale restoration.
+    A_bal = sinkhorn_energy_balance_rect_no_scale(
+        A,
+        steps=sinkhorn_steps,
+        eps=eps,
+    ).float()
+
+    # Reconstruct matrix update.
+    update = U @ A_bal @ V.T
+
+    # First align final matrix update scale to Muon.
+    update = scale_update_like_muon(update, eps=eps)
+
+    # Then apply NorMuon-style postconditioner.
+    # It preserves the norm, so final scale remains Muon-aligned.
+    if apply_normuon and (m != n):
+        update = normuon_postcondition_update(
+            update,
+            second_momentum=second_momentum,
+            beta=normuon_beta,
+            eps=normuon_eps,
+        )
+
+    return update.to(grad.dtype)
+
+
+class SinkSOAP(torch.optim.Optimizer):
+    """
+    Gram-Sinkhorn-Muon + NorMuon postconditioner.
+
+    State per 2D parameter:
+
+        momentum:        [m, n]
+        left_gram:       [m, m]
+        right_gram:      [n, n]
+        second_momentum: [m, 1] if m >= n else [1, n]
+
+    Final update scale is aligned to original Muon Frobenius norm before
+    NorMuon postconditioning.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 0.02,
+        weight_decay: float = 0.0,
+        mu: float = 0.95,
+        gram_beta: float = 0.95,
+        normuon_beta: float = 0.95,
+        sinkhorn_steps: int = 10,
+        nesterov: bool = True,
+        eps: float = 1e-8,
+        normuon_eps: float = 1e-10,
+        apply_normuon: bool =True,
+    ):
+        assert isinstance(params, list)
+        assert len(params) >= 1
+        assert isinstance(params[0], torch.nn.Parameter)
+
+        params = sorted(params, key=lambda x: x.size(), reverse=True)
+
+        defaults = dict(
+            lr=lr,
+            weight_decay=weight_decay,
+            mu=mu,
+            gram_beta=gram_beta,
+            normuon_beta=normuon_beta,
+            sinkhorn_steps=sinkhorn_steps,
+            nesterov=nesterov,
+            eps=eps,
+            normuon_eps=normuon_eps,
+            apply_normuon=apply_normuon,
+        )
+
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        rank = dist.get_rank() if dist.is_initialized() else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+
+            if world_size > 1:
+                pad_len = (world_size - len(params) % world_size) % world_size
+                params_pad = params + [torch.empty_like(params[-1])] * pad_len
+            else:
+                params_pad = params
+
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+
+                    if p.grad is None:
+                        continue
+
+                    if p.grad.ndim != 2:
+                        raise ValueError(
+                            "GramSinkhornNorMuon currently only supports 2D parameters. "
+                            f"Got parameter with shape {tuple(p.shape)}."
+                        )
+
+                    state = self.state[p]
+                    m, n = p.shape
+
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+
+                        state["left_gram"] = torch.zeros(
+                            (m, m),
+                            device=p.device,
+                            dtype=torch.float32,
+                        )
+
+                        state["right_gram"] = torch.zeros(
+                            (n, n),
+                            device=p.device,
+                            dtype=torch.float32,
+                        )
+
+                        if m >= n:
+                            state["second_momentum"] = torch.zeros(
+                                (m, 1),
+                                device=p.device,
+                                dtype=torch.float32,
+                            )
+                        else:
+                            state["second_momentum"] = torch.zeros(
+                                (1, n),
+                                device=p.device,
+                                dtype=torch.float32,
+                            )
+
+                    update = gram_sinkhorn_normuon_update(
+                        grad=p.grad,
+                        momentum=state["momentum"],
+                        left_gram=state["left_gram"],
+                        right_gram=state["right_gram"],
+                        second_momentum=state["second_momentum"],
+                        mu=group["mu"],
+                        gram_beta=group["gram_beta"],
+                        normuon_beta=group["normuon_beta"],
+                        nesterov=group["nesterov"],
+                        sinkhorn_steps=group["sinkhorn_steps"],
+                        eps=group["eps"],
+                        normuon_eps=group["normuon_eps"],
+                        apply_normuon=group["apply_normuon"],
+                    )
+
+                    p.mul_(1.0 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+
+                if world_size > 1:
+                    dist.all_gather(
+                        params_pad[base_i : base_i + world_size],
+                        params_pad[base_i + rank],
+                    )
+
+
 ########################################
 #                Setup                 #
 ########################################
@@ -264,7 +626,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 3350
+    train_steps = 3125
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -288,8 +650,8 @@ for _ in range(num_trials):
                         dict(params=[model.proj.weight], lr=1/320),
                         dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
                        betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
-    optimizer2 = Muon([p for p in model.blocks.parameters() if p.ndim >= 2],
-                      lr=0.035, weight_decay=0.025)
+    optimizer2 = SinkSOAP([p for p in model.blocks.parameters() if p.ndim >= 2],
+                      lr=0.04, weight_decay=0.025)
     optimizers = [optimizer1, optimizer2]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -325,8 +687,8 @@ for _ in range(num_trials):
     for step in range(train_steps + 1):
 
         # --------------- VALIDATION SECTION -----------------
-        val_step_freq = 125 if step / train_steps < 0.9 else 25
-        if step == train_steps or step % val_step_freq == 0:
+        val_step_freq = 125 if step / train_steps < 0.94 else 25
+        if step == train_steps or step % val_step_freq == 0 or step == 3080 or step == 3085 or step == 3090:
             # stop the clock
             dist.barrier()
             time_since_last_val = time.perf_counter() - t0


### PR DESCRIPTION
### Summary

This PR adds a new optimizer variant, SinkSOAP, which reaches the target at 3090 steps.

SinkSOAP is a [SOAP](https://arxiv.org/pdf/2409.11321) based variant inspired by [DeepSeek MHC](https://arxiv.org/pdf/2512.24880) and [SinkGD](https://arxiv.org/pdf/2502.06742). Instead of using the second-order moment **V** as the momentum preconditioner in the SOAP rotated space, SinkSOAP applies a Sinkhorn-style row/column normalization directly to the rotated momentum.

### Method

Let **M** denote the momentum update (with nesterov), and let $Q_L, Q_R$ be the left and right rotation matrices as denoted in [SOAP](https://arxiv.org/pdf/2409.11321). We first rotate the momentum into:

$\tilde{M} = Q_L M Q_R$

Unlike standard SOAP-style second-order preconditioning, SinkSOAP does not maintain or apply a second-order moment in this rotated space. Instead we then apply Sinkhorn-Knopp iteration to $\tilde{M}$ so that the update norm is more evenly distributed across rows and columns.

A simplified iteration is:

```math
\tilde{M}^{(t + 1/2)}_{ij}
=
\frac{\tilde{M}^{(t)}_{ij}}
{\sqrt{\sum_k |\tilde{M}^{(t)}_{ik}|^2 + \epsilon}}
```

```math
\tilde{M}^{(t + 1)}_{ij}
=
\frac{\tilde{M}^{(t + 1/2)}_{ij}}
{\sqrt{\sum_k |\tilde{M}^{(t + 1/2)}_{kj}|^2 + \epsilon}}
```

Finally, we rotate the normalized update back to get the final update:

$O = Q_L^\top \tilde{M}^{(T)} Q_R^\top$

In the submitted run, we use $T = 10$ Sinkhorn-Knopp iterations. Empirically, however, a single iteration already works well, and increasing to 10 iterations only provides a small additional gain.

This makes the method Adafactor-like in spirit, especially in the single-iteration case. However, SinkSOAP is not the same as SOAP (factorized) from [SOAP](https://arxiv.org/pdf/2409.11321)￼, since it does not use any second-order term as the main preconditioner.

### Handling non-square 2D hidden matrices

SinkSOAP is mostly an independent optimizer and is not mixed with most previous methods from other PRs, including Muon. The only inherited component is the size-dependent normalization idea from NorMuon.

For 2D hidden matrix parameters where `size(0) != size(1)`, we follow [NorMuon](https://arxiv.org/pdf/2510.05491) by maintaining an EMA second-order moment only along the shorter dimension. This moment is then used to normalize the SinkSOAP update $O$, producing a more row/column-balanced update.

Our ablation shows that this NorMuon-style normalization just provides a small (but consistent) improvement over pure SinkSOAP.

### Hyperparameters

- train_steps: 3125
- lr: 0.04
- first order momentum $\beta_1$: 0.95
- SOAP $\beta_2$: 0.95
- NorMuon $\beta_2$: 0.95
- weight_decay: 0.025
- lr_schedule: WSD with `cooldown_frac=0.7`, same as Muon.
- Sinkhorn-Knopp iterations: 10

logfile: `records/track_3_optimization/results/20260514_sinksoap/d0155dd0-f77d-48a9-8eb4-453f894b9476.txt`

### Result

The result is evaluated over 10 runs. At step 3090, the result is:
- mean loss: 3.278464
- Significance check:  `(3.28 - 3.278464) * sqrt(10) =0.004857 > 0.004 `

### Notes

SinkSOAP suggests that, using a second-order-moment preconditioner in the rotated SOAP space may be unnecessary or even suboptimal. A simple Sinkhorn-style normalization of the rotated momentum already gives strong performance.

Apart from the NorMuon-style normalization for non-square 2D hidden matrices, SinkSOAP remains a clean standalone optimizer.

---

Thanks to @zhenghaoxu-gatech for running the experiments.