### PR TITLE
Track 3: 2900 steps (n=9) Muon Tail Reference Interpolation

### DIFF
--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/PR_SUMMARY.md
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/PR_SUMMARY.md
@@ -1,0 +1,71 @@
+# PR Summary
+
+## Title
+
+Track 3: Tail Reference Interpolation reaches 3.28 in 2900 steps
+
+## Summary
+
+This PR adds the `20260520_tail_refinterp_2900` Track 3 optimization record.
+The method starts from the PR #300 Aurora-on-`mlp.proj` stack and retargets it
+to an exact 2900-step endpoint. The dataset, validation stream, global batch
+size, model architecture, and training loss are unchanged.
+
+The main new mechanism is Tail Reference Interpolation. The run captures a full
+model-weight reference at step `2375`, then evaluates the fixed step-2900
+checkpoint at:
+
+```text
+theta_eval = theta_2900 - 0.075 * (theta_2900 - theta_2375)
+           = 0.925 * theta_2900 + 0.075 * theta_2375
+```
+
+This is a deterministic final-window interpolation back toward the late
+trajectory. It is combined with late-only Tempered Polar, extended Contra-Muon,
+a late radial/u-w retune, and a clipped final tail-velocity transform.
+
+## Result
+
+At the fixed checkpoint `step=2900`, nine consecutive clean full-run seeds
+reach:
+
+```text
+seed 0: 3.27803
+seed 1: 3.27899
+seed 2: 3.27857
+seed 3: 3.27819
+seed 4: 3.27867
+seed 5: 3.27855
+seed 6: 3.27853
+seed 7: 3.27805
+seed 8: 3.27960
+mean:   3.278576
+```
+
+Track 3 precision:
+
+```text
+(3.28 - 3.278576) * sqrt(9) = 0.004273 >= 0.004
+z = 3.287179
+p = 0.000505982
+```
+
+## Reproduction Files
+
+The result folder includes:
+
+```text
+records/track_3_optimization/results/20260520_tail_refinterp_2900/train_gpt_tail_refinterp_2900.py
+records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
+records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed0.txt
+...
+records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed8.txt
+```
+
+Run:
+
+```bash
+records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
+```
+
+The default runner replays seeds `0 1 2 3 4 5 6 7 8` sequentially.

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/README.md
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/README.md
@@ -1,0 +1,186 @@
+# Exact-2900 Tail Reference Interpolation
+
+Author: Jesse Clark
+
+This Track 3 submission keeps the benchmark data stream, global batch size, and
+model architecture unchanged. It starts from the PR #300
+Aurora-on-`mlp.proj` optimizer stack and retargets it to an exact 2900-step
+endpoint.
+
+The main new endpoint mechanism is Tail Reference Interpolation. The run
+captures a full model-weight reference at step `2375`, then evaluates the final
+step-2900 checkpoint with:
+
+```text
+theta_eval = theta_2900 + gamma * (theta_2900 - theta_2375)
+gamma = -0.075
+```
+
+Equivalently:
+
+```text
+theta_eval = 0.925 * theta_2900 + 0.075 * theta_2375
+```
+
+This is a small deterministic interpolation back toward the late-training
+trajectory. It is used only at the fixed final validation point and does not use
+validation feedback during a run.
+
+## Result
+
+The submitted fixed checkpoint is step `2900`. The nine logs below are clean
+full runs from seeds 0 through 8. No run was stopped early, dropped, or selected
+based on validation loss.
+
+Under the Track 3 precision rule:
+
+```text
+n=9
+mean=3.278576
+(3.28 - mean) * sqrt(9) = 0.004273
+required = 0.004000
+```
+
+Using the README's `sigma=0.0013` normal approximation:
+
+```text
+z = 3.287179
+p = 0.000505982
+```
+
+| Seed | Log | 2900 val | Train time | Step avg |
+| -: | - | -: | -: | -: |
+| 0 | [refinterp_2900_seed0.txt](refinterp_2900_seed0.txt) | 3.27803 | 4798.129s | 1654.53ms |
+| 1 | [refinterp_2900_seed1.txt](refinterp_2900_seed1.txt) | 3.27899 | 4778.006s | 1647.59ms |
+| 2 | [refinterp_2900_seed2.txt](refinterp_2900_seed2.txt) | 3.27857 | 4907.369s | 1692.20ms |
+| 3 | [refinterp_2900_seed3.txt](refinterp_2900_seed3.txt) | 3.27819 | 4755.410s | 1639.80ms |
+| 4 | [refinterp_2900_seed4.txt](refinterp_2900_seed4.txt) | 3.27867 | 4842.459s | 1669.81ms |
+| 5 | [refinterp_2900_seed5.txt](refinterp_2900_seed5.txt) | 3.27855 | 4767.208s | 1643.86ms |
+| 6 | [refinterp_2900_seed6.txt](refinterp_2900_seed6.txt) | 3.27853 | 4695.982s | 1619.30ms |
+| 7 | [refinterp_2900_seed7.txt](refinterp_2900_seed7.txt) | 3.27805 | 4861.523s | 1676.39ms |
+| 8 | [refinterp_2900_seed8.txt](refinterp_2900_seed8.txt) | 3.27960 | 4814.127s | 1660.04ms |
+| **Mean** |  | **3.278576** |  |  |
+
+## Configuration
+
+Frozen runner:
+
+```text
+records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
+```
+
+Frozen trainer:
+
+```text
+records/track_3_optimization/results/20260520_tail_refinterp_2900/train_gpt_tail_refinterp_2900.py
+```
+
+Core settings:
+
+```text
+TRAIN_STEPS=2900
+SCHEDULE_STEPS=3020
+CONTRA_TO_NORMAL_END_STEP=2750
+
+TEMPERED_POLAR_RHO=0.05
+TEMPERED_POLAR_MAX_DELTA=0.25
+TEMPERED_POLAR_RAMP_START_STEP=2600
+TEMPERED_POLAR_RAMP_END_STEP=2800
+
+RADIAL_OUTWARD_SCALE=0.5
+RADIAL_OUTWARD_SCALE_LATE=0.4
+RADIAL_DECAY_START_STEP=2400
+RADIAL_DECAY_END_STEP=2900
+
+TARGET_UW_LATE=0.400
+TARGET_UW_RAMP_START_STEP=2400
+TARGET_UW_RAMP_END_STEP=2800
+TARGET_UW_FINAL=0.400
+TARGET_UW_SCOPE=all
+
+TAIL_VEL_START_STEP=2500
+TAIL_VEL_BETA=0.90
+TAIL_VEL_GAMMA=-6.0
+TAIL_VEL_MAX_DELTA_RATIO=0.01
+
+REF_EXTRAP_CAPTURE_STEP=2375
+REF_EXTRAP_GAMMA=-0.075
+REF_EXTRAP_APPLY_START_STEP=2900
+```
+
+## Method
+
+This candidate is built on the PR #300 optimizer stack:
+
+- Aurora row-balanced polar update on `mlp.proj`.
+- Contra-Muon and the PR294/PR287 optimizer schedule lineage.
+- SOAP-style MLP/V preconditioning and radial/u-w-floor machinery inherited
+  from the existing Track 3 line.
+
+The exact-2900 changes are:
+
+- Extend Contra-Muon later, to `CONTRA_TO_NORMAL_END_STEP=2750`.
+- Use late-only Tempered Polar, ramping `rho` from 0 to `0.05` during steps
+  `2600..2800`.
+- Retune the late radial brake from `0.5` to `0.4` during steps `2400..2900`.
+- Ramp the update/weight floor to `TARGET_UW=0.400` during steps `2400..2800`.
+- Keep an EMA of recent parameter updates from step `2500` and apply a clipped
+  final tail-velocity transform with `gamma=-6`.
+- Capture a step-2375 reference and evaluate step 2900 with the fixed
+  `gamma=-0.075` reference interpolation.
+
+What worked:
+
+- Late-only Tempered Polar was better than perturbing the full trajectory.
+- The late radial and `TARGET_UW=0.400` retune improved the exact-2900 endpoint.
+- Tail velocity with negative gamma helped versus earlier final-weight probes.
+- The step-2375 reference interpolation was the decisive move, especially on
+  weak seeds.
+
+What did not work:
+
+- Positive Tail Extrapolated EMA/XEWA was monotone worse in the seed-1 sweep.
+- More Tempered Polar rho/cap surface tuning did not move the mean enough.
+- Training-loss EMA gating was too weak to separate good and bad seeds.
+
+## Reproduction
+
+Run the submitted seeds:
+
+```bash
+records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
+```
+
+Run a shorter check:
+
+```bash
+SEEDS="0 1" records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
+```
+
+Recompute the reported statistics:
+
+```bash
+python3 records/track_3_optimization/results/20260520_tail_refinterp_2900/summarize_submission_stats.py --step 2900 \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed0.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed1.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed2.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed3.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed4.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed5.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed6.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed7.txt \
+  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed8.txt
+```
+
+## Credits
+
+This submission incorporates features from the following previous submissions
+and PRs:
+
+- @kumarkrishna PR274 / Skylight-001: NorMuon-lite row/column variance
+  normalization, u/w floor postprocessing, and `lr=0.0375` style Muon setup.
+- @nilin PR275 and PR291: Contra-Muon / Soft-Muon lineage.
+- @samacqua PR278: SOAP preconditioning machinery / MLP SOAP idea.
+- @SPThole PR283: Trustlight attention-SOAP path lineage.
+- @yash-oai PR287: power-law learning-rate cooldown.
+- PR #300: Aurora on `mlp.proj` plus extended Contra-Muon on the PR294 stack.

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/README.md
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/README.md
@@ -134,7 +134,7 @@ What worked:
 - Late-only Tempered Polar was better than perturbing the full trajectory.
 - The late radial and `TARGET_UW=0.400` retune improved the exact-2900 endpoint.
 - Tail velocity with negative gamma helped versus earlier final-weight probes.
