### PR TITLE
Track 3: capped RRE extrapolation reaches 2925 steps

### DIFF
--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/1786243c-db47-49ff-bff8-3faf814bf763.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/1786243c-db47-49ff-bff8-3faf814bf763.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 80GB HBM3 with world_size=1
+Run UTC timestamp=2026-05-19T20:15:50Z
+Using seed=0
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.46100 train_time:266.602s step_avg:2132.81ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.09687 train_time:454.950s step_avg:1819.80ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.94690 train_time:643.107s step_avg:1714.95ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83584 train_time:830.105s step_avg:1660.21ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76243 train_time:1018.701s step_avg:1629.92ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71647 train_time:1206.640s step_avg:1608.85ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67454 train_time:1396.075s step_avg:1595.51ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63325 train_time:1583.837s step_avg:1583.84ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.60921 train_time:1772.331s step_avg:1575.41ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57722 train_time:1959.722s step_avg:1567.78ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55176 train_time:2148.576s step_avg:1562.60ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.52053 train_time:2336.020s step_avg:1557.35ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.49929 train_time:2523.359s step_avg:1552.84ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47146 train_time:2712.705s step_avg:1550.12ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44482 train_time:2902.128s step_avg:1547.80ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41880 train_time:3090.400s step_avg:1545.20ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39515 train_time:3279.180s step_avg:1543.14ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37178 train_time:3467.252s step_avg:1541.00ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35082 train_time:3655.768s step_avg:1539.27ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.33005 train_time:3844.149s step_avg:1537.66ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31123 train_time:4033.190s step_avg:1536.45ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29506 train_time:4222.008s step_avg:1535.28ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28726 train_time:4328.365s step_avg:1534.88ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28587 train_time:4343.761s step_avg:1534.90ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28465 train_time:4359.048s step_avg:1534.88ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28368 train_time:4374.244s step_avg:1534.82ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28267 train_time:4389.631s step_avg:1534.84ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28183 train_time:4404.885s step_avg:1534.80ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28139 train_time:4412.806s step_avg:1534.89ms extrap_count:11 extrap_rel:9.954e-04 handoff:keep
+step:2880/3020 val_loss:3.28098 train_time:4420.071s step_avg:1534.75ms extrap_count:12 extrap_rel:9.668e-04 handoff:keep
+step:2890/3020 val_loss:3.28020 train_time:4435.305s step_avg:1534.71ms extrap_count:14 extrap_rel:8.977e-04 handoff:keep
+step:2895/3020 val_loss:3.27982 train_time:4443.244s step_avg:1534.80ms extrap_count:15 extrap_rel:8.695e-04 handoff:keep
+step:2900/3020 val_loss:3.27949 train_time:4450.473s step_avg:1534.65ms extrap_count:16 extrap_rel:8.310e-04 handoff:keep
+step:2910/3020 val_loss:3.27885 train_time:4465.620s step_avg:1534.58ms extrap_count:18 extrap_rel:7.702e-04 handoff:keep
+step:2920/3020 val_loss:3.27821 train_time:4480.745s step_avg:1534.50ms extrap_count:20 extrap_rel:7.011e-04 handoff:keep
+step:2925/3020 val_loss:3.27793 train_time:4488.664s step_avg:1534.59ms extrap_count:21 extrap_rel:6.708e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/1853c4b8-77a6-48b1-9459-da4a45427ea7.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/1853c4b8-77a6-48b1-9459-da4a45427ea7.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 80GB HBM3 with world_size=1
+Run UTC timestamp=2026-05-19T22:42:46Z
+Using seed=4
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.47282 train_time:276.990s step_avg:2215.92ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.10350 train_time:471.481s step_avg:1885.92ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.95165 train_time:666.049s step_avg:1776.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83557 train_time:860.948s step_avg:1721.90ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76704 train_time:1056.469s step_avg:1690.35ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71753 train_time:1250.825s step_avg:1667.77ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67612 train_time:1446.267s step_avg:1652.88ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63432 train_time:1639.930s step_avg:1639.93ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.61052 train_time:1835.145s step_avg:1631.24ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57716 train_time:2030.754s step_avg:1624.60ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55155 train_time:2226.331s step_avg:1619.15ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.52096 train_time:2421.848s step_avg:1614.57ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.49965 train_time:2617.050s step_avg:1610.49ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47169 train_time:2809.753s step_avg:1605.57ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44530 train_time:3005.980s step_avg:1603.19ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41882 train_time:3200.747s step_avg:1600.37ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39518 train_time:3395.879s step_avg:1598.06ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37151 train_time:3590.986s step_avg:1595.99ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35058 train_time:3787.357s step_avg:1594.68ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.33002 train_time:3983.808s step_avg:1593.52ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31107 train_time:4179.921s step_avg:1592.35ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29498 train_time:4375.742s step_avg:1591.18ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28708 train_time:4485.485s step_avg:1590.60ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28576 train_time:4501.238s step_avg:1590.54ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28456 train_time:4516.938s step_avg:1590.47ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28355 train_time:4532.601s step_avg:1590.39ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28254 train_time:4548.404s step_avg:1590.35ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28177 train_time:4564.097s step_avg:1590.28ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28134 train_time:4572.326s step_avg:1590.37ms extrap_count:11 extrap_rel:9.962e-04 handoff:keep
+step:2880/3020 val_loss:3.28093 train_time:4579.837s step_avg:1590.22ms extrap_count:12 extrap_rel:9.672e-04 handoff:keep
+step:2890/3020 val_loss:3.28015 train_time:4595.484s step_avg:1590.13ms extrap_count:14 extrap_rel:8.966e-04 handoff:keep
+step:2895/3020 val_loss:3.27979 train_time:4603.700s step_avg:1590.22ms extrap_count:15 extrap_rel:8.695e-04 handoff:keep
+step:2900/3020 val_loss:3.27943 train_time:4611.192s step_avg:1590.07ms extrap_count:16 extrap_rel:8.312e-04 handoff:keep
+step:2910/3020 val_loss:3.27876 train_time:4626.923s step_avg:1590.01ms extrap_count:18 extrap_rel:7.702e-04 handoff:keep
+step:2920/3020 val_loss:3.27813 train_time:4642.623s step_avg:1589.94ms extrap_count:20 extrap_rel:6.999e-04 handoff:keep
+step:2925/3020 val_loss:3.27785 train_time:4650.812s step_avg:1590.02ms extrap_count:21 extrap_rel:6.710e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/4e96056c-e936-4400-8353-403af8e4fe50.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/4e96056c-e936-4400-8353-403af8e4fe50.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 NVL with world_size=1
+Run UTC timestamp=2026-05-19T20:15:47Z
+Using seed=2
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.47443 train_time:308.249s step_avg:2465.99ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.11552 train_time:549.705s step_avg:2198.82ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.95239 train_time:791.881s step_avg:2111.68ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83189 train_time:1032.946s step_avg:2065.89ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76195 train_time:1274.499s step_avg:2039.20ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71356 train_time:1515.166s step_avg:2020.22ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67118 train_time:1756.732s step_avg:2007.69ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63248 train_time:1997.496s step_avg:1997.50ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.60817 train_time:2238.803s step_avg:1990.05ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57557 train_time:2479.509s step_avg:1983.61ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55156 train_time:2721.036s step_avg:1978.93ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.52154 train_time:2961.695s step_avg:1974.46ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.50011 train_time:3203.233s step_avg:1971.22ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47145 train_time:3444.146s step_avg:1968.08ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44404 train_time:3685.798s step_avg:1965.76ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41795 train_time:3926.609s step_avg:1963.30ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39470 train_time:4168.189s step_avg:1961.50ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37121 train_time:4408.931s step_avg:1959.53ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35015 train_time:4650.508s step_avg:1958.11ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.32992 train_time:4891.290s step_avg:1956.52ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31089 train_time:5132.909s step_avg:1955.39ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29455 train_time:5373.743s step_avg:1954.09ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28686 train_time:5508.855s step_avg:1953.49ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28549 train_time:5528.254s step_avg:1953.45ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28431 train_time:5547.612s step_avg:1953.38ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28329 train_time:5566.974s step_avg:1953.32ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28227 train_time:5586.383s step_avg:1953.28ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28152 train_time:5605.762s step_avg:1953.23ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28107 train_time:5615.842s step_avg:1953.34ms extrap_count:11 extrap_rel:9.963e-04 handoff:keep
+step:2880/3020 val_loss:3.28064 train_time:5625.160s step_avg:1953.18ms extrap_count:12 extrap_rel:9.674e-04 handoff:keep
+step:2890/3020 val_loss:3.27984 train_time:5644.530s step_avg:1953.12ms extrap_count:14 extrap_rel:8.973e-04 handoff:keep
+step:2895/3020 val_loss:3.27947 train_time:5654.596s step_avg:1953.23ms extrap_count:15 extrap_rel:8.694e-04 handoff:keep
+step:2900/3020 val_loss:3.27914 train_time:5663.911s step_avg:1953.07ms extrap_count:16 extrap_rel:8.307e-04 handoff:keep
+step:2910/3020 val_loss:3.27849 train_time:5683.272s step_avg:1953.01ms extrap_count:18 extrap_rel:7.704e-04 handoff:keep
+step:2920/3020 val_loss:3.27787 train_time:5702.625s step_avg:1952.95ms extrap_count:20 extrap_rel:7.011e-04 handoff:keep
+step:2925/3020 val_loss:3.27761 train_time:5712.701s step_avg:1953.06ms extrap_count:21 extrap_rel:6.711e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/6721c9f5-1f63-4c07-8cb9-fee0f9b313b4.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/6721c9f5-1f63-4c07-8cb9-fee0f9b313b4.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 80GB HBM3 with world_size=1
+Run UTC timestamp=2026-05-19T20:15:55Z
+Using seed=3
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.45305 train_time:312.767s step_avg:2502.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.10409 train_time:520.721s step_avg:2082.88ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.94945 train_time:728.531s step_avg:1942.75ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83525 train_time:935.866s step_avg:1871.73ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76101 train_time:1143.795s step_avg:1830.07ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71467 train_time:1351.059s step_avg:1801.41ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67087 train_time:1558.996s step_avg:1781.71ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63268 train_time:1767.156s step_avg:1767.16ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.60820 train_time:1975.568s step_avg:1756.06ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57607 train_time:2182.767s step_avg:1746.21ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55131 train_time:2391.189s step_avg:1739.05ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.51998 train_time:2598.287s step_avg:1732.19ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.49937 train_time:2807.131s step_avg:1727.47ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47057 train_time:3014.460s step_avg:1722.55ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44500 train_time:3222.856s step_avg:1718.86ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41852 train_time:3431.418s step_avg:1715.71ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39493 train_time:3640.130s step_avg:1713.00ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37190 train_time:3847.714s step_avg:1710.09ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35088 train_time:4056.394s step_avg:1707.96ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.33033 train_time:4264.667s step_avg:1705.87ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31155 train_time:4474.044s step_avg:1704.40ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29534 train_time:4681.400s step_avg:1702.33ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28752 train_time:4798.390s step_avg:1701.56ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28624 train_time:4815.197s step_avg:1701.48ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28500 train_time:4831.869s step_avg:1701.36ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28399 train_time:4848.688s step_avg:1701.29ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28300 train_time:4865.388s step_avg:1701.18ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28224 train_time:4881.986s step_avg:1701.04ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28179 train_time:4890.594s step_avg:1701.08ms extrap_count:11 extrap_rel:9.950e-04 handoff:keep
+step:2880/3020 val_loss:3.28139 train_time:4898.602s step_avg:1700.90ms extrap_count:12 extrap_rel:9.665e-04 handoff:keep
+step:2890/3020 val_loss:3.28062 train_time:4915.265s step_avg:1700.78ms extrap_count:14 extrap_rel:8.960e-04 handoff:keep
+step:2895/3020 val_loss:3.28027 train_time:4923.891s step_avg:1700.83ms extrap_count:15 extrap_rel:8.688e-04 handoff:keep
+step:2900/3020 val_loss:3.27991 train_time:4931.904s step_avg:1700.66ms extrap_count:16 extrap_rel:8.307e-04 handoff:keep
+step:2910/3020 val_loss:3.27927 train_time:4948.565s step_avg:1700.54ms extrap_count:18 extrap_rel:7.702e-04 handoff:keep
+step:2920/3020 val_loss:3.27865 train_time:4965.212s step_avg:1700.42ms extrap_count:20 extrap_rel:7.013e-04 handoff:keep
+step:2925/3020 val_loss:3.27838 train_time:4973.835s step_avg:1700.46ms extrap_count:21 extrap_rel:6.707e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/89f1440d-ac2f-4666-be46-8bd6a403b613.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/89f1440d-ac2f-4666-be46-8bd6a403b613.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 80GB HBM3 with world_size=1
+Run UTC timestamp=2026-05-19T22:42:47Z
+Using seed=6
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.46043 train_time:242.400s step_avg:1939.20ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.10823 train_time:427.626s step_avg:1710.51ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.94676 train_time:612.668s step_avg:1633.78ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83380 train_time:797.551s step_avg:1595.10ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76518 train_time:981.575s step_avg:1570.52ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71338 train_time:1165.240s step_avg:1553.65ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67317 train_time:1349.634s step_avg:1542.44ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63253 train_time:1533.378s step_avg:1533.38ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.60925 train_time:1717.621s step_avg:1526.77ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57923 train_time:1901.326s step_avg:1521.06ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55232 train_time:2085.770s step_avg:1516.92ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.52294 train_time:2269.377s step_avg:1512.92ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.50141 train_time:2454.073s step_avg:1510.20ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47128 train_time:2638.058s step_avg:1507.46ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44537 train_time:2823.293s step_avg:1505.76ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41896 train_time:3007.242s step_avg:1503.62ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39560 train_time:3191.973s step_avg:1502.10ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37225 train_time:3375.546s step_avg:1500.24ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35129 train_time:3559.712s step_avg:1498.83ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.33094 train_time:3743.145s step_avg:1497.26ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31180 train_time:3927.324s step_avg:1496.12ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29575 train_time:4111.217s step_avg:1494.99ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28795 train_time:4214.745s step_avg:1494.59ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28660 train_time:4229.625s step_avg:1494.57ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28544 train_time:4244.404s step_avg:1494.51ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28439 train_time:4259.222s step_avg:1494.46ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28343 train_time:4274.058s step_avg:1494.43ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28268 train_time:4288.799s step_avg:1494.36ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28223 train_time:4296.468s step_avg:1494.42ms extrap_count:11 extrap_rel:9.959e-04 handoff:keep
+step:2880/3020 val_loss:3.28184 train_time:4303.435s step_avg:1494.25ms extrap_count:12 extrap_rel:9.673e-04 handoff:keep
+step:2890/3020 val_loss:3.28099 train_time:4318.112s step_avg:1494.16ms extrap_count:14 extrap_rel:8.976e-04 handoff:keep
+step:2895/3020 val_loss:3.28066 train_time:4325.823s step_avg:1494.24ms extrap_count:15 extrap_rel:8.688e-04 handoff:keep
+step:2900/3020 val_loss:3.28031 train_time:4332.831s step_avg:1494.08ms extrap_count:16 extrap_rel:8.313e-04 handoff:keep
+step:2910/3020 val_loss:3.27964 train_time:4347.489s step_avg:1493.98ms extrap_count:18 extrap_rel:7.700e-04 handoff:keep
+step:2920/3020 val_loss:3.27903 train_time:4362.164s step_avg:1493.89ms extrap_count:20 extrap_rel:7.011e-04 handoff:keep
+step:2925/3020 val_loss:3.27877 train_time:4369.854s step_avg:1493.97ms extrap_count:21 extrap_rel:6.707e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/8ef4bff2-671c-44d1-b451-4c300317a3b1.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/8ef4bff2-671c-44d1-b451-4c300317a3b1.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 80GB HBM3 with world_size=1
+Run UTC timestamp=2026-05-19T22:42:49Z
+Using seed=7
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.46601 train_time:266.560s step_avg:2132.48ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.09924 train_time:455.678s step_avg:1822.71ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.94895 train_time:644.558s step_avg:1718.82ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83235 train_time:833.246s step_avg:1666.49ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.75992 train_time:1023.055s step_avg:1636.89ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71419 train_time:1210.245s step_avg:1613.66ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67271 train_time:1397.291s step_avg:1596.90ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63135 train_time:1584.438s step_avg:1584.44ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.61071 train_time:1771.227s step_avg:1574.42ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57698 train_time:1960.050s step_avg:1568.04ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55160 train_time:2149.841s step_avg:1563.52ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.51972 train_time:2339.208s step_avg:1559.47ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.50004 train_time:2530.329s step_avg:1557.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47087 train_time:2718.572s step_avg:1553.47ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44386 train_time:2907.321s step_avg:1550.57ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41749 train_time:3094.626s step_avg:1547.31ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39378 train_time:3283.298s step_avg:1545.08ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37042 train_time:3471.131s step_avg:1542.72ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.34992 train_time:3660.389s step_avg:1541.22ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.32932 train_time:3847.788s step_avg:1539.12ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31019 train_time:4036.019s step_avg:1537.53ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29388 train_time:4223.875s step_avg:1535.95ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28604 train_time:4328.975s step_avg:1535.10ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28472 train_time:4344.242s step_avg:1535.07ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28355 train_time:4359.271s step_avg:1534.95ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28253 train_time:4374.304s step_avg:1534.84ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28152 train_time:4389.498s step_avg:1534.79ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28077 train_time:4404.551s step_avg:1534.69ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28034 train_time:4412.422s step_avg:1534.76ms extrap_count:11 extrap_rel:9.953e-04 handoff:keep
+step:2880/3020 val_loss:3.27992 train_time:4419.657s step_avg:1534.60ms extrap_count:12 extrap_rel:9.670e-04 handoff:keep
+step:2890/3020 val_loss:3.27914 train_time:4435.032s step_avg:1534.61ms extrap_count:14 extrap_rel:8.970e-04 handoff:keep
+step:2895/3020 val_loss:3.27877 train_time:4443.004s step_avg:1534.72ms extrap_count:15 extrap_rel:8.688e-04 handoff:keep
+step:2900/3020 val_loss:3.27845 train_time:4450.231s step_avg:1534.56ms extrap_count:16 extrap_rel:8.314e-04 handoff:keep
+step:2910/3020 val_loss:3.27777 train_time:4465.313s step_avg:1534.47ms extrap_count:18 extrap_rel:7.704e-04 handoff:keep
+step:2920/3020 val_loss:3.27714 train_time:4480.407s step_avg:1534.39ms extrap_count:20 extrap_rel:7.011e-04 handoff:keep
+step:2925/3020 val_loss:3.27684 train_time:4488.305s step_avg:1534.46ms extrap_count:21 extrap_rel:6.706e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/README.md
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/README.md
@@ -1,0 +1,72 @@
+# Track 3: capped RRE extrapolation on the PR #300 stack
+
+This result applies a fixed vector-extrapolation overlay to the Track 3 optimizer stack from PR #300. The base stack is Aurora on `mlp.proj`, radial brake, extended Contra-Muon to normal ramp, SOAP on MLP+V, and the inherited power-law cooldown. The new piece is reduced-rank extrapolation (RRE) applied late in training with a fixed schedule:
+
+```text
+extrapolation_name = rre
+extrap_start_step = 2820
+extrap_every = 5
+RRE history length k = 4
+extrap_damping = 0.875
+extrap_max_rel = 0.001
+extrap_reset_momentum = False
+extrap_stop_step = 2925
+extrap_after_stop_every = 0
+```
+
+The submitted step count is **2925**. All eight runs are full runs from step 0. Each logfile includes the full training script used for the run. For review convenience, `train_gpt_simple_rre_pr300_2925.py` contains the same train-code path with the submitted RRE and stop-step settings as defaults.
+
+## Result
+
+At step 2925:
+
+```text
+n = 8
+mean val loss = 3.27812750
+std            = 0.00088134
+(3.28 - mu) * sqrt(n) = 0.00529623
+```
+
+This exceeds the Track 3 README threshold of `0.004`. Equivalently, with `sigma=0.0013`, this is `z = 4.0740`, one-sided `p = 2.31e-05`.
+
+For comparison, the same eight runs have mean val loss `3.27969250` at step 2900, which does not clear the threshold.
+
+| Seed | Log | 2900 val | 2925 val |
+| -: | - | -: | -: |
+| 0 | `1786243c-db47-49ff-bff8-3faf814bf763.txt` | 3.27949 | 3.27793 |
+| 1 | `d95a47ca-e103-4f0f-a273-dcaaca8f8bf7.txt` | 3.28139 | 3.27981 |
+| 2 | `4e96056c-e936-4400-8353-403af8e4fe50.txt` | 3.27914 | 3.27761 |
+| 3 | `6721c9f5-1f63-4c07-8cb9-fee0f9b313b4.txt` | 3.27991 | 3.27838 |
+| 4 | `1853c4b8-77a6-48b1-9459-da4a45427ea7.txt` | 3.27943 | 3.27785 |
+| 5 | `ac500b64-d44e-4052-84a5-7c8627164cf4.txt` | 3.27942 | 3.27783 |
+| 6 | `89f1440d-ac2f-4666-be46-8bd6a403b613.txt` | 3.28031 | 3.27877 |
+| 7 | `8ef4bff2-671c-44d1-b451-4c300317a3b1.txt` | 3.27845 | 3.27684 |
+| **Mean** | | **3.27969250** | **3.27812750** |
+
+## Reproducibility notes
+
+- Dataset, batch size, and model architecture match the Track 3 baseline stack used by PR #300.
+- The RRE schedule is fixed before the run and is identical across seeds.
+- The selected stopping point, 2925, is shared across all trials.
+- The runs were launched on Modal H100 workers. Wall-clock speed is not part of the Track 3 objective.
+
+## Files
+
+- `records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/README.md`
+- `records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/train_gpt_simple_rre_pr300_2925.py`
+- 8 full reproducibility logfiles in the same directory, seeds 0 through 7
+
+## Credits
+
+This submission builds directly on the open PR #300 stack and inherits its credited lineage:
+
+- PR #274 / Skylight-001: NorMuon-lite row/column normalization lineage, u/w floor, and Muon setup.
+- PR #275 / Contra-Muon: Contra-Muon update term.
+- PR #278 / MLP SOAP preconditioning.
+- PR #283 / Trustlight attention-SOAP lineage.
+- PR #287 / power-law LR cooldown.
+- PR #291 / Contra-Muon to Soft-Muon lineage.
+- PR #294 / radial brake.
+- PR #300 / Aurora row-balanced polar on `mlp.proj`, Soft-Muon/NorMuon-lite removal, and extended Contra-Muon ramp.
+
+New in this result: late capped RRE vector extrapolation with no momentum reset.

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/ac500b64-d44e-4052-84a5-7c8627164cf4.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/ac500b64-d44e-4052-84a5-7c8627164cf4.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 NVL with world_size=1
+Run UTC timestamp=2026-05-19T22:42:45Z
+Using seed=5
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.47863 train_time:307.089s step_avg:2456.71ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.10336 train_time:546.041s step_avg:2184.17ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.95081 train_time:785.616s step_avg:2094.98ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83217 train_time:1025.090s step_avg:2050.18ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76270 train_time:1265.382s step_avg:2024.61ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71450 train_time:1505.241s step_avg:2006.99ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67389 train_time:1745.737s step_avg:1995.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63350 train_time:1985.310s step_avg:1985.31ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.60849 train_time:2225.745s step_avg:1978.44ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57786 train_time:2465.457s step_avg:1972.37ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55223 train_time:2706.120s step_avg:1968.09ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.52157 train_time:2945.668s step_avg:1963.78ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.50127 train_time:3186.363s step_avg:1960.84ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47124 train_time:3426.063s step_avg:1957.75ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44429 train_time:3666.555s step_avg:1955.50ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.41820 train_time:3906.445s step_avg:1953.22ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39474 train_time:4146.891s step_avg:1951.48ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37167 train_time:4386.638s step_avg:1949.62ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35069 train_time:4626.809s step_avg:1948.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.33012 train_time:4866.217s step_avg:1946.49ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31110 train_time:5106.364s step_avg:1945.28ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29478 train_time:5345.805s step_avg:1943.93ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28707 train_time:5480.389s step_avg:1943.40ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28576 train_time:5499.732s step_avg:1943.37ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28454 train_time:5519.032s step_avg:1943.32ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28351 train_time:5538.310s step_avg:1943.27ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28254 train_time:5557.627s step_avg:1943.23ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28174 train_time:5576.937s step_avg:1943.18ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28135 train_time:5586.964s step_avg:1943.29ms extrap_count:11 extrap_rel:9.953e-04 handoff:keep
+step:2880/3020 val_loss:3.28093 train_time:5596.237s step_avg:1943.14ms extrap_count:12 extrap_rel:9.675e-04 handoff:keep
+step:2890/3020 val_loss:3.28011 train_time:5615.540s step_avg:1943.09ms extrap_count:14 extrap_rel:8.973e-04 handoff:keep
+step:2895/3020 val_loss:3.27976 train_time:5625.559s step_avg:1943.20ms extrap_count:15 extrap_rel:8.689e-04 handoff:keep
+step:2900/3020 val_loss:3.27942 train_time:5634.858s step_avg:1943.05ms extrap_count:16 extrap_rel:8.311e-04 handoff:keep
+step:2910/3020 val_loss:3.27877 train_time:5654.140s step_avg:1943.00ms extrap_count:18 extrap_rel:7.703e-04 handoff:keep
+step:2920/3020 val_loss:3.27813 train_time:5673.420s step_avg:1942.95ms extrap_count:20 extrap_rel:7.010e-04 handoff:keep
+step:2925/3020 val_loss:3.27783 train_time:5683.457s step_avg:1943.06ms extrap_count:21 extrap_rel:6.709e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/d95a47ca-e103-4f0f-a273-dcaaca8f8bf7.txt
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/d95a47ca-e103-4f0f-a273-dcaaca8f8bf7.txt
@@ -1,0 +1,1897 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "none").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "20"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "0"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "1.0"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0"))
+# EXTRAPOLATION_LANDING_CONTROLS_PATCHED
+EXTRAPOLATION_DAMPING_FINAL = float(os.environ.get("EXTRAPOLATION_DAMPING_FINAL", str(EXTRAPOLATION_DAMPING)))
+EXTRAPOLATION_DAMPING_TAPER_START = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_START", "0"))
+EXTRAPOLATION_DAMPING_TAPER_END = int(os.environ.get("EXTRAPOLATION_DAMPING_TAPER_END", "0"))
+EXTRAPOLATION_MAX_REL_FINAL = float(os.environ.get("EXTRAPOLATION_MAX_REL_FINAL", str(EXTRAPOLATION_MAX_REL)))
+EXTRAPOLATION_MAX_REL_TAPER_START = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_START", "0"))
+EXTRAPOLATION_MAX_REL_TAPER_END = int(os.environ.get("EXTRAPOLATION_MAX_REL_TAPER_END", "0"))
+EXTRAPOLATION_BLOCK_MAX_REL = float(os.environ.get("EXTRAPOLATION_BLOCK_MAX_REL", "0"))
+EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE = float(os.environ.get("EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE", "1.0"))
+EXTRAPOLATION_MOMENTUM_PROJECT = os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT", "none").strip().lower()
+EXTRAPOLATION_MOMENTUM_PROJECT_SCALE = float(os.environ.get("EXTRAPOLATION_MOMENTUM_PROJECT_SCALE", "1.0"))
+assert EXTRAPOLATION_MOMENTUM_PROJECT in {"none", "anti_delta"}
+# EXTRAPOLATION_VECTOR_CONTROLS_PATCHED
+EXTRAPOLATION_SUBSPACE_RANK = int(os.environ.get("EXTRAPOLATION_SUBSPACE_RANK", "1"))
+EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT = float(os.environ.get("EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT", "0.5"))
+EXTRAPOLATION_BLOCK_COSINE_FLOOR = float(os.environ.get("EXTRAPOLATION_BLOCK_COSINE_FLOOR", "1.0"))
+
+
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "0"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_subspace_project_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    diffs = [iterates[i + 1].float() - iterates[i].float() for i in range(len(iterates) - 1)]
+    U = torch.stack(diffs)
+    try:
+        G = U @ U.T
+        evals, evecs = torch.linalg.eigh(G)
+        finite = torch.isfinite(evals) & (evals > 1e-12)
+        if not bool(finite.any()):
+            return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+        order = torch.argsort(evals, descending=True)
+        rank = max(1, min(int(EXTRAPOLATION_SUBSPACE_RANK), int(finite.sum().item())))
+        projected = torch.zeros_like(delta)
+        kept = 0
+        for idx in order:
+            if not bool(finite[idx]):
+                continue
+            basis = evecs[:, idx] @ U
+            denom = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+            projected = projected + basis * (torch.dot(delta.flatten(), basis.flatten()) / denom)
+            kept += 1
+            if kept >= rank:
+                break
+        return _finish_extrapolation(iterates[-1], current + projected, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_accel_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    delta = rre - current
+    accel = current - 2 * iterates[-2].float() + iterates[-3].float()
+    try:
+        accel_norm_sq = torch.dot(accel.flatten(), accel.flatten()).clamp_min(1e-12)
+        dot = torch.dot(delta.flatten(), accel.flatten())
+        if torch.isfinite(dot) and dot > 0:
+            delta = delta - max(0.0, EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT) * accel * (dot / accel_norm_sq)
+        return _finish_extrapolation(iterates[-1], current + delta, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+def rre_normed_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    current_norm = current.norm().clamp_min(1e-12)
+    try:
+        normed = [x.float() / x.float().norm().clamp_min(1e-12) for x in iterates]
+        normed_extrapolated = rre_extrapolate(
+            normed,
+            regularization=regularization,
+            damping=1.0,
+        ).float()
+        extrapolated = normed_extrapolated * current_norm
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "rre_subspace": rre_subspace_project_extrapolate,
+    "rre_subspace_project": rre_subspace_project_extrapolate,
+    "rre_accel_residual": rre_accel_residual_extrapolate,
+    "rre_acceleration_residual": rre_accel_residual_extrapolate,
+    "rre_normed": rre_normed_extrapolate,
+    "rre_unit_norm": rre_normed_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+def _smoothstep_extrap(x):
+    x = min(1.0, max(0.0, float(x)))
+    return x * x * (3 - 2 * x)
+
+def extrap_scheduled_value(step, base, final, taper_start, taper_end):
+    if taper_start <= 0 or taper_end <= taper_start or step <= taper_start:
+        return base
+    if step >= taper_end:
+        return final
+    t = _smoothstep_extrap((step - taper_start) / max(1, taper_end - taper_start))
+    return base + t * (final - base)
+
+def scale_orthogonal_delta(delta, basis, orthogonal_scale):
+    if orthogonal_scale == 1.0:
+        return delta
+    basis_norm_sq = torch.dot(basis.flatten(), basis.flatten()).clamp_min(1e-12)
+    dot = torch.dot(delta.flatten(), basis.flatten())
+    if not torch.isfinite(dot):
+        return delta
+    if dot <= 0:
+        return max(0.0, orthogonal_scale) * delta
+    projection = basis * (dot / basis_norm_sq)
+    residual = delta - projection
+    return projection + max(0.0, orthogonal_scale) * residual
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _project_momentum_against_delta(self, params, flat_delta):
+        if EXTRAPOLATION_MOMENTUM_PROJECT == "none":
+            return
+        offsets = self._parameter_offsets(params)
+        for p, (start, end) in zip(params, offsets):
+            state = self.state.get(p)
+            if not state or "momentum" not in state:
+                continue
+            delta = flat_delta[start:end].view_as(p).float()
+            denom = torch.dot(delta.flatten(), delta.flatten()).clamp_min(1e-12)
+            momentum = state["momentum"].float()
+            dot = torch.dot(momentum.flatten(), delta.flatten())
+            if not torch.isfinite(dot):
+                continue
+            if EXTRAPOLATION_MOMENTUM_PROJECT == "anti_delta" and dot < 0:
+                projected = momentum - max(0.0, EXTRAPOLATION_MOMENTUM_PROJECT_SCALE) * delta * (dot / denom)
+                state["momentum"].copy_(projected.to(state["momentum"].dtype))
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _weight_delta_blocks_by_velocity(self, params, current_f32, delta, previous_f32, floor):
+        if floor >= 1.0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        weighted = delta.clone()
+        floor = max(0.0, min(1.0, float(floor)))
+        for group in by_layer.values():
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            v = torch.cat([
+                current_f32[offsets[i][0]:offsets[i][1]] - previous_f32[offsets[i][0]:offsets[i][1]]
+                for i in group
+            ])
+            denom = (d.norm() * v.norm()).clamp_min(1e-12)
+            cos = torch.dot(d.flatten(), v.flatten()) / denom
+            if not torch.isfinite(cos):
+                continue
+            weight = floor + (1.0 - floor) * max(0.0, min(1.0, float(cos)))
+            for i in group:
+                start, end = offsets[i]
+                weighted[start:end].copy_(delta[start:end] * weight)
+        return weighted
+
+    def _cap_delta_blocks(self, params, current_f32, delta, block_max_rel):
+        if block_max_rel <= 0:
+            return delta
+        offsets = self._parameter_offsets(params)
+        by_layer = {}
+        for i, p in enumerate(params):
+            key = getattr(p, "_extrap_layer_key", f"param_{i}")
+            by_layer.setdefault(key, []).append(i)
+        capped = delta.clone()
+        for group in by_layer.values():
+            cur = torch.cat([current_f32[offsets[i][0]:offsets[i][1]] for i in group])
+            d = torch.cat([delta[offsets[i][0]:offsets[i][1]] for i in group])
+            rel = float(d.norm() / cur.norm().clamp_min(1e-12))
+            if rel <= block_max_rel:
+                continue
+            scale = block_max_rel / max(rel, 1e-12)
+            for i in group:
+                start, end = offsets[i]
+                capped[start:end].copy_(delta[start:end] * scale)
+        return capped
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        damping_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_DAMPING,
+            EXTRAPOLATION_DAMPING_FINAL,
+            EXTRAPOLATION_DAMPING_TAPER_START,
+            EXTRAPOLATION_DAMPING_TAPER_END,
+        )
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                damping_now,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping_now,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        if EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE != 1.0 and len(self.extrap_checkpoints) >= 2:
+            velocity = current_f32 - self.extrap_checkpoints[-2].float()
+            delta = scale_orthogonal_delta(delta, velocity, EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE)
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        max_rel_now = extrap_scheduled_value(
+            next_step,
+            EXTRAPOLATION_MAX_REL,
+            EXTRAPOLATION_MAX_REL_FINAL,
+            EXTRAPOLATION_MAX_REL_TAPER_START,
+            EXTRAPOLATION_MAX_REL_TAPER_END,
+        )
+        extrap_rel = float(delta.norm() / current_norm)
+        if max_rel_now > 0 and extrap_rel > max_rel_now:
+            delta = delta * (max_rel_now / max(extrap_rel, 1e-12))
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_COSINE_FLOOR < 1.0 and len(self.extrap_checkpoints) >= 2:
+            previous_f32 = self.extrap_checkpoints[-2].float()
+            delta = self._weight_delta_blocks_by_velocity(
+                params,
+                current_f32,
+                delta,
+                previous_f32,
+                EXTRAPOLATION_BLOCK_COSINE_FLOOR,
+            )
+            extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_BLOCK_MAX_REL > 0:
+            delta = self._cap_delta_blocks(params, current_f32, delta, EXTRAPOLATION_BLOCK_MAX_REL)
+            extrap_rel = float(delta.norm() / current_norm)
+        extrapolated = (current_f32 + delta).to(current.dtype)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_MOMENTUM_PROJECT != "none":
+            self._project_momentum_against_delta(params, delta)
+            self.last_handoff_mode = EXTRAPOLATION_MOMENTUM_PROJECT
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using extrapolation_landing damping_final={EXTRAPOLATION_DAMPING_FINAL} damping_taper=({EXTRAPOLATION_DAMPING_TAPER_START},{EXTRAPOLATION_DAMPING_TAPER_END}) max_rel_final={EXTRAPOLATION_MAX_REL_FINAL} max_rel_taper=({EXTRAPOLATION_MAX_REL_TAPER_START},{EXTRAPOLATION_MAX_REL_TAPER_END}) block_max_rel={EXTRAPOLATION_BLOCK_MAX_REL} alignment_orthogonal_scale={EXTRAPOLATION_ALIGNMENT_ORTHOGONAL_SCALE} momentum_project={EXTRAPOLATION_MOMENTUM_PROJECT} momentum_project_scale={EXTRAPOLATION_MOMENTUM_PROJECT_SCALE}")
+print0(f"Using extrapolation_vector subspace_rank={EXTRAPOLATION_SUBSPACE_RANK} residual_weight={EXTRAPOLATION_VECTOR_RESIDUAL_WEIGHT} block_cosine_floor={EXTRAPOLATION_BLOCK_COSINE_FLOOR}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", str(train_steps)))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu130 compiled for CUDA 13.0
+Running on device_name=NVIDIA H100 80GB HBM3 with world_size=1
+Run UTC timestamp=2026-05-19T20:15:49Z
+Using seed=1
+Experiment=contra-muon-to-soft-muon
+Intuition=PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=3020, schedule_steps=3050.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2500
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using vector_extrapolation=rre every=5 start_step=2820 checkpoints=4 regularization=1e-06 damping=0.875 reset_momentum=False stop_step=2925 after_stop_every=0 param_filter=all
+Using extrapolation_blend_weight=0.25 blend_max_extra_rel=0.25 blend_orthogonal=True
+Using extrapolation_landing damping_final=0.875 damping_taper=(0,0) max_rel_final=0.001 max_rel_taper=(0,0) block_max_rel=0.0 alignment_orthogonal_scale=1.0 momentum_project=none momentum_project_scale=1.0
+Using extrapolation_vector subspace_rank=1 residual_weight=0.5 block_cosine_floor=1.0
+Using checkpoint_load_path= checkpoint_save_step=0 checkpoint_save_path= checkpoint_exit_after_save=False
+Using model_num_layers=12 model_dim=768 val_tokens=10485760 train_batch_tokens=524288 micro_batch_sequences=64
+Using lr_sprint start=0 end=0 scale=1.0 ramp_steps=0 apply_to=muon
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+Using run_stop_step=2925 train_steps=3020
+step:125/3020 val_loss:4.47416 train_time:258.067s step_avg:2064.54ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:250/3020 val_loss:4.10758 train_time:447.362s step_avg:1789.45ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:375/3020 val_loss:3.95280 train_time:637.685s step_avg:1700.49ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:500/3020 val_loss:3.83982 train_time:826.359s step_avg:1652.72ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:625/3020 val_loss:3.76630 train_time:1015.918s step_avg:1625.47ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:750/3020 val_loss:3.71775 train_time:1204.473s step_avg:1605.96ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:875/3020 val_loss:3.67636 train_time:1394.169s step_avg:1593.34ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1000/3020 val_loss:3.63594 train_time:1583.572s step_avg:1583.57ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1125/3020 val_loss:3.61238 train_time:1773.144s step_avg:1576.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1250/3020 val_loss:3.57962 train_time:1962.302s step_avg:1569.84ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1375/3020 val_loss:3.55376 train_time:2152.986s step_avg:1565.81ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1500/3020 val_loss:3.52286 train_time:2342.604s step_avg:1561.74ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1625/3020 val_loss:3.50253 train_time:2532.913s step_avg:1558.72ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1750/3020 val_loss:3.47332 train_time:2722.291s step_avg:1555.59ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:1875/3020 val_loss:3.44687 train_time:2912.761s step_avg:1553.47ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2000/3020 val_loss:3.42101 train_time:3102.324s step_avg:1551.16ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2125/3020 val_loss:3.39690 train_time:3292.068s step_avg:1549.21ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2250/3020 val_loss:3.37367 train_time:3481.010s step_avg:1547.12ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2375/3020 val_loss:3.35261 train_time:3670.854s step_avg:1545.62ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2500/3020 val_loss:3.33213 train_time:3859.895s step_avg:1543.96ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2625/3020 val_loss:3.31315 train_time:4049.900s step_avg:1542.82ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2750/3020 val_loss:3.29681 train_time:4239.623s step_avg:1541.68ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2820/3020 val_loss:3.28911 train_time:4345.989s step_avg:1541.13ms extrap_count:0 extrap_rel:0.000e+00 handoff:none
+step:2830/3020 val_loss:3.28775 train_time:4361.312s step_avg:1541.10ms extrap_count:2 extrap_rel:1.000e-03 handoff:keep
+step:2840/3020 val_loss:3.28650 train_time:4376.496s step_avg:1541.02ms extrap_count:4 extrap_rel:1.000e-03 handoff:keep
+step:2850/3020 val_loss:3.28549 train_time:4391.695s step_avg:1540.95ms extrap_count:6 extrap_rel:1.000e-03 handoff:keep
+step:2860/3020 val_loss:3.28450 train_time:4407.003s step_avg:1540.91ms extrap_count:8 extrap_rel:1.000e-03 handoff:keep
+step:2870/3020 val_loss:3.28378 train_time:4422.244s step_avg:1540.85ms extrap_count:10 extrap_rel:1.000e-03 handoff:keep
+step:2875/3020 val_loss:3.28330 train_time:4430.198s step_avg:1540.94ms extrap_count:11 extrap_rel:9.956e-04 handoff:keep
+step:2880/3020 val_loss:3.28290 train_time:4437.506s step_avg:1540.80ms extrap_count:12 extrap_rel:9.671e-04 handoff:keep
+step:2890/3020 val_loss:3.28210 train_time:4452.765s step_avg:1540.75ms extrap_count:14 extrap_rel:8.974e-04 handoff:keep
+step:2895/3020 val_loss:3.28173 train_time:4460.739s step_avg:1540.84ms extrap_count:15 extrap_rel:8.692e-04 handoff:keep
+step:2900/3020 val_loss:3.28139 train_time:4467.993s step_avg:1540.69ms extrap_count:16 extrap_rel:8.308e-04 handoff:keep
+step:2910/3020 val_loss:3.28074 train_time:4483.205s step_avg:1540.62ms extrap_count:18 extrap_rel:7.702e-04 handoff:keep
+step:2920/3020 val_loss:3.28009 train_time:4498.457s step_avg:1540.57ms extrap_count:20 extrap_rel:7.006e-04 handoff:keep
+step:2925/3020 val_loss:3.27981 train_time:4506.404s step_avg:1540.65ms extrap_count:21 extrap_rel:6.711e-04 handoff:keep