-- The step-2375 reference interpolation was the decisive move, especially on
+- The step-2375 reference interpolation was very helpful, especially on
   weak seeds.
 
 What did not work:

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed0.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed0.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T02:49:42Z
+Using seed=0
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed0_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.45803 train_time:208.980s step_avg:1671.84ms
+step:250/2900 val_loss:4.10472 train_time:414.809s step_avg:1659.24ms
+step:375/2900 val_loss:3.94713 train_time:621.165s step_avg:1656.44ms
+step:500/2900 val_loss:3.83523 train_time:827.270s step_avg:1654.54ms
+step:625/2900 val_loss:3.76109 train_time:1034.246s step_avg:1654.79ms
+step:750/2900 val_loss:3.71438 train_time:1240.043s step_avg:1653.39ms
+step:875/2900 val_loss:3.66965 train_time:1446.740s step_avg:1653.42ms
+step:1000/2900 val_loss:3.63021 train_time:1652.736s step_avg:1652.74ms
+step:1125/2900 val_loss:3.60325 train_time:1859.328s step_avg:1652.74ms
+step:1250/2900 val_loss:3.57441 train_time:2065.354s step_avg:1652.28ms
+step:1375/2900 val_loss:3.54798 train_time:2272.068s step_avg:1652.41ms
+step:1500/2900 val_loss:3.51793 train_time:2478.162s step_avg:1652.11ms
+step:1625/2900 val_loss:3.49655 train_time:2685.263s step_avg:1652.47ms
+step:1750/2900 val_loss:3.46745 train_time:2891.296s step_avg:1652.17ms
+step:1875/2900 val_loss:3.44055 train_time:3098.180s step_avg:1652.36ms
+step:2000/2900 val_loss:3.41468 train_time:3304.234s step_avg:1652.12ms
+step:2125/2900 val_loss:3.39074 train_time:3511.036s step_avg:1652.25ms
+step:2250/2900 val_loss:3.36788 train_time:3717.225s step_avg:1652.10ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34694 train_time:3923.698s step_avg:1652.08ms
+step:2500/2900 val_loss:3.32716 train_time:4129.696s step_avg:1651.88ms
+step:2625/2900 val_loss:3.30615 train_time:4337.603s step_avg:1652.42ms
+step:2750/2900 val_loss:3.29183 train_time:4547.172s step_avg:1653.52ms
+step:2875/2900 val_loss:3.28021 train_time:4756.555s step_avg:1654.45ms
+step:2900/2900 val_loss:3.27803 train_time:4798.129s step_avg:1654.53ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed1.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed1.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T12:35:23Z
+Using seed=1
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed1_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.48247 train_time:208.379s step_avg:1667.03ms
+step:250/2900 val_loss:4.11485 train_time:413.901s step_avg:1655.60ms
+step:375/2900 val_loss:3.95397 train_time:619.230s step_avg:1651.28ms
+step:500/2900 val_loss:3.84011 train_time:823.676s step_avg:1647.35ms
+step:625/2900 val_loss:3.76292 train_time:1029.131s step_avg:1646.61ms
+step:750/2900 val_loss:3.71456 train_time:1233.992s step_avg:1645.32ms
+step:875/2900 val_loss:3.67184 train_time:1439.259s step_avg:1644.87ms
+step:1000/2900 val_loss:3.63328 train_time:1643.976s step_avg:1643.98ms
+step:1125/2900 val_loss:3.60756 train_time:1849.403s step_avg:1643.91ms
+step:1250/2900 val_loss:3.57586 train_time:2053.931s step_avg:1643.14ms
+step:1375/2900 val_loss:3.55026 train_time:2259.396s step_avg:1643.20ms
+step:1500/2900 val_loss:3.51906 train_time:2464.351s step_avg:1642.90ms
+step:1625/2900 val_loss:3.49769 train_time:2670.138s step_avg:1643.16ms
+step:1750/2900 val_loss:3.46885 train_time:2875.786s step_avg:1643.31ms
+step:1875/2900 val_loss:3.44182 train_time:3082.100s step_avg:1643.79ms
+step:2000/2900 val_loss:3.41599 train_time:3287.607s step_avg:1643.80ms
+step:2125/2900 val_loss:3.39204 train_time:3494.007s step_avg:1644.24ms
+step:2250/2900 val_loss:3.36856 train_time:3699.552s step_avg:1644.25ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34799 train_time:3905.722s step_avg:1644.51ms
+step:2500/2900 val_loss:3.32790 train_time:4110.811s step_avg:1644.32ms
+step:2625/2900 val_loss:3.30696 train_time:4317.820s step_avg:1644.88ms
+step:2750/2900 val_loss:3.29273 train_time:4526.858s step_avg:1646.13ms
+step:2875/2900 val_loss:3.28118 train_time:4736.533s step_avg:1647.49ms
+step:2900/2900 val_loss:3.27899 train_time:4778.006s step_avg:1647.59ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed2.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed2.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T06:58:50Z
+Using seed=2
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed2_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.46935 train_time:213.580s step_avg:1708.64ms
+step:250/2900 val_loss:4.10625 train_time:424.217s step_avg:1696.87ms
+step:375/2900 val_loss:3.94872 train_time:635.401s step_avg:1694.40ms
+step:500/2900 val_loss:3.83366 train_time:846.034s step_avg:1692.07ms
+step:625/2900 val_loss:3.75903 train_time:1057.348s step_avg:1691.76ms
+step:750/2900 val_loss:3.71256 train_time:1268.020s step_avg:1690.69ms
+step:875/2900 val_loss:3.66938 train_time:1479.123s step_avg:1690.43ms
+step:1000/2900 val_loss:3.63089 train_time:1689.361s step_avg:1689.36ms
+step:1125/2900 val_loss:3.60486 train_time:1900.703s step_avg:1689.51ms
+step:1250/2900 val_loss:3.57388 train_time:2111.676s step_avg:1689.34ms
+step:1375/2900 val_loss:3.55026 train_time:2322.473s step_avg:1689.07ms
+step:1500/2900 val_loss:3.51676 train_time:2533.143s step_avg:1688.76ms
+step:1625/2900 val_loss:3.49711 train_time:2744.301s step_avg:1688.80ms
+step:1750/2900 val_loss:3.46740 train_time:2954.771s step_avg:1688.44ms
+step:1875/2900 val_loss:3.44049 train_time:3166.076s step_avg:1688.57ms
+step:2000/2900 val_loss:3.41481 train_time:3376.628s step_avg:1688.31ms
+step:2125/2900 val_loss:3.39129 train_time:3588.034s step_avg:1688.49ms
+step:2250/2900 val_loss:3.36849 train_time:3798.685s step_avg:1688.30ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34747 train_time:4010.316s step_avg:1688.55ms
+step:2500/2900 val_loss:3.32756 train_time:4221.076s step_avg:1688.43ms
+step:2625/2900 val_loss:3.30669 train_time:4433.788s step_avg:1689.06ms
+step:2750/2900 val_loss:3.29235 train_time:4648.995s step_avg:1690.54ms
+step:2875/2900 val_loss:3.28075 train_time:4864.531s step_avg:1692.01ms
+step:2900/2900 val_loss:3.27857 train_time:4907.369s step_avg:1692.20ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed3.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed3.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T08:24:01Z
+Using seed=3
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed3_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.45978 train_time:207.198s step_avg:1657.59ms
+step:250/2900 val_loss:4.10593 train_time:411.092s step_avg:1644.37ms
+step:375/2900 val_loss:3.94819 train_time:616.136s step_avg:1643.03ms
+step:500/2900 val_loss:3.83563 train_time:820.305s step_avg:1640.61ms
+step:625/2900 val_loss:3.76220 train_time:1024.792s step_avg:1639.67ms
+step:750/2900 val_loss:3.71240 train_time:1228.851s step_avg:1638.47ms
+step:875/2900 val_loss:3.66996 train_time:1433.621s step_avg:1638.42ms
+step:1000/2900 val_loss:3.63269 train_time:1637.933s step_avg:1637.93ms
+step:1125/2900 val_loss:3.60584 train_time:1842.794s step_avg:1638.04ms
+step:1250/2900 val_loss:3.57279 train_time:2046.980s step_avg:1637.58ms
+step:1375/2900 val_loss:3.54599 train_time:2251.834s step_avg:1637.70ms
+step:1500/2900 val_loss:3.51722 train_time:2456.115s step_avg:1637.41ms
+step:1625/2900 val_loss:3.49651 train_time:2661.004s step_avg:1637.54ms
+step:1750/2900 val_loss:3.46726 train_time:2865.262s step_avg:1637.29ms
+step:1875/2900 val_loss:3.43996 train_time:3069.954s step_avg:1637.31ms
+step:2000/2900 val_loss:3.41413 train_time:3273.968s step_avg:1636.98ms
+step:2125/2900 val_loss:3.39055 train_time:3478.829s step_avg:1637.10ms
+step:2250/2900 val_loss:3.36790 train_time:3682.952s step_avg:1636.87ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34686 train_time:3888.067s step_avg:1637.08ms
+step:2500/2900 val_loss:3.32684 train_time:4092.297s step_avg:1636.92ms
+step:2625/2900 val_loss:3.30609 train_time:4298.090s step_avg:1637.37ms
+step:2750/2900 val_loss:3.29196 train_time:4505.879s step_avg:1638.50ms
+step:2875/2900 val_loss:3.28038 train_time:4714.093s step_avg:1639.68ms
+step:2900/2900 val_loss:3.27819 train_time:4755.410s step_avg:1639.80ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed4.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed4.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T04:13:09Z
+Using seed=4
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed4_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.48192 train_time:209.391s step_avg:1675.13ms
+step:250/2900 val_loss:4.11066 train_time:416.176s step_avg:1664.70ms
+step:375/2900 val_loss:3.95146 train_time:624.665s step_avg:1665.77ms
+step:500/2900 val_loss:3.83745 train_time:832.807s step_avg:1665.61ms
+step:625/2900 val_loss:3.76345 train_time:1041.402s step_avg:1666.24ms
+step:750/2900 val_loss:3.71558 train_time:1249.347s step_avg:1665.80ms
+step:875/2900 val_loss:3.67189 train_time:1457.899s step_avg:1666.17ms
+step:1000/2900 val_loss:3.63265 train_time:1665.779s step_avg:1665.78ms
+step:1125/2900 val_loss:3.60653 train_time:1874.180s step_avg:1665.94ms
+step:1250/2900 val_loss:3.57573 train_time:2082.312s step_avg:1665.85ms
+step:1375/2900 val_loss:3.54982 train_time:2291.129s step_avg:1666.28ms
+step:1500/2900 val_loss:3.51892 train_time:2499.246s step_avg:1666.16ms
+step:1625/2900 val_loss:3.49716 train_time:2708.091s step_avg:1666.52ms
+step:1750/2900 val_loss:3.46837 train_time:2916.520s step_avg:1666.58ms
+step:1875/2900 val_loss:3.44131 train_time:3125.156s step_avg:1666.75ms
+step:2000/2900 val_loss:3.41572 train_time:3333.549s step_avg:1666.77ms
+step:2125/2900 val_loss:3.39200 train_time:3542.301s step_avg:1666.97ms
+step:2250/2900 val_loss:3.36850 train_time:3750.637s step_avg:1666.95ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34780 train_time:3959.360s step_avg:1667.10ms
+step:2500/2900 val_loss:3.32795 train_time:4167.896s step_avg:1667.16ms
+step:2625/2900 val_loss:3.30671 train_time:4377.989s step_avg:1667.81ms
+step:2750/2900 val_loss:3.29244 train_time:4589.565s step_avg:1668.93ms
+step:2875/2900 val_loss:3.28087 train_time:4800.692s step_avg:1669.81ms
+step:2900/2900 val_loss:3.27867 train_time:4842.459s step_avg:1669.81ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed5.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed5.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T09:46:38Z
+Using seed=5
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed5_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.46750 train_time:207.809s step_avg:1662.48ms
+step:250/2900 val_loss:4.09800 train_time:412.621s step_avg:1650.48ms
+step:375/2900 val_loss:3.94786 train_time:617.792s step_avg:1647.45ms
+step:500/2900 val_loss:3.83507 train_time:822.521s step_avg:1645.04ms
+step:625/2900 val_loss:3.76411 train_time:1027.584s step_avg:1644.13ms
+step:750/2900 val_loss:3.71367 train_time:1232.454s step_avg:1643.27ms
+step:875/2900 val_loss:3.67012 train_time:1437.877s step_avg:1643.29ms
+step:1000/2900 val_loss:3.63021 train_time:1642.936s step_avg:1642.94ms
+step:1125/2900 val_loss:3.60465 train_time:1848.933s step_avg:1643.50ms
+step:1250/2900 val_loss:3.57458 train_time:2053.653s step_avg:1642.92ms
+step:1375/2900 val_loss:3.54943 train_time:2259.175s step_avg:1643.04ms
+step:1500/2900 val_loss:3.51827 train_time:2464.351s step_avg:1642.90ms
+step:1625/2900 val_loss:3.49591 train_time:2669.847s step_avg:1642.98ms
+step:1750/2900 val_loss:3.46765 train_time:2875.215s step_avg:1642.98ms
+step:1875/2900 val_loss:3.44174 train_time:3080.963s step_avg:1643.18ms
+step:2000/2900 val_loss:3.41534 train_time:3285.585s step_avg:1642.79ms
+step:2125/2900 val_loss:3.39165 train_time:3491.020s step_avg:1642.83ms
+step:2250/2900 val_loss:3.36875 train_time:3695.862s step_avg:1642.61ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34771 train_time:3900.803s step_avg:1642.44ms
+step:2500/2900 val_loss:3.32791 train_time:4104.864s step_avg:1641.95ms
+step:2625/2900 val_loss:3.30665 train_time:4310.320s step_avg:1642.03ms
+step:2750/2900 val_loss:3.29239 train_time:4517.792s step_avg:1642.83ms
+step:2875/2900 val_loss:3.28079 train_time:4725.776s step_avg:1643.75ms
+step:2900/2900 val_loss:3.27855 train_time:4767.208s step_avg:1643.86ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed6.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed6.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T05:37:11Z
+Using seed=6
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed6_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.48199 train_time:202.914s step_avg:1623.31ms
+step:250/2900 val_loss:4.11007 train_time:402.986s step_avg:1611.94ms
+step:375/2900 val_loss:3.95722 train_time:604.241s step_avg:1611.31ms
+step:500/2900 val_loss:3.83419 train_time:804.744s step_avg:1609.49ms
+step:625/2900 val_loss:3.76292 train_time:1006.944s step_avg:1611.11ms
+step:750/2900 val_loss:3.71273 train_time:1208.146s step_avg:1610.86ms
+step:875/2900 val_loss:3.67067 train_time:1410.656s step_avg:1612.18ms
+step:1000/2900 val_loss:3.63186 train_time:1612.081s step_avg:1612.08ms
+step:1125/2900 val_loss:3.60643 train_time:1814.728s step_avg:1613.09ms
+step:1250/2900 val_loss:3.57469 train_time:2016.954s step_avg:1613.56ms
+step:1375/2900 val_loss:3.54800 train_time:2219.371s step_avg:1614.09ms
+step:1500/2900 val_loss:3.51887 train_time:2421.206s step_avg:1614.14ms
+step:1625/2900 val_loss:3.49696 train_time:2623.476s step_avg:1614.45ms
+step:1750/2900 val_loss:3.46691 train_time:2825.284s step_avg:1614.45ms
+step:1875/2900 val_loss:3.44010 train_time:3027.837s step_avg:1614.85ms
+step:2000/2900 val_loss:3.41438 train_time:3230.248s step_avg:1615.12ms
+step:2125/2900 val_loss:3.39161 train_time:3432.754s step_avg:1615.41ms
+step:2250/2900 val_loss:3.36829 train_time:3634.982s step_avg:1615.55ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34720 train_time:3837.967s step_avg:1615.99ms
+step:2500/2900 val_loss:3.32740 train_time:4039.973s step_avg:1615.99ms
+step:2625/2900 val_loss:3.30644 train_time:4243.749s step_avg:1616.67ms
+step:2750/2900 val_loss:3.29216 train_time:4449.254s step_avg:1617.91ms
+step:2875/2900 val_loss:3.28074 train_time:4655.100s step_avg:1619.17ms
+step:2900/2900 val_loss:3.27853 train_time:4695.982s step_avg:1619.30ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed7.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed7.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T11:09:27Z
+Using seed=7
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed7_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.47876 train_time:211.977s step_avg:1695.81ms
+step:250/2900 val_loss:4.10294 train_time:420.360s step_avg:1681.44ms
+step:375/2900 val_loss:3.94802 train_time:628.704s step_avg:1676.54ms
+step:500/2900 val_loss:3.83408 train_time:836.268s step_avg:1672.54ms
+step:625/2900 val_loss:3.76136 train_time:1045.006s step_avg:1672.01ms
+step:750/2900 val_loss:3.71180 train_time:1253.475s step_avg:1671.30ms
+step:875/2900 val_loss:3.67034 train_time:1462.403s step_avg:1671.32ms
+step:1000/2900 val_loss:3.62962 train_time:1670.839s step_avg:1670.84ms
+step:1125/2900 val_loss:3.60559 train_time:1879.407s step_avg:1670.58ms
+step:1250/2900 val_loss:3.57299 train_time:2087.442s step_avg:1669.95ms
+step:1375/2900 val_loss:3.54859 train_time:2296.303s step_avg:1670.04ms
+step:1500/2900 val_loss:3.51992 train_time:2504.749s step_avg:1669.83ms
+step:1625/2900 val_loss:3.49895 train_time:2714.112s step_avg:1670.22ms
+step:1750/2900 val_loss:3.46717 train_time:2923.101s step_avg:1670.34ms
+step:1875/2900 val_loss:3.44046 train_time:3132.909s step_avg:1670.88ms
+step:2000/2900 val_loss:3.41465 train_time:3342.569s step_avg:1671.28ms
+step:2125/2900 val_loss:3.39132 train_time:3552.619s step_avg:1671.82ms
+step:2250/2900 val_loss:3.36779 train_time:3762.261s step_avg:1672.12ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34705 train_time:3972.236s step_avg:1672.52ms
+step:2500/2900 val_loss:3.32710 train_time:4181.469s step_avg:1672.59ms
+step:2625/2900 val_loss:3.30613 train_time:4392.423s step_avg:1673.30ms
+step:2750/2900 val_loss:3.29193 train_time:4605.612s step_avg:1674.77ms
+step:2875/2900 val_loss:3.28026 train_time:4819.137s step_avg:1676.22ms
+step:2900/2900 val_loss:3.27805 train_time:4861.523s step_avg:1676.39ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed8.txt
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed8.txt
@@ -1,0 +1,1912 @@
+"""
+radial_scale_then_radius_correct.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+dampen radial gradient component
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+The SOAP-like preconditioning from samacqua / PR 278 is also applied to the attention value-projection (V) matrices in this submission.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with local overrides for 2900-step target sweeps.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3050"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "pr300-aurora-proj-tempered-polar"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2500"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", str(TARGET_UW)))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "0"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "0"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", str(TARGET_UW_LATE)))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", str(RADIAL_OUTWARD_SCALE)))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "0"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "0"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", "2800"))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "0"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "0"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "0"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "0.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "0"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "0.0"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/track3_late"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"pr300_tp2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.9.1+cu128 compiled for CUDA 12.8
+Running on device_name=NVIDIA GH200 480GB with world_size=1
+Run UTC timestamp=2026-05-20T13:58:11Z
+Using seed=8
+Experiment=pr300-aurora-proj-tempered-polar
+Intuition=PR300 Aurora-on-mlp.proj stack plus conservative tempered-polar residual after Newton-Schulz.
+Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.
+This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.
+MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.
+Schedule uses hardcoded PR 287 cooldown constants with train_steps=2900, schedule_steps=3020.
+Using contra_muon_coeff=-0.2
+Using soft_muon_p=0.1
+Using soft_muon_scale=none
+Using soft_muon_input_norm=frobenius_schatten4
+Using soft_muon_ceil=0.0
+Using contra_hold_end_step=0
+Using contra_to_normal_end_step=2750
+Using normal_to_soft_start_step=2500
+Using normal_to_soft_end_step=3010
+Using mu=0.95
+Using muon_lr=0.0375
+Using adam_lr_late_mult=1.0
+Using adam_lr_ramp_start_step=0
+Using adam_lr_ramp_end_step=0
+Using muon_lr_late_mult=1.0
+Using muon_lr_ramp_start_step=0
+Using muon_lr_ramp_end_step=0
+Using muon_weight_decay=0.025
+Using target_uw=0.3825
+Using target_uw_late=0.4
+Using target_uw_ramp_start_step=2400
+Using target_uw_ramp_end_step=2800
+Using target_uw_final=0.4
+Using target_uw_decay_start_step=0
+Using target_uw_decay_end_step=0
+Using target_uw_deficit_gate=0.0
+Using target_uw_scope=all
+Using train_loss_ema_beta=0.98
+Using target_uw_adapt_mode=off
+Using target_uw_adapt_decide_step=2375
+Using target_uw_adapt_threshold=inf
+Using target_uw_adapt_direction=high
+Using soap_target_uw=0.3825
+Using nonsoap_target_uw=0.3825
+Using di_fc_alpha=0.3
+Using cgi_alpha=0.14
+Using nor_beta2=1.0
+Using soap_beta2=0.9
+Using soap_precondition_frequency=10
+Using soap_denom_power=0.5
+Using soap_blend=1.0
+Using soap_update_before_use=False
+Using soap_param_mode=mlp_plus_v
+Using attn_soap_denom_floor=0.55
+Using attn_soap_blend=1.0
+Using v_soap_blend=0.95
+Using v_soap_blend_ramp_end_step=0
+Using attn_early_trust_floor=0.45
+Using attn_early_trust_cap=0.85
+Using attn_trust_floor_end_step=1375
+Using attn_trust_floor_fade_end_step=1625
+Using attn_trust_min_agree=0.2
+Using attn_trust_min_grad_align=0.0
+Using attn_trust_power=1.0
+Using attn_soap_fade_start_step=1000000000
+Using attn_soap_fade_end_step=1000000000
+Using no_contra_param=
+Using no_softmuon_param=
+Using radial_outward_scale=0.5
+Using radial_inward_scale=1.0
+Using radial_outward_scale_late=0.4
+Using radial_decay_start_step=2400
+Using radial_decay_end_step=2900
+Using radial_adapt_start_step=0
+Using radial_adapt_end_step=0
+Using radial_adapt_k=0.0
+Using radial_adapt_max_extra=0.0
+Using radial_adapt_target_mult=1.0
+Using agree_shrink_enabled=False
+Using agree_shrink_start_step=0
+Using agree_shrink_beta=0.95
+Using agree_shrink_cos_min=0.2
+Using agree_shrink_alpha=0.0
+Using dense_eval_start=2900
+Using dense_eval_end=2900
+Using dense_eval_stride=10
+Using tempered_polar_rho=0.05
+Using tempered_polar_max_delta=0.25
+Using tempered_polar_decay_start_step=0
+Using tempered_polar_decay_end_step=0
+Using tempered_polar_final_rho=0.0
+Using tempered_polar_ramp_start_step=2600
+Using tempered_polar_ramp_end_step=2800
+Using tempered_polar_skip_mlp_proj=False
+Using aurora_relax_lambda=0.0
+Using aurora_relax_max_delta=0.25
+Using aurora_relax_ramp_start_step=0
+Using aurora_relax_ramp_end_step=0
+Using aurora_beta=0.25
+Using aurora_beta_late=0.25
+Using aurora_beta_decay_start_step=0
+Using aurora_beta_decay_end_step=0
+Using tail_ema_enabled=False
+Using tail_ema_start_step=0
+Using tail_ema_beta=0.97
+Using tail_ema_gamma=0.0
+Using tail_ema_max_delta_ratio=0.02
+Using tail_ema_eval_gammas=[]
+Using tail_ema_extra_eval_start_step=2900
+Using tail_vel_enabled=True
+Using tail_vel_start_step=2500
+Using tail_vel_beta=0.9
+Using tail_vel_gamma=-6.0
+Using tail_vel_max_delta_ratio=0.01
+Using tail_vel_eval_gammas=[]
+Using tail_vel_extra_eval_start_step=2900
+Using muon_weight_scale_eval_factors=[]
+Using muon_weight_scale_extra_eval_start_step=2900
+Using proj_weight_scale_eval_factors=[]
+Using proj_weight_scale_extra_eval_start_step=2900
+Using ref_extrap_checkpoint=
+Using ref_extrap_capture_step=2375
+Using ref_extrap_gamma=-0.075
+Using ref_extrap_apply_start_step=2900
+Using ref_extrap_eval_gammas=[]
+Using ref_extrap_extra_eval_start_step=2900
+Using muon_mu_min=0.85
+Using muon_mu_max=0.95
+Using muon_mu_late=0.85
+Using muon_mu_warmup_steps=300
+Using muon_mu_cooldown_steps=100
+Using muon_mu_reheat_start_step=0
+Using muon_mu_reheat_end_step=0
+Using muon_mu_reheat_final=0.95
+Using checkpoint_dir=checkpoints/track3_late
+Using checkpoint_prefix=full_seed8_refinterp
+Using save_checkpoint_steps=[]
+Using load_checkpoint=
+Using exit_after_save_checkpoint=False
+Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.
+====================================================================================================
+step:125/2900 val_loss:4.46709 train_time:209.813s step_avg:1678.50ms
+step:250/2900 val_loss:4.10539 train_time:416.450s step_avg:1665.80ms
+step:375/2900 val_loss:3.95324 train_time:623.878s step_avg:1663.67ms
+step:500/2900 val_loss:3.84262 train_time:830.476s step_avg:1660.95ms
+step:625/2900 val_loss:3.76490 train_time:1037.881s step_avg:1660.61ms
+step:750/2900 val_loss:3.71546 train_time:1244.506s step_avg:1659.34ms
+step:875/2900 val_loss:3.67266 train_time:1451.994s step_avg:1659.42ms
+step:1000/2900 val_loss:3.63233 train_time:1658.748s step_avg:1658.75ms
+step:1125/2900 val_loss:3.60724 train_time:1865.821s step_avg:1658.51ms
+step:1250/2900 val_loss:3.57579 train_time:2072.250s step_avg:1657.80ms
+step:1375/2900 val_loss:3.55130 train_time:2279.437s step_avg:1657.77ms
+step:1500/2900 val_loss:3.51903 train_time:2485.915s step_avg:1657.28ms
+step:1625/2900 val_loss:3.49768 train_time:2692.779s step_avg:1657.09ms
+step:1750/2900 val_loss:3.46922 train_time:2899.308s step_avg:1656.75ms
+step:1875/2900 val_loss:3.44172 train_time:3106.544s step_avg:1656.82ms
+step:2000/2900 val_loss:3.41622 train_time:3313.271s step_avg:1656.64ms
+step:2125/2900 val_loss:3.39218 train_time:3521.003s step_avg:1656.94ms
+step:2250/2900 val_loss:3.36929 train_time:3727.684s step_avg:1656.75ms
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34864 train_time:3935.021s step_avg:1656.85ms
+step:2500/2900 val_loss:3.32881 train_time:4142.060s step_avg:1656.82ms
+step:2625/2900 val_loss:3.30753 train_time:4350.548s step_avg:1657.35ms
+step:2750/2900 val_loss:3.29346 train_time:4560.883s step_avg:1658.50ms
+step:2875/2900 val_loss:3.28178 train_time:4772.155s step_avg:1659.88ms
+step:2900/2900 val_loss:3.27960 train_time:4814.127s step_avg:1660.04ms

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduce the exact-2900 Tail Reference Interpolation candidate.
+# By default this replays the submitted seeds 0..8 sequentially on one node.
+# Override SEEDS for a shorter or longer fixed seed list, e.g. SEEDS="0 1".
+
+SEEDS="${SEEDS:-0 1 2 3 4 5 6 7 8}"
+BASE_MASTER_PORT="${BASE_MASTER_PORT:-29600}"
+MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+LOCAL_ADDR="${LOCAL_ADDR:-127.0.0.1}"
+NPROC_PER_NODE="${NPROC_PER_NODE:-1}"
+LOG_DIR="${LOG_DIR:-logs/track3_tail_refinterp_2900}"
+SCRIPT="records/track_3_optimization/results/20260520_tail_refinterp_2900/train_gpt_tail_refinterp_2900.py"
+
+mkdir -p "$LOG_DIR"
+
+for seed in $SEEDS; do
+  port=$((BASE_MASTER_PORT + seed))
+  echo "Running seed ${seed} on port ${port}"
+  TRAIN_STEPS="${TRAIN_STEPS:-2900}" \
+  SCHEDULE_STEPS="${SCHEDULE_STEPS:-3020}" \
+  DENSE_EVAL_START="${DENSE_EVAL_START:-2900}" \
+  DENSE_EVAL_END="${DENSE_EVAL_END:-2900}" \
+  DENSE_EVAL_STRIDE="${DENSE_EVAL_STRIDE:-10}" \
+  CONTRA_TO_NORMAL_END_STEP="${CONTRA_TO_NORMAL_END_STEP:-2750}" \
+  TEMPERED_POLAR_RHO="${TEMPERED_POLAR_RHO:-0.05}" \
+  TEMPERED_POLAR_MAX_DELTA="${TEMPERED_POLAR_MAX_DELTA:-0.25}" \
+  TEMPERED_POLAR_RAMP_START_STEP="${TEMPERED_POLAR_RAMP_START_STEP:-2600}" \
+  TEMPERED_POLAR_RAMP_END_STEP="${TEMPERED_POLAR_RAMP_END_STEP:-2800}" \
+  RADIAL_OUTWARD_SCALE="${RADIAL_OUTWARD_SCALE:-0.5}" \
+  RADIAL_OUTWARD_SCALE_LATE="${RADIAL_OUTWARD_SCALE_LATE:-0.4}" \
+  RADIAL_DECAY_START_STEP="${RADIAL_DECAY_START_STEP:-2400}" \
+  RADIAL_DECAY_END_STEP="${RADIAL_DECAY_END_STEP:-2900}" \
+  TAIL_EMA_START_STEP="${TAIL_EMA_START_STEP:-0}" \
+  TAIL_EMA_GAMMA="${TAIL_EMA_GAMMA:-0.0}" \
+  TAIL_VEL_START_STEP="${TAIL_VEL_START_STEP:-2500}" \
+  TAIL_VEL_BETA="${TAIL_VEL_BETA:-0.90}" \
+  TAIL_VEL_GAMMA="${TAIL_VEL_GAMMA:--6.0}" \
+  TAIL_VEL_MAX_DELTA_RATIO="${TAIL_VEL_MAX_DELTA_RATIO:-0.01}" \
+  TARGET_UW_LATE="${TARGET_UW_LATE:-0.400}" \
+  TARGET_UW_RAMP_START_STEP="${TARGET_UW_RAMP_START_STEP:-2400}" \
+  TARGET_UW_RAMP_END_STEP="${TARGET_UW_RAMP_END_STEP:-2800}" \
+  TARGET_UW_FINAL="${TARGET_UW_FINAL:-0.400}" \
+  TARGET_UW_DECAY_START_STEP="${TARGET_UW_DECAY_START_STEP:-0}" \
+  TARGET_UW_DECAY_END_STEP="${TARGET_UW_DECAY_END_STEP:-0}" \
+  TARGET_UW_SCOPE="${TARGET_UW_SCOPE:-all}" \
+  REF_EXTRAP_CAPTURE_STEP="${REF_EXTRAP_CAPTURE_STEP:-2375}" \
+  REF_EXTRAP_GAMMA="${REF_EXTRAP_GAMMA:--0.075}" \
+  REF_EXTRAP_APPLY_START_STEP="${REF_EXTRAP_APPLY_START_STEP:-2900}" \
+  CHECKPOINT_PREFIX="${CHECKPOINT_PREFIX:-tail_refinterp_2900_seed${seed}}" \
+  torchrun \
+    --nnodes=1 \
+    --nproc_per_node="$NPROC_PER_NODE" \
+    --master_addr="$MASTER_ADDR" \
+    --master_port="$port" \
+    --local_addr="$LOCAL_ADDR" \
+    "$SCRIPT" \
+    --seed "$seed" \
+    2>&1 | tee "$LOG_DIR/tail_refinterp_2900_seed${seed}.txt"
+done

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/summarize_submission_stats.py
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/summarize_submission_stats.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import re
+from pathlib import Path
+
+
+VAL_RE = re.compile(r"step:(\d+)/(\d+)\s+val_loss:([0-9.]+)")
+EXTRA_EVAL_RE = re.compile(
+    r"(xewa_eval|tail_vel_eval)\s+step:(\d+)/(\d+)\s+gamma:([-+0-9.eE]+)\s+val_loss:([0-9.]+)"
+)
+CONFIG_GAMMA_RE = re.compile(r"Using (tail_ema_gamma|tail_vel_gamma)=([-+0-9.eE]+)")
+TAIL_VEL_FILENAME_GAMMA_RE = re.compile(r"_vg([-+]?[0-9]+(?:p[0-9]+)?)_")
+XEWA_FILENAME_GAMMA_RE = re.compile(r"_g([-+]?[0-9]+(?:p[0-9]+)?)_md")
+
+EVAL_KIND_TO_PREFIX = {
+    "xewa": "xewa_eval",
+    "tail_vel": "tail_vel_eval",
+}
+EVAL_KIND_TO_CONFIG_KEY = {
+    "xewa": "tail_ema_gamma",
+    "tail_vel": "tail_vel_gamma",
+}
+
+
+def same_float(left: float, right: float) -> bool:
+    return abs(left - right) <= 1e-12
+
+
+def parse_filename_gamma(path: Path, eval_kind: str) -> float | None:
+    if eval_kind == "tail_vel":
+        match = TAIL_VEL_FILENAME_GAMMA_RE.search(path.name)
+    elif eval_kind == "xewa":
+        match = XEWA_FILENAME_GAMMA_RE.search(path.name)
+    else:
+        match = None
+    if match is None:
+        return None
+    return float(match.group(1).replace("p", "."))
+
+
+def parse_loss(path: Path, step: int | None, eval_kind: str, gamma: float | None) -> tuple[int, float]:
+    matches: list[tuple[int, float]] = []
+    extra_matches: list[tuple[int, float]] = []
+    config_gamma = parse_filename_gamma(path, eval_kind)
+    text = path.read_text(errors="replace")
+    for line in text.splitlines():
+        config_match = CONFIG_GAMMA_RE.search(line)
+        if (
+            config_match is not None
+            and eval_kind != "standard"
+            and config_match.group(1) == EVAL_KIND_TO_CONFIG_KEY[eval_kind]
+        ):
+            config_gamma = float(config_match.group(2))
+
+        match = VAL_RE.search(line)
+        if match is not None:
+            current_step = int(match.group(1))
+            total_step = int(match.group(2))
+            loss = float(match.group(3))
+            if step is None:
+                if current_step == total_step:
+                    matches.append((current_step, loss))
+            elif current_step == step:
+                matches.append((current_step, loss))
+
+        extra_match = EXTRA_EVAL_RE.search(line)
+        if eval_kind != "standard" and gamma is not None and extra_match is not None:
+            current_prefix = extra_match.group(1)
+            current_step = int(extra_match.group(2))
+            total_step = int(extra_match.group(3))
+            current_gamma = float(extra_match.group(4))
+            loss = float(extra_match.group(5))
+            if current_prefix != EVAL_KIND_TO_PREFIX[eval_kind] or not same_float(current_gamma, gamma):
+                continue
+            if step is None:
+                if current_step == total_step:
+                    extra_matches.append((current_step, loss))
+            elif current_step == step:
+                extra_matches.append((current_step, loss))
+
+    if eval_kind != "standard":
+        if gamma is None:
+            raise ValueError("--gamma is required when --eval-kind is not standard")
+        if extra_matches:
+            return extra_matches[-1]
+        if config_gamma is not None and same_float(config_gamma, gamma) and matches:
+            return matches[-1]
+        requested = "final" if step is None else str(step)
+        raise ValueError(f"{path}: no {eval_kind} validation loss found for step {requested} and gamma {gamma:g}")
+
+    if not matches:
+        requested = "final" if step is None else str(step)
+        raise ValueError(f"{path}: no validation loss found for step {requested}")
+    return matches[-1]
+
+
+def normal_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--step", type=int, default=2985)
+    parser.add_argument("--eval-kind", choices=["standard", "xewa", "tail_vel"], default="standard")
+    parser.add_argument("--gamma", type=float)
+    parser.add_argument("--target", type=float, default=3.28)
+    parser.add_argument("--sigma", type=float, default=0.0013)
+    args = parser.parse_args()
+
+    rows = []
+    for path in args.logs:
+        step, loss = parse_loss(path, args.step, args.eval_kind, args.gamma)
+        rows.append((path, step, loss))
+
+    losses = [loss for _, _, loss in rows]
+    mean = sum(losses) / len(losses)
+    if len(losses) > 1:
+        variance = sum((loss - mean) ** 2 for loss in losses) / (len(losses) - 1)
+        std = math.sqrt(variance)
+        stderr = std / math.sqrt(len(losses))
+        t_stat = (mean - args.target) / stderr if stderr > 0 else float("-inf")
+    else:
+        std = float("nan")
+        stderr = float("nan")
+        t_stat = float("nan")
+
+    precision = (args.target - mean) * math.sqrt(len(losses))
+    z_stat = precision / args.sigma
+    z_pvalue = normal_cdf(-z_stat)
+    passes_track3 = precision >= 0.004
+
+    if len(losses) < 2:
+        pvalue_text = "needs_at_least_2_runs"
+    else:
+        try:
+            import scipy.stats
+
+            pvalue = scipy.stats.ttest_1samp(losses, args.target, alternative="less").pvalue
+            pvalue_text = f"{pvalue:.6g}"
+        except Exception as exc:
+            pvalue_text = f"unavailable ({exc}); normal_approx={normal_cdf(t_stat):.6g}"
+
+    print("logs:")
+    for path, step, loss in rows:
+        print(f"  {path} step={step} val_loss={loss:.5f}")
+    print(f"n={len(losses)}")
+    print(f"mean={mean:.6f}")
+    print(f"std={std:.6f}")
+    print(f"stderr={stderr:.6f}")
+    print(f"target={args.target:.6f}")
+    print(f"track3_sigma={args.sigma:.6f}")
+    print(f"track3_precision=(target-mean)*sqrt(n)={precision:.6f}")
+    print(f"track3_required_precision=0.004000")
+    print(f"track3_z={z_stat:.6f}")
+    print(f"track3_z_pvalue_less={z_pvalue:.6g}")
+    print(f"passes_track3_precision={passes_track3}")
+    print(f"t_stat={t_stat:.6f}")
+    print(f"ttest_pvalue_less={pvalue_text}")
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_3_optimization/results/20260520_tail_refinterp_2900/train_gpt_tail_refinterp_2900.py
+++ b/records/track_3_optimization/results/20260520_tail_refinterp_2900/train_gpt_tail_refinterp_2900.py
@@ -1,0 +1,1748 @@
+"""
+tail_refinterp_2900.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+---
+
+Exact-2900 Tail Reference Interpolation submission
+
+---
+
+This submission incorporates features from the following previous submissions
+
+@nilin PR291
+
+@kumarkrishna PR274 / Skylight-001
+  NorMuon-lite row/column variance normalization
+  u/w floor postprocessing
+  lr=0.0375 style Muon setup
+
+@nilin (me): PR275 / Contra-Muon
+  Introduces Contra-Muon update term
+
+@samacqua: PR278 / MLP SOAP preconditioning
+  SOAP preconditioning machinery / MLP SOAP idea.
+  Our script uses that SOAP machinery and extends the selected SOAP set to MLP+V.
+
+@yash-oai: PR287 / power law LR schedule
+  Power-law LR schedule PowerCool:
+  min(flat_lr, c * (t_end - step)^1.2)
+  PR287-style cooldown constants / schedule tuning.
+
+This exact-2900 candidate starts from the PR #300 Aurora-on-mlp.proj stack,
+extends Contra-Muon later, adds a late Tempered Polar residual, retunes late
+radial/u-w control, applies a final tail-velocity transform, and evaluates the
+step-2900 weights with a small interpolation back toward a step-2375 reference.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+SEED = args.seed
+# PR #300 base with defaults set to the exact-2900 reference-interpolation
+# submission candidate.
+FINAL_TRAIN_STEPS = int(os.environ.get("TRAIN_STEPS", "2900"))
+FINAL_SCHEDULE_STEPS = int(os.environ.get("SCHEDULE_STEPS", "3020"))
+FINAL_LR_POWER = 1.2
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+FINAL_MUON_WD = 0.025
+EXPERIMENT_NAME = "tail-reference-interpolation-2900"
+EXPERIMENT_INTUITION = "PR300 Aurora-on-mlp.proj stack with late optimizer retuning and final step-2375/2900 reference interpolation."
+CONTRA_MUON_COEFF = -0.2
+SOFT_MUON_P = 0.1
+SOFT_MUON_SCALE = "none"
+SOFT_MUON_INPUT_NORM = "frobenius_schatten4"
+SOFT_MUON_CEIL = 0.00
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = int(os.environ.get("CONTRA_TO_NORMAL_END_STEP", "2750"))
+NORMAL_TO_SOFT_START_STEP = int(os.environ.get("NORMAL_TO_SOFT_START_STEP", "2500"))
+NORMAL_TO_SOFT_END_STEP = int(os.environ.get("NORMAL_TO_SOFT_END_STEP", "3010"))
+MU = 0.95
+MUON_LR = 0.0375
+MUON_WEIGHT_DECAY = FINAL_MUON_WD
+ADAM_LR_LATE_MULT = float(os.environ.get("ADAM_LR_LATE_MULT", "1.0"))
+ADAM_LR_RAMP_START_STEP = int(os.environ.get("ADAM_LR_RAMP_START_STEP", "0"))
+ADAM_LR_RAMP_END_STEP = int(os.environ.get("ADAM_LR_RAMP_END_STEP", "0"))
+MUON_LR_LATE_MULT = float(os.environ.get("MUON_LR_LATE_MULT", "1.0"))
+MUON_LR_RAMP_START_STEP = int(os.environ.get("MUON_LR_RAMP_START_STEP", "0"))
+MUON_LR_RAMP_END_STEP = int(os.environ.get("MUON_LR_RAMP_END_STEP", "0"))
+TARGET_UW = 0.3825
+TARGET_UW_LATE = float(os.environ.get("TARGET_UW_LATE", "0.400"))
+TARGET_UW_RAMP_START_STEP = int(os.environ.get("TARGET_UW_RAMP_START_STEP", "2400"))
+TARGET_UW_RAMP_END_STEP = int(os.environ.get("TARGET_UW_RAMP_END_STEP", "2800"))
+TARGET_UW_FINAL = float(os.environ.get("TARGET_UW_FINAL", "0.400"))
+TARGET_UW_DECAY_START_STEP = int(os.environ.get("TARGET_UW_DECAY_START_STEP", "0"))
+TARGET_UW_DECAY_END_STEP = int(os.environ.get("TARGET_UW_DECAY_END_STEP", "0"))
+TARGET_UW_DEFICIT_GATE = float(os.environ.get("TARGET_UW_DEFICIT_GATE", "0.0"))
+TARGET_UW_SCOPE = os.environ.get("TARGET_UW_SCOPE", "all")
+TRAIN_LOSS_EMA_BETA = float(os.environ.get("TRAIN_LOSS_EMA_BETA", "0.98"))
+TARGET_UW_ADAPT_MODE = os.environ.get("TARGET_UW_ADAPT_MODE", "off")
+TARGET_UW_ADAPT_DECIDE_STEP = int(os.environ.get("TARGET_UW_ADAPT_DECIDE_STEP", "2375"))
+TARGET_UW_ADAPT_THRESHOLD = float(os.environ.get("TARGET_UW_ADAPT_THRESHOLD", "inf"))
+TARGET_UW_ADAPT_DIRECTION = os.environ.get("TARGET_UW_ADAPT_DIRECTION", "high")
+SOAP_TARGET_UW = TARGET_UW
+NONSOAP_TARGET_UW = TARGET_UW
+DI_FC_ALPHA = float(os.environ.get("DI_FC_ALPHA", "0.30"))
+CGI_ALPHA = float(os.environ.get("CGI_ALPHA", "0.14"))
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+SOAP_UPDATE_BEFORE_USE = False
+SOAP_PARAM_MODE = "mlp_plus_v"
+ATTN_SOAP_DENOM_FLOOR = 0.55
+ATTN_SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+V_SOAP_BLEND_RAMP_END_STEP = 0
+ATTN_EARLY_TRUST_FLOOR = 0.45
+ATTN_EARLY_TRUST_CAP = 0.85
+ATTN_TRUST_FLOOR_END_STEP = 1375
+ATTN_TRUST_FLOOR_FADE_END_STEP = 1625
+ATTN_TRUST_MIN_AGREE = 0.20
+ATTN_TRUST_MIN_GRAD_ALIGN = 0.00
+ATTN_TRUST_POWER = 1.00
+ATTN_SOAP_FADE_START_STEP = 1000000000
+ATTN_SOAP_FADE_END_STEP = 1000000000
+NO_CONTRA_PARAM = ""
+NO_SOFTMUON_PARAM = ""
+TRAIN_PROGRESS_INTERVAL = 0
+LOG_DIR = Path("logs")
+RADIAL_OUTWARD_SCALE = float(os.environ.get("RADIAL_OUTWARD_SCALE", "0.5"))
+RADIAL_INWARD_SCALE = float(os.environ.get("RADIAL_INWARD_SCALE", "1.0"))
+RADIAL_OUTWARD_SCALE_LATE = float(os.environ.get("RADIAL_OUTWARD_SCALE_LATE", "0.4"))
+RADIAL_DECAY_START_STEP = int(os.environ.get("RADIAL_DECAY_START_STEP", "2400"))
+RADIAL_DECAY_END_STEP = int(os.environ.get("RADIAL_DECAY_END_STEP", "2900"))
+RADIAL_ADAPT_START_STEP = int(os.environ.get("RADIAL_ADAPT_START_STEP", "0"))
+RADIAL_ADAPT_END_STEP = int(os.environ.get("RADIAL_ADAPT_END_STEP", "0"))
+RADIAL_ADAPT_K = float(os.environ.get("RADIAL_ADAPT_K", "0.0"))
+RADIAL_ADAPT_MAX_EXTRA = float(os.environ.get("RADIAL_ADAPT_MAX_EXTRA", "0.0"))
+RADIAL_ADAPT_TARGET_MULT = float(os.environ.get("RADIAL_ADAPT_TARGET_MULT", "1.0"))
+AGREE_SHRINK_START_STEP = int(os.environ.get("AGREE_SHRINK_START_STEP", "0"))
+AGREE_SHRINK_BETA = float(os.environ.get("AGREE_SHRINK_BETA", "0.95"))
+AGREE_SHRINK_COS_MIN = float(os.environ.get("AGREE_SHRINK_COS_MIN", "0.20"))
+AGREE_SHRINK_ALPHA = float(os.environ.get("AGREE_SHRINK_ALPHA", "0.0"))
+AGREE_SHRINK_ENABLED = AGREE_SHRINK_ALPHA != 0.0 and AGREE_SHRINK_START_STEP > 0
+DENSE_EVAL_START = int(os.environ.get("DENSE_EVAL_START", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_END = int(os.environ.get("DENSE_EVAL_END", str(FINAL_TRAIN_STEPS)))
+DENSE_EVAL_STRIDE = int(os.environ.get("DENSE_EVAL_STRIDE", "10"))
+TEMPERED_POLAR_RHO = float(os.environ.get("TEMPERED_POLAR_RHO", "0.05"))
+TEMPERED_POLAR_MAX_DELTA = float(os.environ.get("TEMPERED_POLAR_MAX_DELTA", "0.25"))
+TEMPERED_POLAR_DECAY_START_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_START_STEP", "0"))
+TEMPERED_POLAR_DECAY_END_STEP = int(os.environ.get("TEMPERED_POLAR_DECAY_END_STEP", "0"))
+TEMPERED_POLAR_FINAL_RHO = float(os.environ.get("TEMPERED_POLAR_FINAL_RHO", "0.0"))
+TEMPERED_POLAR_RAMP_START_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_START_STEP", "2600"))
+TEMPERED_POLAR_RAMP_END_STEP = int(os.environ.get("TEMPERED_POLAR_RAMP_END_STEP", "2800"))
+TEMPERED_POLAR_SKIP_MLP_PROJ = bool(int(os.environ.get("TEMPERED_POLAR_SKIP_MLP_PROJ", "0")))
+AURORA_RELAX_LAMBDA = float(os.environ.get("AURORA_RELAX_LAMBDA", "0.0"))
+AURORA_RELAX_MAX_DELTA = float(os.environ.get("AURORA_RELAX_MAX_DELTA", "0.25"))
+AURORA_RELAX_RAMP_START_STEP = int(os.environ.get("AURORA_RELAX_RAMP_START_STEP", "0"))
+AURORA_RELAX_RAMP_END_STEP = int(os.environ.get("AURORA_RELAX_RAMP_END_STEP", "0"))
+AURORA_BETA = float(os.environ.get("AURORA_BETA", "0.25"))
+AURORA_BETA_LATE = float(os.environ.get("AURORA_BETA_LATE", str(AURORA_BETA)))
+AURORA_BETA_DECAY_START_STEP = int(os.environ.get("AURORA_BETA_DECAY_START_STEP", "0"))
+AURORA_BETA_DECAY_END_STEP = int(os.environ.get("AURORA_BETA_DECAY_END_STEP", "0"))
+
+def parse_float_list(raw: str) -> list[float]:
+    if not raw.strip():
+        return []
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+def parse_int_list(raw: str) -> set[int]:
+    if not raw.strip():
+        return set()
+    return {int(part.strip()) for part in raw.split(",") if part.strip()}
+
+TAIL_EMA_START_STEP = int(os.environ.get("TAIL_EMA_START_STEP", "0"))
+TAIL_EMA_BETA = float(os.environ.get("TAIL_EMA_BETA", "0.97"))
+TAIL_EMA_GAMMA = float(os.environ.get("TAIL_EMA_GAMMA", "0.0"))
+TAIL_EMA_MAX_DELTA_RATIO = float(os.environ.get("TAIL_EMA_MAX_DELTA_RATIO", "0.02"))
+TAIL_EMA_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_EMA_EVAL_GAMMAS", ""))
+TAIL_EMA_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_EMA_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_EMA_ENABLED = (
+    TAIL_EMA_START_STEP > 0
+    and (TAIL_EMA_GAMMA != 0.0 or len(TAIL_EMA_EVAL_GAMMAS) > 0)
+)
+TAIL_VEL_START_STEP = int(os.environ.get("TAIL_VEL_START_STEP", "2500"))
+TAIL_VEL_BETA = float(os.environ.get("TAIL_VEL_BETA", "0.90"))
+TAIL_VEL_GAMMA = float(os.environ.get("TAIL_VEL_GAMMA", "-6.0"))
+TAIL_VEL_MAX_DELTA_RATIO = float(os.environ.get("TAIL_VEL_MAX_DELTA_RATIO", "0.01"))
+TAIL_VEL_EVAL_GAMMAS = parse_float_list(os.environ.get("TAIL_VEL_EVAL_GAMMAS", ""))
+TAIL_VEL_EXTRA_EVAL_START_STEP = int(os.environ.get("TAIL_VEL_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS)))
+TAIL_VEL_ENABLED = (
+    TAIL_VEL_START_STEP > 0
+    and (TAIL_VEL_GAMMA != 0.0 or len(TAIL_VEL_EVAL_GAMMAS) > 0)
+)
+MUON_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("MUON_WEIGHT_SCALE_EVAL_FACTORS", ""))
+MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+PROJ_WEIGHT_SCALE_EVAL_FACTORS = parse_float_list(os.environ.get("PROJ_WEIGHT_SCALE_EVAL_FACTORS", ""))
+PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+REF_EXTRAP_CHECKPOINT = os.environ.get("REF_EXTRAP_CHECKPOINT", "")
+REF_EXTRAP_CAPTURE_STEP = int(os.environ.get("REF_EXTRAP_CAPTURE_STEP", "2375"))
+REF_EXTRAP_GAMMA = float(os.environ.get("REF_EXTRAP_GAMMA", "-0.075"))
+REF_EXTRAP_APPLY_START_STEP = int(os.environ.get("REF_EXTRAP_APPLY_START_STEP", str(FINAL_TRAIN_STEPS)))
+REF_EXTRAP_EVAL_GAMMAS = parse_float_list(os.environ.get("REF_EXTRAP_EVAL_GAMMAS", ""))
+REF_EXTRAP_EXTRA_EVAL_START_STEP = int(
+    os.environ.get("REF_EXTRAP_EXTRA_EVAL_START_STEP", str(FINAL_TRAIN_STEPS))
+)
+_MU_MIN = float(os.environ.get("MUON_MU_MIN", "0.85"))
+_MU_MAX = float(os.environ.get("MUON_MU_MAX", "0.95"))
+_MU_LATE = float(os.environ.get("MUON_MU_LATE", str(_MU_MIN)))
+_MU_WARMUP_STEPS = int(os.environ.get("MUON_MU_WARMUP_STEPS", "300"))
+_MU_COOLDOWN_STEPS = int(os.environ.get("MUON_MU_COOLDOWN_STEPS", "100"))
+_MU_REHEAT_START_STEP = int(os.environ.get("MUON_MU_REHEAT_START_STEP", "0"))
+_MU_REHEAT_END_STEP = int(os.environ.get("MUON_MU_REHEAT_END_STEP", "0"))
+_MU_REHEAT_FINAL = float(os.environ.get("MUON_MU_REHEAT_FINAL", str(_MU_MAX)))
+CHECKPOINT_DIR = Path(os.environ.get("CHECKPOINT_DIR", "checkpoints/tail_refinterp_2900"))
+CHECKPOINT_PREFIX = os.environ.get("CHECKPOINT_PREFIX", f"tail_refinterp_2900_seed{SEED}")
+SAVE_CHECKPOINT_STEPS = parse_int_list(os.environ.get("SAVE_CHECKPOINT_STEPS", ""))
+LOAD_CHECKPOINT = os.environ.get("LOAD_CHECKPOINT", "")
+EXIT_AFTER_SAVE_CHECKPOINT = bool(int(os.environ.get("EXIT_AFTER_SAVE_CHECKPOINT", "0")))
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024, start_batch: int = 0):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    assert len(files) > 0, f"no files matched {filename_pattern}"
+    file_index = 0
+    tokens = _load_data_shard(files[file_index])
+    batches_to_skip = start_batch
+    while batches_to_skip > 0:
+        shard_batches = max(0, (len(tokens) - 2) // batch_size)
+        if batches_to_skip < shard_batches:
+            break
+        batches_to_skip -= shard_batches
+        file_index += 1
+        tokens = _load_data_shard(files[file_index])
+    pos = batches_to_skip * batch_size
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            file_index += 1
+            tokens, pos = _load_data_shard(files[file_index]), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_EPS = 1e-7
+
+def aurora_beta_for_step(step: int | None) -> float:
+    if step is None or AURORA_BETA_DECAY_END_STEP <= AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step < AURORA_BETA_DECAY_START_STEP:
+        return AURORA_BETA
+    if step >= AURORA_BETA_DECAY_END_STEP:
+        return AURORA_BETA_LATE
+    progress = (step - AURORA_BETA_DECAY_START_STEP) / (
+        AURORA_BETA_DECAY_END_STEP - AURORA_BETA_DECAY_START_STEP
+    )
+    return AURORA_BETA * (1.0 - progress) + AURORA_BETA_LATE * progress
+
+def zeropower_plain_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    X = _ns_inner(X)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def aurora_relax_lambda_for_step(step: int | None) -> float:
+    if step is None or AURORA_RELAX_RAMP_END_STEP <= AURORA_RELAX_RAMP_START_STEP:
+        return AURORA_RELAX_LAMBDA
+    return AURORA_RELAX_LAMBDA * _linear_ramp(
+        step, AURORA_RELAX_RAMP_START_STEP, AURORA_RELAX_RAMP_END_STEP
+    )
+
+def apply_aurora_relax(aurora: Tensor, plain: Tensor, step: int | None) -> Tensor:
+    relax_lambda = aurora_relax_lambda_for_step(step)
+    if relax_lambda == 0.0:
+        return aurora
+    aurora_norm = gram_frobenius_norm_estimate(aurora)
+    residual = plain.float() - aurora.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = aurora_norm * AURORA_RELAX_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = aurora.float() + relax_lambda * residual * clip_scale
+    mixed = mixed * aurora_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(aurora.dtype)
+
+def zeropower_via_newtonschulz5(G: Tensor, step: int | None = None) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        beta = aurora_beta_for_step(step)
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(beta)
+        X = U.mT
+        if AURORA_RELAX_LAMBDA != 0.0:
+            plain = zeropower_plain_newtonschulz5(G)
+            X = apply_aurora_relax(X, plain, step)
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def _soft_coefficients(p: float) -> tuple[float, tuple[float, ...]]:
+    if p == 0.0:
+        return 1.0, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if p == 0.1:
+        return 0.0, (0.1091613623, 0.07085664498, 0.05210528973, 0.05457295795, 0.05011334061, 0.03334622198, 0.05022104481, 0.1053727358, 0.1187323776, 0.1185061091, 0.1185059576, 0.1185059576)
+    raise ValueError(f"unsupported soft-muon singular-value power: {p}")
+
+def zeropower_frobenius_norm_like(G: Tensor) -> float:
+    return (G.numel() / max(G.size(-2), G.size(-1)))**0.5
+
+def soft_via_newtonschulz5(G: Tensor, p: float, scale_mode: str, input_norm: str) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if input_norm == "frobenius_schatten4":
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    elif input_norm != "frobenius":
+        raise ValueError(f"unsupported soft_muon input_norm: {input_norm}")
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+    constant, coeffs = _soft_coefficients(p)
+
+    a, b, c = 2, -1.5, 0.5
+    basis = [X]
+    for _ in range(len(coeffs)):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+        basis.append(X)
+
+    out = constant * basis[-1]
+    for coeff, basis_term in zip(coeffs, basis[:-1]):
+        out = out + coeff * basis_term
+
+    value_at_one = constant + sum(coeffs)
+    if scale_mode == "top":
+        out = out / value_at_one
+    elif scale_mode == "top_sqrt":
+        out = out / value_at_one**0.5
+    elif scale_mode == "frobenius":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * theoretical_opower_norm / gram_frobenius_norm_estimate(out)
+    elif scale_mode == "frobenius_sqrt":
+        theoretical_opower_norm = zeropower_frobenius_norm_like(out)
+        out = out * (theoretical_opower_norm / gram_frobenius_norm_estimate(out))**0.5
+    elif scale_mode != "none":
+        raise ValueError(f"unsupported soft_muon scale: {scale_mode}")
+
+    if G.size(-2) > G.size(-1):
+        out = out.mT
+    return out
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    is_mlp_fc = name.endswith(".mlp.fc.weight")
+    is_mlp_proj = name.endswith(".mlp.proj.weight")
+    is_attn_proj = name.endswith(".attn.proj.weight")
+    is_qkv = (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+    )
+    is_q = name.endswith(".attn.q.weight")
+    is_k = name.endswith(".attn.k.weight")
+    is_v = name.endswith(".attn.v.weight")
+    if SOAP_PARAM_MODE == "mlp_all":
+        return is_mlp_fc or is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_fc":
+        return is_mlp_fc
+    if SOAP_PARAM_MODE == "mlp_proj":
+        return is_mlp_proj
+    if SOAP_PARAM_MODE == "mlp_plus_attn_proj":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj
+    if SOAP_PARAM_MODE == "mlp_plus_q":
+        return is_mlp_fc or is_mlp_proj or is_q
+    if SOAP_PARAM_MODE == "mlp_plus_k":
+        return is_mlp_fc or is_mlp_proj or is_k
+    if SOAP_PARAM_MODE == "mlp_plus_v":
+        return is_mlp_fc or is_mlp_proj or is_v
+    if SOAP_PARAM_MODE == "mlp_plus_qkv":
+        return is_mlp_fc or is_mlp_proj or is_qkv
+    if SOAP_PARAM_MODE == "all_hidden":
+        return is_mlp_fc or is_mlp_proj or is_attn_proj or is_qkv
+    raise ValueError(f"unknown SOAP_PARAM_MODE={SOAP_PARAM_MODE}")
+
+def is_attn_proj_param(name: str) -> bool:
+    return name.endswith(".attn.proj.weight")
+
+def is_attn_param(name: str) -> bool:
+    return (
+        name.endswith(".attn.q.weight")
+        or name.endswith(".attn.k.weight")
+        or name.endswith(".attn.v.weight")
+        or name.endswith(".attn.proj.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def param_matches_spec(name: str, spec: str) -> bool:
+    keys = {part.strip() for part in spec.split(",") if part.strip()}
+    return (
+        ("q" in keys and name.endswith(".attn.q.weight"))
+        or ("k" in keys and name.endswith(".attn.k.weight"))
+        or ("v" in keys and name.endswith(".attn.v.weight"))
+        or ("attn_proj" in keys and name.endswith(".attn.proj.weight"))
+    )
+
+def tensor_cosine(a: Tensor, b: Tensor, eps: float = 1e-8) -> Tensor:
+    a_f, b_f = a.float(), b.float()
+    return (a_f * b_f).sum() / (a_f.norm() * b_f.norm()).clamp_min(eps)
+
+def trust_gate(raw: Tensor, soap: Tensor, grad: Tensor, eps: float = 1e-8) -> Tensor:
+    # SOAP is trusted when it still points with raw momentum and is at least as
+    # gradient-aligned as raw momentum. This catches stale whitening bases.
+    raw_grad = tensor_cosine(raw, grad, eps)
+    soap_grad = tensor_cosine(soap, grad, eps)
+    soap_raw = tensor_cosine(soap, raw, eps)
+
+    agree_gate = ((soap_raw - ATTN_TRUST_MIN_AGREE) / (1 - ATTN_TRUST_MIN_AGREE)).clamp(0, 1)
+    denom = (raw_grad - ATTN_TRUST_MIN_GRAD_ALIGN).clamp_min(eps)
+    grad_gate = ((soap_grad - ATTN_TRUST_MIN_GRAD_ALIGN) / denom).clamp(0, 1)
+    gate = (agree_gate * grad_gate).clamp(0, 1)
+    if ATTN_TRUST_POWER != 1.0:
+        gate = gate.pow(ATTN_TRUST_POWER)
+    return gate
+
+def early_trust_floor_for_step(step: int) -> float:
+    if ATTN_TRUST_FLOOR_FADE_END_STEP <= ATTN_TRUST_FLOOR_END_STEP:
+        return 0.0 if step >= ATTN_TRUST_FLOOR_FADE_END_STEP else ATTN_EARLY_TRUST_FLOOR
+    if step < ATTN_TRUST_FLOOR_END_STEP:
+        return ATTN_EARLY_TRUST_FLOOR
+    if step >= ATTN_TRUST_FLOOR_FADE_END_STEP:
+        return 0.0
+    return ATTN_EARLY_TRUST_FLOOR * (
+        ATTN_TRUST_FLOOR_FADE_END_STEP - step
+    ) / (ATTN_TRUST_FLOOR_FADE_END_STEP - ATTN_TRUST_FLOOR_END_STEP)
+
+def bounded_trust_gate(gate: Tensor, step: int) -> Tensor:
+    floor = early_trust_floor_for_step(step)
+    cap = ATTN_EARLY_TRUST_CAP if step < ATTN_TRUST_FLOOR_FADE_END_STEP else 1.0
+    return gate.clamp(min=floor, max=cap)
+
+def attention_soap_blend_for_step(step: int) -> float:
+    if step < ATTN_SOAP_FADE_START_STEP:
+        return 1.0
+    if step >= ATTN_SOAP_FADE_END_STEP:
+        return 0.0
+    if ATTN_SOAP_FADE_END_STEP <= ATTN_SOAP_FADE_START_STEP:
+        return 0.0
+    return (
+        ATTN_SOAP_FADE_END_STEP - step
+    ) / (ATTN_SOAP_FADE_END_STEP - ATTN_SOAP_FADE_START_STEP)
+
+def norm_preserving_blend(raw: Tensor, soap: Tensor, gate: Tensor, eps: float = 1e-8) -> Tensor:
+    blended = raw + (soap - raw) * gate.to(raw.dtype)
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    blended_norm = gram_frobenius_norm_estimate(blended, eps=eps)
+    return (blended * (raw_norm / blended_norm).to(blended.dtype)).to(raw.dtype)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, target_uw: float = 0.0, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    outward_scale = update_f.new_tensor(radial_outward_scale_for_step(step))
+    if (
+        RADIAL_ADAPT_K != 0.0
+        and RADIAL_ADAPT_MAX_EXTRA > 0.0
+        and step >= RADIAL_ADAPT_START_STEP
+        and (RADIAL_ADAPT_END_STEP <= RADIAL_ADAPT_START_STEP or step < RADIAL_ADAPT_END_STEP)
+        and target_uw > 0.0
+    ):
+        u_fro = update_f.norm().clamp_min(eps)
+        p_fro = param_f.norm().clamp_min(eps)
+        target = update_f.new_tensor(target_uw * RADIAL_ADAPT_TARGET_MULT).clamp_min(eps)
+        uw_excess = ((u_fro / p_fro) / target - 1.0).clamp_min(0.0)
+        extra = (uw_excess * RADIAL_ADAPT_K).clamp_max(RADIAL_ADAPT_MAX_EXTRA)
+        outward_scale = (outward_scale - extra).clamp_min(0.0)
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    radial_scale = torch.where(
+        coeff < 0,
+        outward_scale,
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def apply_agreement_shrink(update: Tensor, state: dict, step: int, eps: float = 1e-12) -> Tensor:
+    if not AGREE_SHRINK_ENABLED or step < AGREE_SHRINK_START_STEP:
+        return update
+    update_f = update.float()
+    if "agree_update_ema" not in state:
+        state["agree_update_ema"] = update_f.clone()
+        return update
+    update_ema = state["agree_update_ema"]
+    denom = update_f.norm().clamp_min(eps) * update_ema.norm().clamp_min(eps)
+    cos = (update_f * update_ema).sum() / denom
+    denom_cos = max(AGREE_SHRINK_COS_MIN, eps)
+    shrink_amount = ((AGREE_SHRINK_COS_MIN - cos) / denom_cos).clamp(0.0, 1.0)
+    shrink = 1.0 - AGREE_SHRINK_ALPHA * shrink_amount
+    update_ema.mul_(AGREE_SHRINK_BETA).add_(update_f, alpha=1.0 - AGREE_SHRINK_BETA)
+    return (update_f * shrink).to(update.dtype)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def muon_lr_mult_for_step(step: int) -> float:
+    if MUON_LR_RAMP_END_STEP <= MUON_LR_RAMP_START_STEP:
+        return MUON_LR_LATE_MULT
+    ramp = _linear_ramp(step, MUON_LR_RAMP_START_STEP, MUON_LR_RAMP_END_STEP)
+    return 1.0 + (MUON_LR_LATE_MULT - 1.0) * ramp
+
+def adam_lr_mult_for_step(step: int) -> float:
+    if ADAM_LR_RAMP_END_STEP <= ADAM_LR_RAMP_START_STEP:
+        return ADAM_LR_LATE_MULT
+    ramp = _linear_ramp(step, ADAM_LR_RAMP_START_STEP, ADAM_LR_RAMP_END_STEP)
+    return 1.0 + (ADAM_LR_LATE_MULT - 1.0) * ramp
+
+if TARGET_UW_ADAPT_MODE not in {"off", "observe", "train_loss_gate"}:
+    raise ValueError(f"unsupported target_uw_adapt_mode: {TARGET_UW_ADAPT_MODE}")
+if TARGET_UW_ADAPT_DIRECTION not in {"high", "low"}:
+    raise ValueError(f"unsupported target_uw_adapt_direction: {TARGET_UW_ADAPT_DIRECTION}")
+
+train_loss_last = None
+train_loss_ema = None
+target_uw_adapt_active = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+target_uw_adapt_decided = TARGET_UW_ADAPT_MODE != "train_loss_gate"
+
+def target_uw_for_step(step: int) -> float:
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate" and not target_uw_adapt_active:
+        return TARGET_UW
+    if TARGET_UW_RAMP_END_STEP <= TARGET_UW_RAMP_START_STEP:
+        target = TARGET_UW
+    else:
+        ramp = _linear_ramp(step, TARGET_UW_RAMP_START_STEP, TARGET_UW_RAMP_END_STEP)
+        target = TARGET_UW * (1.0 - ramp) + TARGET_UW_LATE * ramp
+    if TARGET_UW_DECAY_END_STEP > TARGET_UW_DECAY_START_STEP:
+        decay = _linear_ramp(step, TARGET_UW_DECAY_START_STEP, TARGET_UW_DECAY_END_STEP)
+        target = target * (1.0 - decay) + TARGET_UW_FINAL * decay
+    return target
+
+def update_train_loss_metrics(loss_sum: Tensor, local_token_count: int):
+    global train_loss_last, train_loss_ema
+    dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+    train_loss = (loss_sum / (local_token_count * dist.get_world_size())).item()
+    train_loss_last = train_loss
+    if train_loss_ema is None:
+        train_loss_ema = train_loss
+    else:
+        train_loss_ema = (
+            TRAIN_LOSS_EMA_BETA * train_loss_ema
+            + (1.0 - TRAIN_LOSS_EMA_BETA) * train_loss
+        )
+
+def maybe_update_target_uw_train_loss_gate(step: int):
+    global target_uw_adapt_active, target_uw_adapt_decided
+    if TARGET_UW_ADAPT_MODE != "train_loss_gate" or target_uw_adapt_decided:
+        return
+    if step < TARGET_UW_ADAPT_DECIDE_STEP or train_loss_ema is None:
+        return
+    if TARGET_UW_ADAPT_DIRECTION == "high":
+        target_uw_adapt_active = train_loss_ema >= TARGET_UW_ADAPT_THRESHOLD
+    else:
+        target_uw_adapt_active = train_loss_ema <= TARGET_UW_ADAPT_THRESHOLD
+    target_uw_adapt_decided = True
+    print0(
+        "target_uw_train_loss_gate "
+        + f"step:{step} train_loss_ema:{train_loss_ema:.6f} "
+        + f"train_loss_last:{train_loss_last:.6f} "
+        + f"threshold:{TARGET_UW_ADAPT_THRESHOLD:.6f} "
+        + f"direction:{TARGET_UW_ADAPT_DIRECTION} active:{target_uw_adapt_active}",
+        console=True,
+    )
+
+def train_loss_suffix() -> str:
+    if TARGET_UW_ADAPT_MODE == "off":
+        return ""
+    last = "nan" if train_loss_last is None else f"{train_loss_last:.5f}"
+    ema = "nan" if train_loss_ema is None else f"{train_loss_ema:.5f}"
+    if TARGET_UW_ADAPT_MODE == "train_loss_gate":
+        gate = "on" if target_uw_adapt_active else "off"
+        if not target_uw_adapt_decided:
+            gate = "pending"
+        return f" train_loss:{last} train_loss_ema:{ema} target_uw_gate:{gate}"
+    return f" train_loss:{last} train_loss_ema:{ema}"
+
+def effective_target_uw_for_update(step: int, cur_uw: Tensor, scheduled_target_uw: float) -> Tensor:
+    scheduled_target = cur_uw.new_tensor(scheduled_target_uw)
+    if TARGET_UW_DEFICIT_GATE <= 0.0 or TARGET_UW_LATE <= TARGET_UW:
+        return scheduled_target
+    base_target = cur_uw.new_tensor(TARGET_UW).clamp_min(1e-12)
+    boost = (scheduled_target - base_target).clamp_min(0.0)
+    deficit = (1.0 - cur_uw / base_target).clamp_min(0.0)
+    gate = (deficit / TARGET_UW_DEFICIT_GATE).clamp(0.0, 1.0)
+    return base_target + boost * gate
+
+def target_uw_scope_applies(name: str, use_soap: bool) -> bool:
+    if TARGET_UW_SCOPE == "all":
+        return True
+    if TARGET_UW_SCOPE == "none":
+        return False
+    if TARGET_UW_SCOPE == "soap":
+        return use_soap
+    if TARGET_UW_SCOPE == "nonsoap":
+        return not use_soap
+    if TARGET_UW_SCOPE == "mlp":
+        return ".mlp." in name
+    if TARGET_UW_SCOPE == "mlp_proj":
+        return name.endswith(".mlp.proj.weight")
+    if TARGET_UW_SCOPE == "attn":
+        return is_attn_param(name)
+    if TARGET_UW_SCOPE == "attn_proj":
+        return is_attn_proj_param(name)
+    raise ValueError(f"unsupported target_uw_scope: {TARGET_UW_SCOPE}")
+
+def radial_outward_scale_for_step(step: int) -> float:
+    if RADIAL_DECAY_END_STEP <= RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step < RADIAL_DECAY_START_STEP:
+        return RADIAL_OUTWARD_SCALE
+    if step >= RADIAL_DECAY_END_STEP:
+        return RADIAL_OUTWARD_SCALE_LATE
+    progress = (step - RADIAL_DECAY_START_STEP) / (RADIAL_DECAY_END_STEP - RADIAL_DECAY_START_STEP)
+    return RADIAL_OUTWARD_SCALE * (1.0 - progress) + RADIAL_OUTWARD_SCALE_LATE * progress
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def soft_blend_for_step(step: int) -> float:
+    return min(SOFT_MUON_CEIL, _linear_ramp(step, NORMAL_TO_SOFT_START_STEP, NORMAL_TO_SOFT_END_STEP))
+
+def tempered_polar_rho_for_step(step: int) -> float:
+    rho = TEMPERED_POLAR_RHO
+    if TEMPERED_POLAR_DECAY_END_STEP > TEMPERED_POLAR_DECAY_START_STEP:
+        if step >= TEMPERED_POLAR_DECAY_END_STEP:
+            rho = TEMPERED_POLAR_FINAL_RHO
+        elif step >= TEMPERED_POLAR_DECAY_START_STEP:
+            progress = (step - TEMPERED_POLAR_DECAY_START_STEP) / (
+                TEMPERED_POLAR_DECAY_END_STEP - TEMPERED_POLAR_DECAY_START_STEP
+            )
+            rho = rho * (1.0 - progress) + TEMPERED_POLAR_FINAL_RHO * progress
+    if TEMPERED_POLAR_RAMP_END_STEP > TEMPERED_POLAR_RAMP_START_STEP:
+        if step < TEMPERED_POLAR_RAMP_START_STEP:
+            return 0.0
+        if step < TEMPERED_POLAR_RAMP_END_STEP:
+            ramp = (step - TEMPERED_POLAR_RAMP_START_STEP) / (
+                TEMPERED_POLAR_RAMP_END_STEP - TEMPERED_POLAR_RAMP_START_STEP
+            )
+            rho *= ramp
+    return rho
+
+def apply_tempered_polar(prepolar: Tensor, polar: Tensor, polar_norm: Tensor, step: int) -> Tensor:
+    rho = tempered_polar_rho_for_step(step)
+    if rho == 0.0:
+        return polar
+    residual = prepolar.float() - polar.float()
+    residual_norm = gram_frobenius_norm_estimate(residual)
+    max_residual_norm = polar_norm * TEMPERED_POLAR_MAX_DELTA
+    clip_scale = torch.clamp(max_residual_norm / residual_norm.clamp_min(1e-10), max=1.0)
+    mixed = polar.float() + rho * residual * clip_scale
+    mixed = mixed * polar_norm / gram_frobenius_norm_estimate(mixed).clamp_min(1e-10)
+    return mixed.to(polar.dtype)
+
+def muon_update(
+    update,
+    second_moment,
+    step,
+    beta2=NOR_BETA2,
+    use_contra=True,
+    use_soft=True,
+    use_tempered_polar=True,
+):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update, step)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    if use_tempered_polar:
+        ns_update = apply_tempered_polar(normalized_grad, ns_update, update_norm_estimate, step)
+
+    contra_coeff = contra_coeff_for_step(step) if use_contra else 0.0
+    contra_update = ns_update + contra_coeff * normalized_grad
+    contra_update = contra_update * update_norm_estimate / gram_frobenius_norm_estimate(contra_update)
+    if use_soft:
+        soft_update = soft_via_newtonschulz5(update, SOFT_MUON_P, SOFT_MUON_SCALE, SOFT_MUON_INPUT_NORM)
+        soft_update = soft_update * update_norm_estimate / gram_frobenius_norm_estimate(soft_update)
+        blend = soft_blend_for_step(step)
+    else:
+        soft_update = contra_update
+        blend = 0.0
+    update = contra_update + (soft_update - contra_update) * blend
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+    # Per-row variance (or per-col if matrix is wide). Keep along the longer dim.
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)  # shape (..., m, 1)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)  # shape (..., 1, n)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    update = update * (vnorm / vnorm_new)
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.attn_proj_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_proj_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.no_contra_params = {p for n, p in named_params if param_matches_spec(n, NO_CONTRA_PARAM)}
+        self.no_soft_params = {p for n, p in named_params if param_matches_spec(n, NO_SOFTMUON_PARAM)}
+        self.mlp_proj_params = {p for n, p in named_params if n.endswith(".mlp.proj.weight")}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                        if p in self.soap_params:
+                            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+                            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+                            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+                            state["q_row"] = None
+                            state["q_col"] = None
+                            state["soap_step"] = 0
+                        # Second-moment buffer matches per-row-or-col shape.
+                        if p.size(-2) >= p.size(-1):
+                            state["second_moment"] = torch.zeros((*p.shape[:-1], 1),
+                                dtype=torch.float32, device=p.device)
+                        else:
+                            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]),
+                                dtype=torch.float32, device=p.device)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    is_attn_soap = p in self.attn_soap_params
+                    use_soap = p in self.soap_params
+                    if use_soap and SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                    if use_soap:
+                        if is_attn_soap:
+                            soap_blend = V_SOAP_BLEND if p in self.v_params else ATTN_SOAP_BLEND
+                            if p in self.v_params and V_SOAP_BLEND_RAMP_END_STEP > 0:
+                                soap_blend *= _linear_ramp(self.step_count, 0, V_SOAP_BLEND_RAMP_END_STEP)
+                            soap_update = soap_precondition_momentum(
+                                momentum_update, state, blend=soap_blend,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR
+                            )
+                            if p in self.attn_proj_soap_params:
+                                gate = bounded_trust_gate(
+                                    trust_gate(momentum_update, soap_update, grad),
+                                    self.step_count
+                                )
+                            else:
+                                gate = torch.ones((), dtype=torch.float32, device=p.device)
+                            gate = gate * attention_soap_blend_for_step(self.step_count)
+                            momentum_update = norm_preserving_blend(momentum_update, soap_update, gate)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(
+                        momentum_update,
+                        state["second_moment"],
+                        self.step_count,
+                        use_contra=p not in self.no_contra_params,
+                        use_soft=p not in self.no_soft_params,
+                        use_tempered_polar=not (TEMPERED_POLAR_SKIP_MLP_PROJ and p in self.mlp_proj_params),
+                    )
+                    param_name = self.param_names[p]
+                    target_uw = (
+                        target_uw_for_step(self.step_count)
+                        if target_uw_scope_applies(param_name, use_soap)
+                        else TARGET_UW
+                    )
+                    update = scale_radial_update(update, p, self.step_count, target_uw)
+                    # u/w-floor. SOAP and non-SOAP params can use different floors.
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    cur_uw = u_fro / p_fro
+                    target_uw_eff = effective_target_uw_for_update(self.step_count, cur_uw, target_uw)
+                    scale = torch.where(cur_uw < target_uw_eff, target_uw_eff * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    update = apply_agreement_shrink(update, state, self.step_count)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    # WD set to 0 — u/w target replaces wd's role (smaller updates as p grows).
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap and not SOAP_UPDATE_BEFORE_USE:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+if (SAVE_CHECKPOINT_STEPS or LOAD_CHECKPOINT) and dist.get_world_size() != 1:
+    raise RuntimeError("checkpoint save/resume is only implemented for single-process screening runs")
+
+# logging setup
+if dist.get_rank() == 0:
+    log_dir = LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0(f"Experiment={EXPERIMENT_NAME}")
+print0(f"Intuition={EXPERIMENT_INTUITION}")
+print0("Muon update linearly changes from Contra Muon to normal Muon, then normal Muon to soft Muon.")
+print0("This script retains the PR 274 NorMuon-lite row/column variance normalization and u/w-floor postprocessing.")
+print0("MLP and V SOAP stay on all run; V SOAP blend is fixed at 0.95.")
+print0(f"Schedule uses hardcoded PR 287 cooldown constants with train_steps={FINAL_TRAIN_STEPS}, schedule_steps={FINAL_SCHEDULE_STEPS}.")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF}")
+print0(f"Using soft_muon_p={SOFT_MUON_P}")
+print0(f"Using soft_muon_scale={SOFT_MUON_SCALE}")
+print0(f"Using soft_muon_input_norm={SOFT_MUON_INPUT_NORM}")
+print0(f"Using soft_muon_ceil={SOFT_MUON_CEIL}")
+print0(f"Using contra_hold_end_step={CONTRA_HOLD_END_STEP}")
+print0(f"Using contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using normal_to_soft_start_step={NORMAL_TO_SOFT_START_STEP}")
+print0(f"Using normal_to_soft_end_step={NORMAL_TO_SOFT_END_STEP}")
+print0(f"Using mu={MU}")
+print0(f"Using muon_lr={MUON_LR}")
+print0(f"Using adam_lr_late_mult={ADAM_LR_LATE_MULT}")
+print0(f"Using adam_lr_ramp_start_step={ADAM_LR_RAMP_START_STEP}")
+print0(f"Using adam_lr_ramp_end_step={ADAM_LR_RAMP_END_STEP}")
+print0(f"Using muon_lr_late_mult={MUON_LR_LATE_MULT}")
+print0(f"Using muon_lr_ramp_start_step={MUON_LR_RAMP_START_STEP}")
+print0(f"Using muon_lr_ramp_end_step={MUON_LR_RAMP_END_STEP}")
+print0(f"Using muon_weight_decay={MUON_WEIGHT_DECAY}")
+print0(f"Using target_uw={TARGET_UW}")
+print0(f"Using target_uw_late={TARGET_UW_LATE}")
+print0(f"Using target_uw_ramp_start_step={TARGET_UW_RAMP_START_STEP}")
+print0(f"Using target_uw_ramp_end_step={TARGET_UW_RAMP_END_STEP}")
+print0(f"Using target_uw_final={TARGET_UW_FINAL}")
+print0(f"Using target_uw_decay_start_step={TARGET_UW_DECAY_START_STEP}")
+print0(f"Using target_uw_decay_end_step={TARGET_UW_DECAY_END_STEP}")
+print0(f"Using target_uw_deficit_gate={TARGET_UW_DEFICIT_GATE}")
+print0(f"Using target_uw_scope={TARGET_UW_SCOPE}")
+print0(f"Using train_loss_ema_beta={TRAIN_LOSS_EMA_BETA}")
+print0(f"Using target_uw_adapt_mode={TARGET_UW_ADAPT_MODE}")
+print0(f"Using target_uw_adapt_decide_step={TARGET_UW_ADAPT_DECIDE_STEP}")
+print0(f"Using target_uw_adapt_threshold={TARGET_UW_ADAPT_THRESHOLD}")
+print0(f"Using target_uw_adapt_direction={TARGET_UW_ADAPT_DIRECTION}")
+print0(f"Using soap_target_uw={SOAP_TARGET_UW}")
+print0(f"Using nonsoap_target_uw={NONSOAP_TARGET_UW}")
+print0(f"Using di_fc_alpha={DI_FC_ALPHA}")
+print0(f"Using cgi_alpha={CGI_ALPHA}")
+print0(f"Using nor_beta2={NOR_BETA2}")
+print0(f"Using soap_beta2={SOAP_BETA2}")
+print0(f"Using soap_precondition_frequency={SOAP_PRECONDITION_FREQUENCY}")
+print0(f"Using soap_denom_power={SOAP_DENOM_POWER}")
+print0(f"Using soap_blend={SOAP_BLEND}")
+print0(f"Using soap_update_before_use={SOAP_UPDATE_BEFORE_USE}")
+print0(f"Using soap_param_mode={SOAP_PARAM_MODE}")
+print0(f"Using attn_soap_denom_floor={ATTN_SOAP_DENOM_FLOOR}")
+print0(f"Using attn_soap_blend={ATTN_SOAP_BLEND}")
+print0(f"Using v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using v_soap_blend_ramp_end_step={V_SOAP_BLEND_RAMP_END_STEP}")
+print0(f"Using attn_early_trust_floor={ATTN_EARLY_TRUST_FLOOR}")
+print0(f"Using attn_early_trust_cap={ATTN_EARLY_TRUST_CAP}")
+print0(f"Using attn_trust_floor_end_step={ATTN_TRUST_FLOOR_END_STEP}")
+print0(f"Using attn_trust_floor_fade_end_step={ATTN_TRUST_FLOOR_FADE_END_STEP}")
+print0(f"Using attn_trust_min_agree={ATTN_TRUST_MIN_AGREE}")
+print0(f"Using attn_trust_min_grad_align={ATTN_TRUST_MIN_GRAD_ALIGN}")
+print0(f"Using attn_trust_power={ATTN_TRUST_POWER}")
+print0(f"Using attn_soap_fade_start_step={ATTN_SOAP_FADE_START_STEP}")
+print0(f"Using attn_soap_fade_end_step={ATTN_SOAP_FADE_END_STEP}")
+print0(f"Using no_contra_param={NO_CONTRA_PARAM}")
+print0(f"Using no_softmuon_param={NO_SOFTMUON_PARAM}")
+print0(f"Using radial_outward_scale={RADIAL_OUTWARD_SCALE}")
+print0(f"Using radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using radial_outward_scale_late={RADIAL_OUTWARD_SCALE_LATE}")
+print0(f"Using radial_decay_start_step={RADIAL_DECAY_START_STEP}")
+print0(f"Using radial_decay_end_step={RADIAL_DECAY_END_STEP}")
+print0(f"Using radial_adapt_start_step={RADIAL_ADAPT_START_STEP}")
+print0(f"Using radial_adapt_end_step={RADIAL_ADAPT_END_STEP}")
+print0(f"Using radial_adapt_k={RADIAL_ADAPT_K}")
+print0(f"Using radial_adapt_max_extra={RADIAL_ADAPT_MAX_EXTRA}")
+print0(f"Using radial_adapt_target_mult={RADIAL_ADAPT_TARGET_MULT}")
+print0(f"Using agree_shrink_enabled={AGREE_SHRINK_ENABLED}")
+print0(f"Using agree_shrink_start_step={AGREE_SHRINK_START_STEP}")
+print0(f"Using agree_shrink_beta={AGREE_SHRINK_BETA}")
+print0(f"Using agree_shrink_cos_min={AGREE_SHRINK_COS_MIN}")
+print0(f"Using agree_shrink_alpha={AGREE_SHRINK_ALPHA}")
+print0(f"Using dense_eval_start={DENSE_EVAL_START}")
+print0(f"Using dense_eval_end={DENSE_EVAL_END}")
+print0(f"Using dense_eval_stride={DENSE_EVAL_STRIDE}")
+print0(f"Using tempered_polar_rho={TEMPERED_POLAR_RHO}")
+print0(f"Using tempered_polar_max_delta={TEMPERED_POLAR_MAX_DELTA}")
+print0(f"Using tempered_polar_decay_start_step={TEMPERED_POLAR_DECAY_START_STEP}")
+print0(f"Using tempered_polar_decay_end_step={TEMPERED_POLAR_DECAY_END_STEP}")
+print0(f"Using tempered_polar_final_rho={TEMPERED_POLAR_FINAL_RHO}")
+print0(f"Using tempered_polar_ramp_start_step={TEMPERED_POLAR_RAMP_START_STEP}")
+print0(f"Using tempered_polar_ramp_end_step={TEMPERED_POLAR_RAMP_END_STEP}")
+print0(f"Using tempered_polar_skip_mlp_proj={TEMPERED_POLAR_SKIP_MLP_PROJ}")
+print0(f"Using aurora_relax_lambda={AURORA_RELAX_LAMBDA}")
+print0(f"Using aurora_relax_max_delta={AURORA_RELAX_MAX_DELTA}")
+print0(f"Using aurora_relax_ramp_start_step={AURORA_RELAX_RAMP_START_STEP}")
+print0(f"Using aurora_relax_ramp_end_step={AURORA_RELAX_RAMP_END_STEP}")
+print0(f"Using aurora_beta={AURORA_BETA}")
+print0(f"Using aurora_beta_late={AURORA_BETA_LATE}")
+print0(f"Using aurora_beta_decay_start_step={AURORA_BETA_DECAY_START_STEP}")
+print0(f"Using aurora_beta_decay_end_step={AURORA_BETA_DECAY_END_STEP}")
+print0(f"Using tail_ema_enabled={TAIL_EMA_ENABLED}")
+print0(f"Using tail_ema_start_step={TAIL_EMA_START_STEP}")
+print0(f"Using tail_ema_beta={TAIL_EMA_BETA}")
+print0(f"Using tail_ema_gamma={TAIL_EMA_GAMMA}")
+print0(f"Using tail_ema_max_delta_ratio={TAIL_EMA_MAX_DELTA_RATIO}")
+print0(f"Using tail_ema_eval_gammas={TAIL_EMA_EVAL_GAMMAS}")
+print0(f"Using tail_ema_extra_eval_start_step={TAIL_EMA_EXTRA_EVAL_START_STEP}")
+print0(f"Using tail_vel_enabled={TAIL_VEL_ENABLED}")
+print0(f"Using tail_vel_start_step={TAIL_VEL_START_STEP}")
+print0(f"Using tail_vel_beta={TAIL_VEL_BETA}")
+print0(f"Using tail_vel_gamma={TAIL_VEL_GAMMA}")
+print0(f"Using tail_vel_max_delta_ratio={TAIL_VEL_MAX_DELTA_RATIO}")
+print0(f"Using tail_vel_eval_gammas={TAIL_VEL_EVAL_GAMMAS}")
+print0(f"Using tail_vel_extra_eval_start_step={TAIL_VEL_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_weight_scale_eval_factors={MUON_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using muon_weight_scale_extra_eval_start_step={MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using proj_weight_scale_eval_factors={PROJ_WEIGHT_SCALE_EVAL_FACTORS}")
+print0(f"Using proj_weight_scale_extra_eval_start_step={PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP}")
+print0(f"Using ref_extrap_checkpoint={REF_EXTRAP_CHECKPOINT}")
+print0(f"Using ref_extrap_capture_step={REF_EXTRAP_CAPTURE_STEP}")
+print0(f"Using ref_extrap_gamma={REF_EXTRAP_GAMMA}")
+print0(f"Using ref_extrap_apply_start_step={REF_EXTRAP_APPLY_START_STEP}")
+print0(f"Using ref_extrap_eval_gammas={REF_EXTRAP_EVAL_GAMMAS}")
+print0(f"Using ref_extrap_extra_eval_start_step={REF_EXTRAP_EXTRA_EVAL_START_STEP}")
+print0(f"Using muon_mu_min={_MU_MIN}")
+print0(f"Using muon_mu_max={_MU_MAX}")
+print0(f"Using muon_mu_late={_MU_LATE}")
+print0(f"Using muon_mu_warmup_steps={_MU_WARMUP_STEPS}")
+print0(f"Using muon_mu_cooldown_steps={_MU_COOLDOWN_STEPS}")
+print0(f"Using muon_mu_reheat_start_step={_MU_REHEAT_START_STEP}")
+print0(f"Using muon_mu_reheat_end_step={_MU_REHEAT_END_STEP}")
+print0(f"Using muon_mu_reheat_final={_MU_REHEAT_FINAL}")
+print0(f"Using checkpoint_dir={CHECKPOINT_DIR}")
+print0(f"Using checkpoint_prefix={CHECKPOINT_PREFIX}")
+print0(f"Using save_checkpoint_steps={sorted(SAVE_CHECKPOINT_STEPS)}")
+print0(f"Using load_checkpoint={LOAD_CHECKPOINT}")
+print0(f"Using exit_after_save_checkpoint={EXIT_AFTER_SAVE_CHECKPOINT}")
+print0("Dampened radial gradient component is applied before the u/w floor; post-step radius is corrected to remove tangent drift.")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = FINAL_TRAIN_STEPS
+val_regular_interval = 125
+extra_val_steps = {
+    step
+    for step in range(DENSE_EVAL_START, DENSE_EVAL_END + 1, DENSE_EVAL_STRIDE)
+    if 0 <= step <= train_steps
+}
+
+# initialize model parameters
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+
+# v44: v13 depth-scaled mlp.fc init alpha=0.30 (ported from opus v15)
+_NUM_BLOCKS = len(model.blocks)
+with torch.no_grad():
+    for l_idx, block in enumerate(model.blocks):
+        ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+        s_l = 1.0 - DI_FC_ALPHA * ramp
+        block.mlp.fc.weight.data.mul_(s_l)
+
+# v44: v14 CGI Rademacher channel-gain split alpha=0.14 (ported from opus v15)
+with torch.no_grad():
+    for block in model.blocks:
+        s = (torch.randint(0, 2, block.norm1.gains.shape,
+                           device=block.norm1.gains.device, dtype=torch.float32) * 2 - 1)
+        block.norm1.gains.data.copy_((1.0 - CGI_ALPHA * s).to(block.norm1.gains.dtype))
+        block.norm2.gains.data.copy_((1.0 + CGI_ALPHA * s).to(block.norm2.gains.dtype))
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, weight_decay=MUON_WEIGHT_DECAY, mu=MU)
+optimizers = [optimizer1, optimizer2]
+assert set(p for opt in optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+tail_ema_params = list(optimizer2.param_groups[0]["params"])
+tail_param_names = {p: n for n, p in model.blocks.named_parameters() if p.ndim >= 2}
+tail_named_params = {n: p for p, n in tail_param_names.items()}
+tail_ema_buffers = {}
+tail_vel_params = tail_ema_params
+tail_vel_prev_params = {}
+tail_vel_buffers = {}
+
+@torch.no_grad()
+def update_tail_ema(step: int):
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP:
+        return
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            tail_ema_buffers[p] = p.detach().clone()
+        else:
+            ema.mul_(TAIL_EMA_BETA).add_(p.detach(), alpha=1.0 - TAIL_EMA_BETA)
+
+@torch.no_grad()
+def update_tail_velocity(step: int):
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP:
+        return
+    for p in tail_vel_params:
+        prev = tail_vel_prev_params.get(p)
+        if prev is None:
+            tail_vel_prev_params[p] = p.detach().clone()
+            tail_vel_buffers[p] = torch.zeros_like(p)
+        else:
+            step_delta = p.detach() - prev
+            tail_vel_buffers[p].mul_(TAIL_VEL_BETA).add_(step_delta, alpha=1.0 - TAIL_VEL_BETA)
+            prev.copy_(p.detach())
+
+@torch.no_grad()
+def apply_tail_extrapolated_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_EMA_GAMMA if gamma is None else gamma
+    if not TAIL_EMA_ENABLED or step < TAIL_EMA_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_ema_params:
+        ema = tail_ema_buffers.get(p)
+        if ema is None:
+            continue
+        delta = p.detach() - ema
+        delta_norm = delta.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_EMA_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(delta.dtype)
+        extrap = delta * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def apply_tail_velocity_weights(step: int, gamma: float | None = None):
+    gamma = TAIL_VEL_GAMMA if gamma is None else gamma
+    if not TAIL_VEL_ENABLED or step < TAIL_VEL_START_STEP or gamma == 0.0:
+        return []
+    applied = []
+    for p in tail_vel_params:
+        velocity = tail_vel_buffers.get(p)
+        if velocity is None:
+            continue
+        delta_norm = velocity.float().norm().clamp_min(1e-12)
+        max_delta = TAIL_VEL_MAX_DELTA_RATIO * p.detach().float().norm().clamp_min(1e-12)
+        clip_scale = torch.clamp(max_delta / delta_norm, max=1.0).to(velocity.dtype)
+        extrap = velocity * (gamma * clip_scale)
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+@torch.no_grad()
+def restore_tail_extrapolated_weights(applied):
+    for p, extrap in reversed(applied):
+        p.sub_(extrap)
+
+@torch.no_grad()
+def apply_muon_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    for p in tail_ema_params:
+        p.mul_(factor)
+    return [(tail_ema_params, factor)]
+
+@torch.no_grad()
+def restore_muon_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+@torch.no_grad()
+def apply_proj_weight_scale(factor: float):
+    if factor == 1.0:
+        return []
+    params = [model.proj.weight]
+    if model.proj.bias is not None:
+        params.append(model.proj.bias)
+    for p in params:
+        p.mul_(factor)
+    return [(params, factor)]
+
+@torch.no_grad()
+def restore_proj_weight_scale(applied):
+    for params, factor in reversed(applied):
+        inv = 1.0 / factor
+        for p in params:
+            p.mul_(inv)
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if REF_EXTRAP_CAPTURE_STEP <= 0 or step != REF_EXTRAP_CAPTURE_STEP:
+        return
+    if ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("ref extrapolation requested but no reference state is loaded or captured")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        extrap = (p.detach() - ref) * gamma
+        p.add_(extrap)
+        applied.append((p, extrap))
+    return applied
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    if step < REF_EXTRAP_APPLY_START_STEP:
+        return 0.0
+    return REF_EXTRAP_GAMMA
+
+saved_checkpoint_steps = set()
+should_exit_after_checkpoint = False
+
+def checkpoint_path_for_step(step: int) -> Path:
+    return CHECKPOINT_DIR / f"{CHECKPOINT_PREFIX}_step{step}.pt"
+
+def _named_param_buffer_state(buffer_dict: dict) -> dict[str, Tensor]:
+    return {
+        tail_param_names[p]: value.detach().cpu()
+        for p, value in buffer_dict.items()
+        if p in tail_param_names
+    }
+
+def _restore_named_param_buffer_state(buffer_dict: dict, saved: dict[str, Tensor]):
+    buffer_dict.clear()
+    for name, value in saved.items():
+        p = tail_named_params.get(name)
+        if p is not None:
+            buffer_dict[p] = value.to(device=p.device, dtype=p.dtype)
+
+def build_checkpoint_state(step: int) -> dict:
+    return {
+        "step": step,
+        "seed": SEED,
+        "model": model.state_dict(),
+        "optimizers": [opt.state_dict() for opt in optimizers],
+        "optimizer2_step_count": optimizer2.step_count,
+        "tail_ema_buffers": _named_param_buffer_state(tail_ema_buffers),
+        "tail_vel_prev_params": _named_param_buffer_state(tail_vel_prev_params),
+        "tail_vel_buffers": _named_param_buffer_state(tail_vel_buffers),
+        "torch_rng_state": torch.get_rng_state(),
+        "cuda_rng_state": torch.cuda.get_rng_state(device),
+        "train_loss_last": train_loss_last,
+        "train_loss_ema": train_loss_ema,
+        "target_uw_adapt_mode": TARGET_UW_ADAPT_MODE,
+        "target_uw_adapt_active": target_uw_adapt_active,
+        "target_uw_adapt_decided": target_uw_adapt_decided,
+    }
+
+def maybe_save_checkpoint(step: int):
+    global should_exit_after_checkpoint
+    if step not in SAVE_CHECKPOINT_STEPS or step in saved_checkpoint_steps:
+        return
+    if dist.get_rank() != 0:
+        return
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path_for_step(step)
+    torch.save(build_checkpoint_state(step), path)
+    saved_checkpoint_steps.add(step)
+    print0(f"saved_checkpoint step:{step} path:{path}", console=True)
+    if EXIT_AFTER_SAVE_CHECKPOINT:
+        should_exit_after_checkpoint = True
+
+def load_checkpoint_state(path: str) -> int:
+    global train_loss_last, train_loss_ema, target_uw_adapt_active, target_uw_adapt_decided
+    checkpoint = torch.load(path, map_location=device, weights_only=False)
+    if checkpoint.get("seed") != SEED:
+        raise RuntimeError(f"checkpoint seed {checkpoint.get('seed')} does not match run seed {SEED}")
+    model.load_state_dict(checkpoint["model"])
+    for opt, opt_state in zip(optimizers, checkpoint["optimizers"]):
+        opt.load_state_dict(opt_state)
+    optimizer2.step_count = int(checkpoint["optimizer2_step_count"])
+    _restore_named_param_buffer_state(tail_ema_buffers, checkpoint.get("tail_ema_buffers", {}))
+    _restore_named_param_buffer_state(tail_vel_prev_params, checkpoint.get("tail_vel_prev_params", {}))
+    _restore_named_param_buffer_state(tail_vel_buffers, checkpoint.get("tail_vel_buffers", {}))
+    torch.set_rng_state(checkpoint["torch_rng_state"].cpu())
+    torch.cuda.set_rng_state(checkpoint["cuda_rng_state"].cpu(), device)
+    train_loss_last = checkpoint.get("train_loss_last")
+    train_loss_ema = checkpoint.get("train_loss_ema")
+    if checkpoint.get("target_uw_adapt_mode") == TARGET_UW_ADAPT_MODE:
+        target_uw_adapt_active = bool(checkpoint.get("target_uw_adapt_active", target_uw_adapt_active))
+        target_uw_adapt_decided = bool(checkpoint.get("target_uw_adapt_decided", target_uw_adapt_decided))
+    step = int(checkpoint["step"])
+    print0(f"loaded_checkpoint step:{step} path:{path}", console=True)
+    return step
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = FINAL_SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+def _muon_mu_base_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif _MU_COOLDOWN_STEPS > 0 and step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_LATE)
+    else:
+        return _MU_MAX
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown late).
+
+def _muon_mu_at_step(step, train_steps):
+    mu = _muon_mu_base_at_step(step, train_steps)
+    if _MU_REHEAT_END_STEP > _MU_REHEAT_START_STEP and step >= _MU_REHEAT_START_STEP:
+        start_mu = _muon_mu_base_at_step(_MU_REHEAT_START_STEP, train_steps)
+        reheat = _linear_ramp(step, _MU_REHEAT_START_STEP, _MU_REHEAT_END_STEP)
+        return start_mu * (1.0 - reheat) + _MU_REHEAT_FINAL * reheat
+    return mu
+
+def set_hparams(step):
+    progress = step / FINAL_SCHEDULE_STEPS
+    assert 0 <= progress < 1
+    mu = _muon_mu_at_step(step, FINAL_TRAIN_STEPS)
+    adam_lr_mult = adam_lr_mult_for_step(step)
+    for group in optimizer1.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * adam_lr_mult
+    muon_lr_mult = muon_lr_mult_for_step(step)
+    for group in optimizer2.param_groups:
+        group["lr"] = _lr(step, group["initial_lr"], group["power_c"], FINAL_LR_POWER) * muon_lr_mult
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+start_step = load_checkpoint_state(LOAD_CHECKPOINT) if LOAD_CHECKPOINT else 0
+if REF_EXTRAP_CHECKPOINT:
+    ref_checkpoint = torch.load(REF_EXTRAP_CHECKPOINT, map_location="cpu", weights_only=False)
+    ref_extrap_state = {
+        name: value
+        for name, value in ref_checkpoint["model"].items()
+        if torch.is_floating_point(value)
+    }
+    print0(f"loaded_ref_extrap_checkpoint path:{REF_EXTRAP_CHECKPOINT}", console=True)
+if start_step > train_steps:
+    raise RuntimeError(f"checkpoint step {start_step} exceeds train_steps {train_steps}")
+train_loader = distributed_data_generator(
+    "data/fineweb10B/fineweb_train_*.bin",
+    batch_size,
+    start_batch=start_step,
+)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(start_step, train_steps + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        tail_ema_applied = apply_tail_extrapolated_weights(step)
+        tail_vel_applied = apply_tail_velocity_weights(step)
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + train_loss_suffix(), console=True)
+        restore_tail_extrapolated_weights(ref_extrap_applied)
+        restore_tail_extrapolated_weights(tail_vel_applied)
+        restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_EMA_EVAL_GAMMAS and step >= TAIL_EMA_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_EMA_EVAL_GAMMAS:
+                if abs(gamma - TAIL_EMA_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step, gamma=gamma)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                extra_val_loss = compute_validation_loss()
+                print0(f"xewa_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if TAIL_VEL_EVAL_GAMMAS and step >= TAIL_VEL_EXTRA_EVAL_START_STEP:
+            for gamma in TAIL_VEL_EVAL_GAMMAS:
+                if abs(gamma - TAIL_VEL_GAMMA) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step, gamma=gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(f"tail_vel_eval step:{step}/{train_steps} gamma:{gamma:g} val_loss:{extra_val_loss:.5f}", console=True)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if MUON_WEIGHT_SCALE_EVAL_FACTORS and step >= MUON_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in MUON_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_muon_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"muon_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_muon_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if PROJ_WEIGHT_SCALE_EVAL_FACTORS and step >= PROJ_WEIGHT_SCALE_EXTRA_EVAL_START_STEP:
+            for factor in PROJ_WEIGHT_SCALE_EVAL_FACTORS:
+                if abs(factor - 1.0) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                scale_applied = apply_proj_weight_scale(factor)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"proj_weight_scale_eval step:{step}/{train_steps} "
+                    + f"factor:{factor:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_proj_weight_scale(scale_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        if REF_EXTRAP_EVAL_GAMMAS and step >= REF_EXTRAP_EXTRA_EVAL_START_STEP:
+            for gamma in REF_EXTRAP_EVAL_GAMMAS:
+                if abs(gamma - ref_extrap_gamma_for_step(step)) < 1e-12:
+                    continue
+                tail_ema_applied = apply_tail_extrapolated_weights(step)
+                tail_vel_applied = apply_tail_velocity_weights(step)
+                ref_extrap_applied = apply_ref_extrap_weights(gamma)
+                extra_val_loss = compute_validation_loss()
+                print0(
+                    f"ref_extrap_eval step:{step}/{train_steps} "
+                    + f"gamma:{gamma:g} val_loss:{extra_val_loss:.5f}",
+                    console=True,
+                )
+                restore_tail_extrapolated_weights(ref_extrap_applied)
+                restore_tail_extrapolated_weights(tail_vel_applied)
+                restore_tail_extrapolated_weights(tail_ema_applied)
+        model.train()
+        maybe_save_checkpoint(step)
+        if should_exit_after_checkpoint:
+            print0(f"exit_after_save_checkpoint step:{step}", console=True)
+            break
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    train_loss_sum = torch.zeros((), device=device)
+    train_token_count = 0
+    for i in range(len(inputs) // mbs):
+        mb_targets = targets[i*mbs:(i+1)*mbs]
+        loss = model(inputs[i*mbs:(i+1)*mbs], mb_targets)
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        train_loss_sum += loss.detach()
+        train_token_count += mb_targets.numel()
+        loss.backward()
+    update_train_loss_metrics(train_loss_sum, train_token_count)
+    maybe_update_target_uw_train_loss_gate(step)
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    update_tail_ema(step + 1)
+    update_tail_velocity(step + 1)
+    maybe_capture_ref_extrap_state(step + 1)
+    maybe_save_checkpoint(step + 1)
+    if should_exit_after_checkpoint:
+        print0(f"exit_after_save_checkpoint step:{step+1}", console=True)
+        break
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()


### PR DESCRIPTION
# Track 3: 2900 steps (n=9) Muon Tail Reference Interpolation

This Track 3 submission keeps the benchmark data stream, global batch size, and
model architecture unchanged. It starts from the PR #300
Aurora-on-`mlp.proj` optimizer stack and re-targets it to an exact 2900-step
endpoint.

The main new endpoint mechanism is Tail Reference Interpolation. The run
captures a full model-weight reference at step `2375`, then evaluates the final
step-2900 checkpoint with:

```text
theta_eval = theta_2900 + gamma * (theta_2900 - theta_2375)
gamma = -0.075
```

Equivalently:

```text
theta_eval = 0.925 * theta_2900 + 0.075 * theta_2375
```

This is a small deterministic interpolation back toward the late-training
trajectory. It is used only at the fixed final validation point and does not use
validation feedback during a run.

## Result

The submitted fixed checkpoint is step `2900`. The nine logs below are clean
full runs from seeds 0 through 8. No run was stopped early, dropped, or selected
based on validation loss.

Under the Track 3 precision rule:

```text
n=9
mean=3.278576
(3.28 - mean) * sqrt(9) = 0.004273
required = 0.004000
```

Using the README's `sigma=0.0013` normal approximation:

```text
z = 3.287179
p = 0.000505982
```

| Seed | Log | 2900 val | Train time | Step avg |
| -: | - | -: | -: | -: |
| 0 | [refinterp_2900_seed0.txt](refinterp_2900_seed0.txt) | 3.27803 | 4798.129s | 1654.53ms |
| 1 | [refinterp_2900_seed1.txt](refinterp_2900_seed1.txt) | 3.27899 | 4778.006s | 1647.59ms |
| 2 | [refinterp_2900_seed2.txt](refinterp_2900_seed2.txt) | 3.27857 | 4907.369s | 1692.20ms |
| 3 | [refinterp_2900_seed3.txt](refinterp_2900_seed3.txt) | 3.27819 | 4755.410s | 1639.80ms |
| 4 | [refinterp_2900_seed4.txt](refinterp_2900_seed4.txt) | 3.27867 | 4842.459s | 1669.81ms |
| 5 | [refinterp_2900_seed5.txt](refinterp_2900_seed5.txt) | 3.27855 | 4767.208s | 1643.86ms |
| 6 | [refinterp_2900_seed6.txt](refinterp_2900_seed6.txt) | 3.27853 | 4695.982s | 1619.30ms |
| 7 | [refinterp_2900_seed7.txt](refinterp_2900_seed7.txt) | 3.27805 | 4861.523s | 1676.39ms |
| 8 | [refinterp_2900_seed8.txt](refinterp_2900_seed8.txt) | 3.27960 | 4814.127s | 1660.04ms |
| **Mean** |  | **3.278576** |  |  |

Run on a single GH200. Edit: confirmed on 8xH100 as well.

## Configuration

Frozen runner:

```text
records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
```

Frozen trainer:

```text
records/track_3_optimization/results/20260520_tail_refinterp_2900/train_gpt_tail_refinterp_2900.py
```

Core settings:

```text
TRAIN_STEPS=2900
SCHEDULE_STEPS=3020
CONTRA_TO_NORMAL_END_STEP=2750

TEMPERED_POLAR_RHO=0.05
TEMPERED_POLAR_MAX_DELTA=0.25
TEMPERED_POLAR_RAMP_START_STEP=2600
TEMPERED_POLAR_RAMP_END_STEP=2800

RADIAL_OUTWARD_SCALE=0.5
RADIAL_OUTWARD_SCALE_LATE=0.4
RADIAL_DECAY_START_STEP=2400
RADIAL_DECAY_END_STEP=2900

TARGET_UW_LATE=0.400
TARGET_UW_RAMP_START_STEP=2400
TARGET_UW_RAMP_END_STEP=2800
TARGET_UW_FINAL=0.400
TARGET_UW_SCOPE=all

TAIL_VEL_START_STEP=2500
TAIL_VEL_BETA=0.90
TAIL_VEL_GAMMA=-6.0
TAIL_VEL_MAX_DELTA_RATIO=0.01

REF_EXTRAP_CAPTURE_STEP=2375
REF_EXTRAP_GAMMA=-0.075
REF_EXTRAP_APPLY_START_STEP=2900
```

## Method

This candidate is built on the PR #300 optimizer stack:

- Aurora row-balanced polar update on `mlp.proj`.
- Contra-Muon and the PR294/PR287 optimizer schedule lineage.
- SOAP-style MLP/V preconditioning and radial/u-w-floor machinery inherited
  from the existing Track 3 line.

The exact-2900 changes are:

- Extend Contra-Muon later, to `CONTRA_TO_NORMAL_END_STEP=2750`.
- Use late-only Tempered Polar, ramping `rho` from 0 to `0.05` during steps
  `2600..2800`.
- Retune the late radial brake from `0.5` to `0.4` during steps `2400..2900`.
- Ramp the update/weight floor to `TARGET_UW=0.400` during steps `2400..2800`.
- Keep an EMA of recent parameter updates from step `2500` and apply a clipped
  final tail-velocity transform with `gamma=-6`.
- Capture a step-2375 reference and evaluate step 2900 with the fixed
  `gamma=-0.075` reference interpolation.

What worked:

- Late-only Tempered Polar was better than perturbing the full trajectory.
- The late radial and `TARGET_UW=0.400` retune improved the exact-2900 endpoint.
- Tail velocity with negative gamma helped versus earlier final-weight probes.
- The step-2375 reference interpolation was very helpful, especially on
  weak seeds.

What did not work:

- Positive Tail Extrapolated EMA/XEWA was monotone worse in the seed-1 sweep.
- More Tempered Polar rho/cap surface tuning did not move the mean enough.
- Training-loss EMA gating was too weak to separate good and bad seeds.

## Differences from PR #300

This comparison uses the local PR #300 extraction:

```text
records/track_3_optimization/repro_scripts/pr300_aurora_proj_base.py
```

PR #300 is kept as the base optimizer stack: Aurora on `mlp.proj`, the extended Contra-Muon/Aurora PR294 line, the PR287-style power cooldown, and the existing SOAP/radial/u-w-floor machinery. The exact-2900 candidate changes the endpoint behavior around that base.

Material method changes:

| Area | PR #300 base | Exact-2900 candidate |
| - | - | - |
| Target endpoint | `TRAIN_STEPS=3020`, validated/reporting around the 2930 bin | `TRAIN_STEPS=2900` exact endpoint |
| LR schedule horizon | `SCHEDULE_STEPS=3050` | `SCHEDULE_STEPS=3020` |
| Contra-Muon blend | `CONTRA_TO_NORMAL_END_STEP=2500` | `CONTRA_TO_NORMAL_END_STEP=2750` |
| Tempered Polar | absent | late ramped residual, `rho=0.05`, `max_delta=0.25`, ramp 2600 to 2800 |
| Radial brake | fixed `RADIAL_OUTWARD_SCALE=0.5` | late retune from `0.5` to `0.4`, decay 2400 to 2900 |
| u/w target floor | fixed `TARGET_UW=0.3825` | ramp to/final `TARGET_UW=0.400`, ramp 2400 to 2800, `TARGET_UW_SCOPE=all` |
| Tail velocity final transform | absent | update-EMA from step 2500, `beta=0.90`, final `gamma=-6.0`, clipped at `0.01` parameter norm |
| Final reference interpolation | absent | capture step 2375 and evaluate step 2900 at `0.925 * theta_2900 + 0.075 * theta_2375` |

Harness/probe changes in the experimental trainer:

- Adds final-weight probe hooks for Tail EMA/XEWA, tail velocity, Muon weight scaling, projection scaling, and reference interpolation sweeps.
- Adds single-process checkpoint save/resume support for late-stage screening.
- Adds dense-eval controls and config logging for the 2900 target runs.

Those harness features are not part of the frozen method unless their corresponding config is enabled. The full-log results in this note use only the fixed candidate settings listed above.

## Reproduction

Run the submitted seeds:

```bash
records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
```

Run a shorter check:

```bash
SEEDS="0 1" records/track_3_optimization/results/20260520_tail_refinterp_2900/run.sh
```

Recompute the reported statistics:

```bash
python3 records/track_3_optimization/results/20260520_tail_refinterp_2900/summarize_submission_stats.py --step 2900 \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed0.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed1.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed2.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed3.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed4.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed5.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed6.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed7.txt \
  records/track_3_optimization/results/20260520_tail_refinterp_2900/refinterp_2900_seed8.txt
```

## Credits

This submission incorporates features from the following previous submissions
and PRs:

- @kumarkrishna PR274 / Skylight-001: NorMuon-lite row/column variance
  normalization, u/w floor postprocessing, and `lr=0.0375` style Muon setup.
- @nilin PR275 and PR291: Contra-Muon / Soft-Muon lineage.
- @samacqua PR278: SOAP preconditioning machinery / MLP SOAP idea.
- @SPThole PR283: Trustlight attention-SOAP path lineage.
- @yash-oai PR287: power-law learning-rate cooldown.
- PR #300: Aurora on `mlp.proj` plus extended Contra-Muon on the PR294 stack.