--- a/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/train_gpt_simple_rre_pr300_2925.py
+++ b/records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/train_gpt_simple_rre_pr300_2925.py
@@ -1,0 +1,1584 @@
+"""
+train_gpt_simple_rre_pr300_2925.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning 
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+
+New in this result: a late reduced-rank extrapolation (RRE) overlay over recent
+parameter vectors, damped and capped by relative parameter-vector norm.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = int(os.environ.get("SEED", str(args.seed)))
+# Hardcoded final schedule constants
+FINAL_TRAIN_STEPS = 3020
+FINAL_SCHEDULE_STEPS = 3050
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "contra-muon-to-soft-muon"
+EXPERIMENT_INTUITION = "PR291 plus dampened radial gradient component before the u/w floor, followed by post-step radius correction for tangent drift."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+NORMAL_TO_SOFT_START_STEP = 2500
+NORMAL_TO_SOFT_END_STEP = 3010
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+TARGET_UW = 0.3825
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+EXTRAPOLATION_NAME = os.environ.get("EXTRAPOLATION_NAME", "rre").strip().lower()
+EXTRAPOLATION_EVERY = int(os.environ.get("EXTRAPOLATION_EVERY", "5"))
+EXTRAPOLATION_START_STEP = int(os.environ.get("EXTRAPOLATION_START_STEP", "2820"))
+EXTRAPOLATION_NUM_CHECKPOINTS = int(os.environ.get("EXTRAPOLATION_NUM_CHECKPOINTS", "4"))
+EXTRAPOLATION_REGULARIZATION = float(os.environ.get("EXTRAPOLATION_REGULARIZATION", "1e-6"))
+EXTRAPOLATION_DAMPING = float(os.environ.get("EXTRAPOLATION_DAMPING", "0.875"))
+EXTRAPOLATION_MAX_REL = float(os.environ.get("EXTRAPOLATION_MAX_REL", "0.001"))
+EXTRAPOLATION_BLEND_WEIGHT = float(os.environ.get("EXTRAPOLATION_BLEND_WEIGHT", "0.25"))
+EXTRAPOLATION_BLEND_MAX_EXTRA_REL = float(os.environ.get("EXTRAPOLATION_BLEND_MAX_EXTRA_REL", "0.25"))
+EXTRAPOLATION_BLEND_ORTHOGONAL = os.environ.get("EXTRAPOLATION_BLEND_ORTHOGONAL", "1").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_RESET_MOMENTUM = os.environ.get("EXTRAPOLATION_RESET_MOMENTUM", "0").strip().lower() not in {"0", "false", "no", "off"}
+EXTRAPOLATION_STOP_STEP = int(os.environ.get("EXTRAPOLATION_STOP_STEP", "2925"))
+EXTRAPOLATION_AFTER_STOP_EVERY = int(os.environ.get("EXTRAPOLATION_AFTER_STOP_EVERY", "0"))
+EXTRAPOLATION_PARAM_FILTER = os.environ.get("EXTRAPOLATION_PARAM_FILTER", "all").strip().lower()
+CHECKPOINT_SAVE_STEP = int(os.environ.get("CHECKPOINT_SAVE_STEP", "0"))
+CHECKPOINT_SAVE_PATH = os.environ.get("CHECKPOINT_SAVE_PATH", "").strip()
+CHECKPOINT_LOAD_PATH = os.environ.get("CHECKPOINT_LOAD_PATH", "").strip()
+CHECKPOINT_EXIT_AFTER_SAVE = os.environ.get("CHECKPOINT_EXIT_AFTER_SAVE", "0").strip().lower() in {"1", "true", "yes", "on"}
+MODEL_NUM_LAYERS = int(os.environ.get("MODEL_NUM_LAYERS", "12"))
+MODEL_DIM = int(os.environ.get("MODEL_DIM", "768"))
+VAL_TOKENS = int(os.environ.get("VAL_TOKENS", str(20 * 524288)))
+TRAIN_BATCH_TOKENS = int(os.environ.get("TRAIN_BATCH_TOKENS", str(8 * 64 * 1024)))
+MICRO_BATCH_SEQUENCES = int(os.environ.get("MICRO_BATCH_SEQUENCES", "64"))
+LR_SPRINT_START_STEP = int(os.environ.get("LR_SPRINT_START_STEP", "0"))
+LR_SPRINT_END_STEP = int(os.environ.get("LR_SPRINT_END_STEP", "0"))
+LR_SPRINT_SCALE = float(os.environ.get("LR_SPRINT_SCALE", "1.0"))
+LR_SPRINT_RAMP_STEPS = int(os.environ.get("LR_SPRINT_RAMP_STEPS", "0"))
+LR_SPRINT_APPLY_TO = os.environ.get("LR_SPRINT_APPLY_TO", "muon").strip().lower()
+assert LR_SPRINT_APPLY_TO in {"muon", "adam", "all"}
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_q_param(name: str) -> bool:
+    return name.endswith(".attn.q.weight")
+
+def is_k_param(name: str) -> bool:
+    return name.endswith(".attn.k.weight")
+
+def is_mlp_param(name: str) -> bool:
+    return name.endswith(".mlp.fc.weight") or name.endswith(".mlp.proj.weight")
+
+def extrap_param_matches(name: str) -> bool:
+    spec = EXTRAPOLATION_PARAM_FILTER
+    if spec in {"all", "*"}:
+        return True
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("attn" in keys and is_attn_param(name))
+        or ("qkv" in keys and (is_q_param(name) or is_k_param(name) or is_v_param(name)))
+        or ("q" in keys and is_q_param(name))
+        or ("k" in keys and is_k_param(name))
+        or ("v" in keys and is_v_param(name))
+        or ("attn_proj" in keys and is_attn_proj_param(name))
+        or ("mlp" in keys and is_mlp_param(name))
+        or ("mlp_fc" in keys and name.endswith(".mlp.fc.weight"))
+        or ("mlp_proj" in keys and name.endswith(".mlp.proj.weight"))
+        or ("soap" in keys and should_soap_param(name))
+        or ("nonsoap" in keys and not should_soap_param(name))
+    )
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(RADIAL_OUTWARD_SCALE),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2, use_contra=True, use_soft=True):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+def rre_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        if damping != 1.0:
+            extrapolated = iterates_f32[-1].lerp(extrapolated, damping)
+        if not torch.isfinite(extrapolated).all():
+            return iterates[-1].clone()
+        return extrapolated.to(orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_tsvd_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    U = torch.stack(diffs)
+    G = U @ U.T
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        evals, evecs = torch.linalg.eigh(G)
+        if not torch.isfinite(evals).all() or evals.numel() == 0:
+            return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+        max_eval = evals.max().clamp_min(1e-12)
+        threshold = max(float(regularization), 1e-12) * max_eval
+        keep = evals > threshold
+        if not bool(keep.any()):
+            keep[torch.argmax(evals)] = True
+        V = evecs[:, keep]
+        coeffs = V @ ((V.T @ ones) / evals[keep].clamp_min(1e-12))
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-1] - (gamma @ U)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def _finish_extrapolation(current, extrapolated, damping, orig_dtype):
+    if damping != 1.0:
+        extrapolated = current.float().lerp(extrapolated.float(), damping)
+    if not torch.isfinite(extrapolated).all():
+        return current.clone()
+    return extrapolated.to(orig_dtype)
+
+def mpe_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    second_diffs = [diffs[i + 1] - diffs[i] for i in range(k - 1)]
+    if not second_diffs:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    W = torch.stack(second_diffs)
+    G = W @ W.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    ones = torch.ones(G.size(0), dtype=G.dtype, device=G.device)
+
+    try:
+        coeffs = torch.linalg.solve(G, ones)
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        gamma = torch.flip(torch.cumsum(torch.flip(coeffs, [0]), 0), [0])
+        extrapolated = iterates_f32[-2].clone()
+        for weight, second_diff in zip(gamma, second_diffs):
+            extrapolated = extrapolated - weight * second_diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def mpe_sidi_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(len(iterates_f32) - 1)]
+    basis = torch.stack(diffs[:-1])
+    target = diffs[-1]
+    G = basis @ basis.T
+    reg = regularization * torch.trace(G).clamp_min(0) / max(1, G.size(0)) + 1e-10
+    G = G + reg * torch.eye(G.size(0), device=G.device, dtype=G.dtype)
+    rhs = -(basis @ target)
+
+    try:
+        coeff_head = torch.linalg.solve(G, rhs)
+        coeffs = torch.cat([coeff_head, torch.ones(1, device=G.device, dtype=G.dtype)])
+        coeff_sum = coeffs.sum()
+        if not torch.isfinite(coeff_sum) or coeff_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        coeffs = coeffs / coeff_sum
+        extrapolated = sum(coeffs[i] * iterates_f32[i + 1] for i in range(coeffs.numel()))
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def anderson_extrapolate(iterates, regularization=1e-6, damping=1.0, beta=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    residuals = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    R = torch.stack(residuals)
+    G = R @ R.T
+    reg = regularization * torch.trace(G).clamp_min(0) / k + 1e-10
+    G = G + reg * torch.eye(k, device=G.device, dtype=G.dtype)
+    ones = torch.ones(k, dtype=G.dtype, device=G.device)
+
+    try:
+        alpha = torch.linalg.solve(G, ones)
+        alpha_sum = alpha.sum()
+        if not torch.isfinite(alpha_sum) or alpha_sum.abs() < 1e-12:
+            return iterates[-1].clone()
+        alpha = alpha / alpha_sum
+        x_bar = sum(alpha[i] * iterates_f32[i + 1] for i in range(k))
+        r_bar = sum(alpha[i] * residuals[i] for i in range(k))
+        extrapolated = x_bar + beta * r_bar
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def vea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    eps_prev = [torch.zeros_like(iterates_f32[0]) for _ in iterates_f32]
+    eps_curr = [x.clone() for x in iterates_f32]
+    eps = max(float(regularization), 1e-10)
+
+    try:
+        for _ in range(min(k, 4)):
+            eps_next = []
+            for i in range(len(eps_curr) - 1):
+                diff = eps_curr[i + 1] - eps_curr[i]
+                norm_sq = torch.dot(diff.flatten(), diff.flatten())
+                if norm_sq < eps:
+                    eps_next.append(eps_curr[i + 1].clone())
+                else:
+                    eps_next.append(eps_prev[i + 1] + diff / (norm_sq + eps))
+            if not eps_next:
+                break
+            eps_prev = eps_curr
+            eps_curr = eps_next
+        extrapolated = eps_curr[-1] if eps_curr else iterates_f32[-1]
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def stea_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    k = len(iterates) - 1
+    if k < 2:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    iterates_f32 = [x.float() for x in iterates]
+    diffs = [iterates_f32[i + 1] - iterates_f32[i] for i in range(k)]
+    try:
+        weights = torch.tensor(
+            [1.0 / (torch.norm(d).item() + regularization) for d in diffs],
+            device=iterates[0].device,
+            dtype=torch.float32,
+        )
+        weights = weights / weights.sum().clamp_min(1e-12)
+        extrapolated = iterates_f32[-1].clone()
+        for i, (weight, diff) in enumerate(zip(weights, diffs)):
+            extrapolated = extrapolated - weight * ((i + 1) / k) * diff
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def quadratic_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return iterates[-1].clone()
+
+    orig_dtype = iterates[0].dtype
+    x0 = iterates[-3].float()
+    x1 = iterates[-2].float()
+    x2 = iterates[-1].float()
+    d1 = x1 - x0
+    d2 = x2 - x1
+    dd = d2 - d1
+    dd_norm = torch.dot(dd.flatten(), dd.flatten())
+    if dd_norm < max(float(regularization), 1e-10):
+        return iterates[-1].clone()
+    try:
+        extrapolated = x0 - d1 * (torch.dot(d1.flatten(), dd.flatten()) / dd_norm)
+        return _finish_extrapolation(iterates[-1], extrapolated, damping, orig_dtype)
+    except Exception:
+        return iterates[-1].clone()
+
+def rre_quadratic_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    quad = quadratic_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    quad_delta = quad - current
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    quad_norm = torch.dot(quad_delta.flatten(), quad_delta.flatten()).sqrt().clamp_min(1e-12)
+
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(quad_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    dot = torch.dot(rre_delta.flatten(), quad_delta.flatten())
+    cos = dot / (rre_norm * quad_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = quad_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = quad_delta - rre_delta
+        extra_norm = torch.dot(extra.flatten(), extra.flatten()).sqrt()
+        max_extra = rre_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+        if extra_norm > max_extra:
+            extra = extra * (max_extra / extra_norm.clamp_min(1e-12))
+        blended_delta = rre_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def _blend_extra_delta(base_delta, extra_delta):
+    base_norm = torch.dot(base_delta.flatten(), base_delta.flatten()).sqrt().clamp_min(1e-12)
+    extra_norm = torch.dot(extra_delta.flatten(), extra_delta.flatten()).sqrt()
+    max_extra = base_norm * max(0.0, EXTRAPOLATION_BLEND_MAX_EXTRA_REL)
+    if extra_norm > max_extra:
+        extra_delta = extra_delta * (max_extra / extra_norm.clamp_min(1e-12))
+    return base_delta + max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * extra_delta
+
+def rre_mpe_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 4:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    mpe = mpe_sidi_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    mpe_delta = mpe - current
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(mpe_delta).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    mpe_norm = torch.dot(mpe_delta.flatten(), mpe_delta.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), mpe_delta.flatten())
+    cos = dot / (rre_norm * mpe_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = mpe_delta - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = mpe_delta - rre_delta
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_blend_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    if not torch.isfinite(rre_delta).all() or not torch.isfinite(velocity).all():
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    rre_norm = torch.dot(rre_delta.flatten(), rre_delta.flatten()).sqrt().clamp_min(1e-12)
+    vel_norm = torch.dot(velocity.flatten(), velocity.flatten()).sqrt().clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    cos = dot / (rre_norm * vel_norm)
+    if not torch.isfinite(cos) or cos <= 0:
+        blended_delta = rre_delta
+    else:
+        if EXTRAPOLATION_BLEND_ORTHOGONAL:
+            extra = velocity - rre_delta * (dot / rre_norm.square())
+        else:
+            extra = velocity
+        blended_delta = _blend_extra_delta(rre_delta, extra)
+
+    extrapolated = current + damping * blended_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+def rre_velocity_residual_extrapolate(iterates, regularization=1e-6, damping=1.0):
+    if len(iterates) < 3:
+        return rre_extrapolate(iterates, regularization=regularization, damping=damping)
+
+    orig_dtype = iterates[0].dtype
+    current = iterates[-1].float()
+    rre = rre_extrapolate(iterates, regularization=regularization, damping=1.0).float()
+    rre_delta = rre - current
+    velocity = current - iterates[-2].float()
+    vel_norm_sq = torch.dot(velocity.flatten(), velocity.flatten()).clamp_min(1e-12)
+    dot = torch.dot(rre_delta.flatten(), velocity.flatten())
+    if torch.isfinite(dot) and dot > 0:
+        projection = velocity * (dot / vel_norm_sq)
+        rre_delta = rre_delta - max(0.0, EXTRAPOLATION_BLEND_WEIGHT) * projection
+    extrapolated = current + damping * rre_delta
+    if not torch.isfinite(extrapolated).all():
+        return iterates[-1].clone()
+    return extrapolated.to(orig_dtype)
+
+EXTRAPOLATION_ALGORITHMS = {
+    "rre": rre_extrapolate,
+    "rre_tsvd": rre_tsvd_extrapolate,
+    "mpe": mpe_extrapolate,
+    "mpe_sidi": mpe_sidi_extrapolate,
+    "anderson": anderson_extrapolate,
+    "vea": vea_extrapolate,
+    "stea": stea_extrapolate,
+    "quadratic": quadratic_extrapolate,
+    "rre_quadratic_blend": rre_quadratic_blend_extrapolate,
+    "rre_quad_blend": rre_quadratic_blend_extrapolate,
+    "rre_quadratic_orthogonal": rre_quadratic_blend_extrapolate,
+    "rre_mpe_blend": rre_mpe_blend_extrapolate,
+    "rre_velocity_blend": rre_velocity_blend_extrapolate,
+    "rre_velocity_residual": rre_velocity_residual_extrapolate,
+}
+RRE_LAYERWISE_NAMES = {"rre_layer", "layer_rre", "rre_per_layer", "per_layer_rre"}
+RRE_TENSORWISE_NAMES = {"rre_tensor", "tensor_rre", "rre_per_tensor", "per_tensor_rre"}
+
+def extrap_layer_key(name):
+    parts = name.split(".")
+    if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+        return f"block_{parts[1]}"
+    if parts and parts[0].isdigit():
+        return f"block_{parts[0]}"
+    return name
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        for n, p in named_params:
+            p._extrap_layer_key = extrap_layer_key(n)
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.extrap_params = {p for n, p in named_params if extrap_param_matches(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+        self.extrap_checkpoints = []
+        self.extrap_count = 0
+        self.last_extrap_rel = 0.0
+        self.last_handoff_mode = "none"
+
+    def _flatten_params(self, params):
+        return torch.cat([p.detach().reshape(-1) for p in params])
+
+    def _unflatten_params(self, params, flat_params):
+        offset = 0
+        for p in params:
+            numel = p.numel()
+            p.copy_(flat_params[offset:offset + numel].view_as(p))
+            offset += numel
+
+    def _reset_momentum(self, params):
+        for p in params:
+            state = self.state.get(p)
+            if state and "momentum" in state:
+                state["momentum"].zero_()
+
+    def _parameter_offsets(self, params):
+        offsets = []
+        offset = 0
+        for p in params:
+            next_offset = offset + p.numel()
+            offsets.append((offset, next_offset))
+            offset = next_offset
+        return offsets
+
+    def _rre_groupwise_extrapolate(self, params, checkpoints, damping, mode):
+        offsets = self._parameter_offsets(params)
+        result = checkpoints[-1].clone()
+        if mode == "tensor":
+            groups = [(i,) for i in range(len(params))]
+        else:
+            by_layer = {}
+            for i, p in enumerate(params):
+                key = getattr(p, "_extrap_layer_key", f"param_{i}")
+                by_layer.setdefault(key, []).append(i)
+            groups = list(by_layer.values())
+
+        for group in groups:
+            group_iterates = []
+            for checkpoint in checkpoints:
+                group_iterates.append(torch.cat([checkpoint[offsets[i][0]:offsets[i][1]] for i in group]))
+            group_extrapolated = rre_extrapolate(
+                group_iterates,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=damping,
+            )
+            cursor = 0
+            for i in group:
+                start, end = offsets[i]
+                size = end - start
+                result[start:end].copy_(group_extrapolated[cursor:cursor + size])
+                cursor += size
+        return result
+
+    def _maybe_extrapolate(self, params):
+        extrapolation_name = EXTRAPOLATION_NAME.lower()
+        if EXTRAPOLATION_EVERY <= 0 or extrapolation_name in {"none", "off", "0"}:
+            return
+        params = [p for p in params if p in self.extrap_params]
+        if not params:
+            self.last_handoff_mode = "filter_empty"
+            return
+        extrapolate = EXTRAPOLATION_ALGORITHMS.get(extrapolation_name)
+        is_layerwise_rre = extrapolation_name in RRE_LAYERWISE_NAMES
+        is_tensorwise_rre = extrapolation_name in RRE_TENSORWISE_NAMES
+        if extrapolate is None and not is_layerwise_rre and not is_tensorwise_rre:
+            raise ValueError(f"unknown vector extrapolation algorithm: {EXTRAPOLATION_NAME}")
+
+        next_step = self.step_count + 1
+        if next_step < EXTRAPOLATION_START_STEP:
+            return
+        after_stop = EXTRAPOLATION_STOP_STEP and next_step > EXTRAPOLATION_STOP_STEP
+        every = EXTRAPOLATION_AFTER_STOP_EVERY if after_stop else EXTRAPOLATION_EVERY
+        if after_stop and every <= 0:
+            return
+
+        current = self._flatten_params(params).detach().clone()
+        self.extrap_checkpoints.append(current)
+        if len(self.extrap_checkpoints) > EXTRAPOLATION_NUM_CHECKPOINTS:
+            self.extrap_checkpoints.pop(0)
+        if next_step % every != 0 or len(self.extrap_checkpoints) < EXTRAPOLATION_NUM_CHECKPOINTS:
+            return
+
+        if is_layerwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                EXTRAPOLATION_DAMPING,
+                "layer",
+            )
+        elif is_tensorwise_rre:
+            extrapolated = self._rre_groupwise_extrapolate(
+                params,
+                self.extrap_checkpoints,
+                EXTRAPOLATION_DAMPING,
+                "tensor",
+            )
+        else:
+            extrapolated = extrapolate(
+                self.extrap_checkpoints,
+                regularization=EXTRAPOLATION_REGULARIZATION,
+                damping=EXTRAPOLATION_DAMPING,
+            )
+        current_f32 = current.float()
+        delta = extrapolated.float() - current_f32
+        current_norm = current_f32.norm().clamp_min(1e-12)
+        extrap_rel = float(delta.norm() / current_norm)
+        if EXTRAPOLATION_MAX_REL > 0 and extrap_rel > EXTRAPOLATION_MAX_REL:
+            delta = delta * (EXTRAPOLATION_MAX_REL / max(extrap_rel, 1e-12))
+            extrapolated = (current_f32 + delta).to(current.dtype)
+            extrap_rel = float(delta.norm() / current_norm)
+        self.last_extrap_rel = extrap_rel
+        self._unflatten_params(params, extrapolated)
+        self.extrap_checkpoints = [extrapolated.detach().clone()]
+        final_extrap_before_stop = (
+            EXTRAPOLATION_STOP_STEP
+            and EXTRAPOLATION_AFTER_STOP_EVERY <= 0
+            and next_step + EXTRAPOLATION_EVERY > EXTRAPOLATION_STOP_STEP
+        )
+        if final_extrap_before_stop:
+            self.last_handoff_mode = "keep"
+        elif EXTRAPOLATION_RESET_MOMENTUM:
+            self._reset_momentum(params)
+            self.last_handoff_mode = "reset"
+        else:
+            self.last_handoff_mode = "keep"
+        self.extrap_count += 1
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                    )
+                    update = scale_radial_update(update, p)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw = SOAP_TARGET_UW if use_soap else NONSOAP_TARGET_UW
+                    scale = torch.where(cur_uw < target_uw, target_uw * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+            self._maybe_extrapolate(params)
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using vector_extrapolation={EXTRAPOLATION_NAME} every={EXTRAPOLATION_EVERY} start_step={EXTRAPOLATION_START_STEP} checkpoints={EXTRAPOLATION_NUM_CHECKPOINTS} regularization={EXTRAPOLATION_REGULARIZATION} damping={EXTRAPOLATION_DAMPING} reset_momentum={EXTRAPOLATION_RESET_MOMENTUM} stop_step={EXTRAPOLATION_STOP_STEP} after_stop_every={EXTRAPOLATION_AFTER_STOP_EVERY} param_filter={EXTRAPOLATION_PARAM_FILTER}")
+print0(f"Using extrapolation_blend_weight={EXTRAPOLATION_BLEND_WEIGHT} blend_max_extra_rel={EXTRAPOLATION_BLEND_MAX_EXTRA_REL} blend_orthogonal={EXTRAPOLATION_BLEND_ORTHOGONAL}")
+print0(f"Using checkpoint_load_path={CHECKPOINT_LOAD_PATH} checkpoint_save_step={CHECKPOINT_SAVE_STEP} checkpoint_save_path={CHECKPOINT_SAVE_PATH} checkpoint_exit_after_save={CHECKPOINT_EXIT_AFTER_SAVE}")
+print0(f"Using model_num_layers={MODEL_NUM_LAYERS} model_dim={MODEL_DIM} val_tokens={VAL_TOKENS} train_batch_tokens={TRAIN_BATCH_TOKENS} micro_batch_sequences={MICRO_BATCH_SEQUENCES}")
+print0(f"Using lr_sprint start={LR_SPRINT_START_STEP} end={LR_SPRINT_END_STEP} scale={LR_SPRINT_SCALE} ramp_steps={LR_SPRINT_RAMP_STEPS} apply_to={LR_SPRINT_APPLY_TO}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = VAL_TOKENS
+batch_size = TRAIN_BATCH_TOKENS
+mbs = MICRO_BATCH_SEQUENCES
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=MODEL_NUM_LAYERS, model_dim=MODEL_DIM).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+run_stop_step = int(os.environ.get("RUN_STOP_STEP", "2925"))
+assert 0 < run_stop_step <= train_steps
+val_regular_interval = 125
+extra_val_steps = {2820, 2830, 2840, 2850, 2860, 2870, 2880, 2890, 2895, 2900, 2910, 2920, 2930, 2940, 2950, 2960, 2965, 2970, 2975, 2980, 2985, 2990, 2995, 2999, 3000, 3010, 3020}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_DI_FC_ALPHA = 0.30
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - _DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+_CGI_ALPHA = 0.14
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - _CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + _CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+resume_step = 0
+if CHECKPOINT_LOAD_PATH:
+    checkpoint = torch.load(CHECKPOINT_LOAD_PATH, map_location=device)
+    model.load_state_dict(checkpoint["model"])
+    optimizer1.load_state_dict(checkpoint["optimizer1"])
+    optimizer2.load_state_dict(checkpoint["optimizer2"])
+    resume_step = int(checkpoint.get("step", 0))
+    optimizer2.step_count = int(checkpoint.get("optimizer2_step_count", resume_step))
+    optimizer2.extrap_checkpoints = []
+    optimizer2.extrap_count = 0
+    optimizer2.last_extrap_rel = 0.0
+    optimizer2.last_handoff_mode = "loaded"
+    print0(f"Loaded checkpoint from {CHECKPOINT_LOAD_PATH} at step={resume_step}", console=True)
+    for _ in range(resume_step):
+        next(train_loader)
+
+def save_checkpoint(step: int):
+    if not CHECKPOINT_SAVE_PATH or step != CHECKPOINT_SAVE_STEP:
+        return False
+    path = Path(CHECKPOINT_SAVE_PATH)
+    if dist.get_rank() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "step": step,
+            "model": model.state_dict(),
+            "optimizer1": optimizer1.state_dict(),
+            "optimizer2": optimizer2.state_dict(),
+            "optimizer2_step_count": optimizer2.step_count,
+            "seed": SEED,
+            "model_num_layers": MODEL_NUM_LAYERS,
+            "model_dim": MODEL_DIM,
+        }, path)
+        print0(f"Saved checkpoint to {path} at step={step}", console=True)
+    dist.barrier()
+    return True
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _lr_sprint_scale_at_step(step):
+    if LR_SPRINT_SCALE == 1.0 or LR_SPRINT_START_STEP <= 0:
+        return 1.0
+    end_step = LR_SPRINT_END_STEP if LR_SPRINT_END_STEP > 0 else FINAL_TRAIN_STEPS
+    if step < LR_SPRINT_START_STEP or step > end_step:
+        return 1.0
+    if LR_SPRINT_RAMP_STEPS <= 0:
+        return LR_SPRINT_SCALE
+    ramp = _linear_ramp(step, LR_SPRINT_START_STEP, LR_SPRINT_START_STEP + LR_SPRINT_RAMP_STEPS)
+    return 1.0 + (LR_SPRINT_SCALE - 1.0) * ramp
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = 100
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    sprint_scale = _lr_sprint_scale_at_step(step)
+    for opt in optimizers:
+        for group in opt.param_groups:
+            lr = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER)
+            if (
+                LR_SPRINT_APPLY_TO == "all"
+                or (LR_SPRINT_APPLY_TO == "adam" and opt is optimizer1)
+                or (LR_SPRINT_APPLY_TO == "muon" and opt is optimizer2)
+            ):
+                lr *= sprint_scale
+            group["lr"] = lr
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(resume_step, run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            assert len(val_inputs) % mbs == 0
+            for i in range(len(val_inputs) // mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+        val_loss /= val_tokens
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    saved_checkpoint = save_checkpoint(step)
+    if saved_checkpoint and CHECKPOINT_EXIT_AFTER_SAVE:
+        break
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms"
+               + f" extrap_count:{optimizer2.extrap_count}"
+               + f" extrap_rel:{optimizer2.last_extrap_rel:.3e}"
+               + f" handoff:{optimizer2.last_handoff_mode}", console=True, log=False)
+
+dist.destroy_process_group()


### PR DESCRIPTION
## Summary

Adds a Track 3 optimization result: **2925 steps to 3.28 val_loss**, validated over **n=8 non-cherry-picked full runs, seeds 0..7**.

The change is a small optimizer-side Reduced Rank Extrapolation (RRE) overlay near the end of training. Starting at step 2820, the script keeps a four-point history of recent parameter vectors, periodically solves the RRE combination, and applies the resulting extrapolated move as a damped, relative-norm-capped parameter update. This leaves the PR #300 optimizer stack intact for the main training trajectory, adds no extra forward/backward passes, and uses RRE only as a late bounded acceleration step.

This builds on the open [PR #300 Aurora-on-mlp.proj + extended Contra-Muon stack](https://github.com/KellerJordan/modded-nanogpt/pull/300). The only intended optimizer change is a late, capped RRE vector-extrapolation overlay:

```text
extrapolation_name = rre
extrap_start_step = 2820
extrap_every = 5
RRE history length k = 4
extrap_damping = 0.875
extrap_max_rel = 0.001
extrap_reset_momentum = False
extrap_stop_step = 2925
extrap_after_stop_every = 0
```

The RRE schedule is fixed across all seeds. These are full runs from step 0.

## Result

The submitted step count is **2925**. The result directory contains a readable train script plus 8 full reproducibility logfiles for seeds 0 through 7. Each logfile includes the full train script used for the run; `train_gpt_simple_rre_pr300_2925.py` exposes the same train-code path with the submitted RRE and stop-step settings as defaults.

At step 2925:

```text
n = 8
mean val loss = 3.27812750
std            = 0.00088134
(3.28 - mu) * sqrt(n) = 0.00529623
```

This exceeds the Track 3 README threshold of `0.004`. Equivalently, with `sigma=0.0013`, this is `z = 4.0740`, one-sided `p = 2.31e-05`, satisfying `p < 0.001`.

| Seed | Log | 2900 val | 2925 val |
| -: | - | -: | -: |
| 0 | `1786243c-db47-49ff-bff8-3faf814bf763.txt` | 3.27949 | 3.27793 |
| 1 | `d95a47ca-e103-4f0f-a273-dcaaca8f8bf7.txt` | 3.28139 | 3.27981 |
| 2 | `4e96056c-e936-4400-8353-403af8e4fe50.txt` | 3.27914 | 3.27761 |
| 3 | `6721c9f5-1f63-4c07-8cb9-fee0f9b313b4.txt` | 3.27991 | 3.27838 |
| 4 | `1853c4b8-77a6-48b1-9459-da4a45427ea7.txt` | 3.27943 | 3.27785 |
| 5 | `ac500b64-d44e-4052-84a5-7c8627164cf4.txt` | 3.27942 | 3.27783 |
| 6 | `89f1440d-ac2f-4666-be46-8bd6a403b613.txt` | 3.28031 | 3.27877 |
| 7 | `8ef4bff2-671c-44d1-b451-4c300317a3b1.txt` | 3.27845 | 3.27684 |
| **Mean** | | **3.27969250** | **3.27812750** |

## Flywheel lineage

Flywheel is the experiment graph used to track the run lineage, launch decisions, and parsed results for this candidate: [final n=8 result](https://flywheel.paradigma.inc/node/fff036e6-9dd9-54db-9166-a6ebe5cec914).

## Files

- `records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/README.md`
- `records/track_3_optimization/results/20260520_rre_extrapolation_pr300_2925/train_gpt_simple_rre_pr300_2925.py`
- 8 full reproducibility logfiles in the same directory, seeds 0 through 7

## Credits

This submission incorporates the same base stack lineage credited in PR #300:

- PR #274 / Skylight-001: NorMuon-lite row/column normalization lineage, u/w floor, and Muon setup.
- PR #275 / Contra-Muon: Contra-Muon update term.
- PR #278 / MLP SOAP preconditioning.
- PR #283 / Trustlight attention-SOAP lineage.
- PR #287 / power-law LR cooldown.
- PR #291 / Contra-Muon to Soft-Muon lineage.
- PR #294 / radial brake.
- PR #300 / Aurora row-balanced polar on `mlp.proj`, Soft-Muon/NorMuon-lite removal, and extended Contra-Muon ramp.

New in this PR: late capped RRE vector extrapolation with no momentum reset.
