### PR TITLE
Track 3: 3125 steps (n=20) EMA-Nesterov + Muon

### DIFF
--- a/records/track_3_optimization/results/20260522_ema_nesterov_muon/4d9e83d4-4e3f-43d3-8aae-e3a9031586be.txt
+++ b/records/track_3_optimization/results/20260522_ema_nesterov_muon/4d9e83d4-4e3f-43d3-8aae-e3a9031586be.txt
@@ -1,0 +1,1207 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % dist.get_world_size() == 0
+    local_batch_size = batch_size // dist.get_world_size()
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + dist.get_rank() * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations, not optimizing for wallclock speed
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+@torch.compile
+def muon_update(grad, momentum, mu=0.95, nesterov=True):
+    momentum.lerp_(grad, 1 - mu)
+    update = grad.lerp_(momentum, mu) if nesterov else momentum
+    update = zeropower_via_newtonschulz5(update)
+    update *= max(1, grad.size(-2) / grad.size(-1))**0.5
+    return update
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.02, weight_decay=0, mu=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.size(), reverse=True)
+        defaults = dict(lr=lr, weight_decay=weight_decay, mu=mu)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum"] = torch.zeros_like(p)
+                    update = muon_update(p.grad, state["momentum"], mu=group["mu"])
+                    p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update, alpha=-group["lr"])
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(self, params, inner_optimizer, lookahead_stepsize=0, use_scheduled_lookahead_stepsize=True, lookahead_ema=0.9, prefill_steps=0, rest_steps=0):
+        if lookahead_stepsize < 0.0:
+            raise ValueError("Invalid momentum value: {}".format(lookahead_stepsize))
+
+        super(EMA_Nesterov, self).__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0
+        self.initialize_buffers()
+
+    def __setstate__(self, state):
+        super(EMA_Nesterov, self).__setstate__(state)
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group['params']:
+                param_state = self.state[p]
+                if 'prev_params' not in param_state:
+                    param_state['prev_params'] = (p.clone(), self.it)
+
+                if 'lookahead_buffer' not in param_state:
+                    param_state['lookahead_buffer'] = (torch.zeros_like(p), -1)
+    
+    def get_lr_lambda(self):
+        if isinstance(self.inner_optimizer, list):
+            lr_lambda = self.inner_optimizer[0].param_groups[0]["lr"] / self.inner_optimizer[0].param_groups[0]["initial_lr"]
+        else:
+            lr_lambda = self.inner_optimizer.param_groups[0]["lr"] / self.inner_optimizer.param_groups[0]["initial_lr"]
+        return lr_lambda
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        """Performs nesterov's lookahead."""
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group['params']:
+
+                param_state = self.state[p]         
+
+                lookahead = param_state['lookahead_buffer'][0]
+       
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        """Update nesterov's lookahead direction."""
+        lookahead_ema = self.lookahead_ema
+        for group in self.param_groups:
+            for p in group['params']:
+                param_state = self.state[p]
+                look = p.add(param_state['prev_params'][0], alpha=-1)
+
+                # update lookahead buffer
+                buf = param_state['lookahead_buffer'][0]
+                param_state['lookahead_buffer'] = (buf.lerp_(look, 1 - lookahead_ema), self.it) # m^{t+1} = beta * m^t + (1-beta) * look
+
+                # update prev_params buffer
+                param_state['prev_params'] = (param_state['prev_params'][0].copy_(p), self.it)
+
+    
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass.")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        
+        self.accum_lookahead()
+
+        self.lookahead_status = False
+        self.it += 1
+    
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+num_trials = int(sys.argv[-1]) if len(sys.argv) > 1 else 1
+
+for _ in range(num_trials):
+
+
+    ########################################
+    #       Init & Optim Hyperparams       #
+    ########################################
+
+    # we want to minimize this while still reaching 3.28 val loss
+    train_steps = 3150
+
+    # initialize model parameters
+    for name, p in model.named_parameters():
+        w = p.data
+        if name.endswith("weight"):
+            if "proj" in name:
+                w.zero_()
+            elif "embed" in name:
+                w.normal_()  # default torch init
+            else:
+                w.normal_(std=0.33**0.5 / w.size(-1)**0.5)  # default torch init
+        elif name.endswith("bias"):
+            w.zero_()
+        elif name.endswith("gains"):
+            w.normal_(mean=1, std=0)
+        else:
+            raise Exception(f"Uninitialized parameter: {name}")
+
+    # create the optimizer(s)
+    optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                        dict(params=[model.proj.weight], lr=1/320),
+                        dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                       betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+    optimizer2 = Muon([p for p in model.blocks.parameters() if p.ndim >= 2],
+                      lr=0.035, weight_decay=0.025)
+    optimizers = [optimizer1, optimizer2]
+    optimizers = [EMA_Nesterov(
+        [p for p in model.parameters()],
+        optimizers,
+        lookahead_stepsize=0.6,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.99,
+        prefill_steps=500,
+        rest_steps=train_steps - 750,
+    )]
+    for opt in optimizers[0].inner_optimizer:
+        for group in opt.param_groups:
+            group["initial_lr"] = group["lr"]
+    assert set(p for opt in optimizers for group in opt.param_groups
+               for p in group["params"]) == set(model.parameters()), "optimizer params mismatch"
+    
+
+    # learning rate schedule: stable then decay
+    def set_hparams(step, cooldown_frac=0.7):
+        progress = step / train_steps
+        assert 0 <= progress < 1
+        if progress < 1 - cooldown_frac:
+            eta = 1.0
+        else:
+            eta = (1 - progress) / cooldown_frac
+        for opt in optimizers[0].inner_optimizer:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * eta
+
+
+    ########################################
+    #        Training and Validation       #
+    ########################################
+
+    train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+    for p in model.parameters():
+        dist.broadcast(p.detach(), 0)
+    # start the clock
+    training_time = 0
+    last_val_step = 0
+    dist.barrier()
+    t0 = time.perf_counter()
+    for step in range(train_steps + 1):
+
+        # --------------- VALIDATION SECTION -----------------
+        val_step_freq = 125 if step / train_steps < 0.9 else 25
+        if step == train_steps or step % val_step_freq == 0:
+            # stop the clock
+            dist.barrier()
+            time_since_last_val = time.perf_counter() - t0
+            step_avg = time_since_last_val / (step - last_val_step) if step > 0 else float("nan")
+            last_val_step = step
+            training_time += time_since_last_val
+            model.eval()
+            val_loss = 0
+            with torch.no_grad():
+                assert len(val_inputs) % mbs == 0
+                for i in range(len(val_inputs) // mbs):
+                    val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+            dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+            val_loss /= val_tokens
+            print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+                   + f" step_avg:{1000*step_avg:.2f}ms", console=True)
+            model.train()
+            # start the clock again
+            dist.barrier()
+            t0 = time.perf_counter()
+
+        if step == train_steps:
+            break
+
+        # --------------- TRAINING SECTION -----------------
+        inputs, targets = next(train_loader)
+        # accumulate across microbatches in case we are running with fewer than 8 gpus
+        assert len(inputs) % mbs == 0
+        optimizers[0].nesterov_step()
+        for i in range(len(inputs) // mbs):
+            model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]).backward()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, name
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+        # set optimization hyperparameters and take a step
+        set_hparams(step)
+        for opt in optimizers:
+            opt.step()
+        model.zero_grad(set_to_none=True)
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+====================================================================================================
+Running PyTorch 2.11.0+cu128 compiled for CUDA 12.8 on NVIDIA A100-SXM4-80GB with world_size 8
+====================================================================================================
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66843 train_time:46.854s step_avg:374.83ms
+step:250/3150 val_loss:4.12574 train_time:91.007s step_avg:353.22ms
+step:375/3150 val_loss:3.93917 train_time:134.474s step_avg:347.74ms
+step:500/3150 val_loss:3.83474 train_time:178.468s step_avg:351.96ms
+step:625/3150 val_loss:3.77740 train_time:222.586s step_avg:352.94ms
+step:750/3150 val_loss:3.71535 train_time:266.261s step_avg:349.40ms
+step:875/3150 val_loss:3.66672 train_time:310.297s step_avg:352.29ms
+step:1000/3150 val_loss:3.62599 train_time:354.355s step_avg:352.47ms
+step:1125/3150 val_loss:3.59262 train_time:398.038s step_avg:349.47ms
+step:1250/3150 val_loss:3.55843 train_time:442.188s step_avg:353.20ms
+step:1375/3150 val_loss:3.53308 train_time:486.298s step_avg:352.88ms
+step:1500/3150 val_loss:3.50573 train_time:530.017s step_avg:349.75ms
+step:1625/3150 val_loss:3.48566 train_time:574.188s step_avg:353.36ms
+step:1750/3150 val_loss:3.46244 train_time:618.328s step_avg:353.13ms
+step:1875/3150 val_loss:3.44280 train_time:662.018s step_avg:349.51ms
+step:2000/3150 val_loss:3.42318 train_time:706.151s step_avg:353.07ms
+step:2125/3150 val_loss:3.40418 train_time:750.276s step_avg:353.00ms
+step:2250/3150 val_loss:3.38532 train_time:794.001s step_avg:349.79ms
+step:2375/3150 val_loss:3.36814 train_time:838.103s step_avg:352.82ms
+step:2500/3150 val_loss:3.34661 train_time:882.072s step_avg:351.75ms
+step:2625/3150 val_loss:3.32955 train_time:925.612s step_avg:348.32ms
+step:2750/3150 val_loss:3.31448 train_time:969.504s step_avg:351.14ms
+step:2850/3150 val_loss:3.30331 train_time:1004.298s step_avg:347.94ms
+step:2875/3150 val_loss:3.30071 train_time:1013.381s step_avg:363.35ms
+step:2900/3150 val_loss:3.29796 train_time:1022.084s step_avg:348.11ms
+step:2925/3150 val_loss:3.29502 train_time:1030.786s step_avg:348.06ms
+step:2950/3150 val_loss:3.29273 train_time:1039.489s step_avg:348.13ms
+step:2975/3150 val_loss:3.29033 train_time:1048.190s step_avg:348.03ms
+step:3000/3150 val_loss:3.28811 train_time:1056.893s step_avg:348.13ms
+step:3025/3150 val_loss:3.28564 train_time:1065.596s step_avg:348.12ms
+step:3050/3150 val_loss:3.28354 train_time:1074.673s step_avg:363.10ms
+step:3075/3150 val_loss:3.28191 train_time:1083.373s step_avg:347.97ms
+step:3100/3150 val_loss:3.28038 train_time:1092.072s step_avg:347.99ms
+step:3125/3150 val_loss:3.27931 train_time:1100.773s step_avg:348.01ms
+step:3150/3150 val_loss:3.27872 train_time:1109.472s step_avg:347.98ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.68541 train_time:44.004s step_avg:352.03ms
+step:250/3150 val_loss:4.12585 train_time:87.932s step_avg:351.43ms
+step:375/3150 val_loss:3.94027 train_time:131.505s step_avg:348.59ms
+step:500/3150 val_loss:3.83554 train_time:175.429s step_avg:351.39ms
+step:625/3150 val_loss:3.77356 train_time:219.521s step_avg:352.74ms
+step:750/3150 val_loss:3.71384 train_time:263.235s step_avg:349.71ms
+step:875/3150 val_loss:3.66429 train_time:307.327s step_avg:352.74ms
+step:1000/3150 val_loss:3.62450 train_time:351.425s step_avg:352.78ms
+step:1125/3150 val_loss:3.59062 train_time:395.164s step_avg:349.91ms
+step:1250/3150 val_loss:3.55854 train_time:439.007s step_avg:350.74ms
+step:1375/3150 val_loss:3.53223 train_time:483.135s step_avg:353.03ms
+step:1500/3150 val_loss:3.50472 train_time:526.860s step_avg:349.80ms
+step:1625/3150 val_loss:3.48397 train_time:570.946s step_avg:352.69ms
+step:1750/3150 val_loss:3.46175 train_time:615.143s step_avg:353.57ms
+step:1875/3150 val_loss:3.44203 train_time:658.858s step_avg:349.72ms
+step:2000/3150 val_loss:3.42130 train_time:702.979s step_avg:352.97ms
+step:2125/3150 val_loss:3.40257 train_time:747.096s step_avg:352.94ms
+step:2250/3150 val_loss:3.38416 train_time:790.862s step_avg:350.13ms
+step:2375/3150 val_loss:3.36679 train_time:835.018s step_avg:353.25ms
+step:2500/3150 val_loss:3.34507 train_time:879.000s step_avg:351.85ms
+step:2625/3150 val_loss:3.32806 train_time:922.507s step_avg:348.05ms
+step:2750/3150 val_loss:3.31306 train_time:966.391s step_avg:351.07ms
+step:2850/3150 val_loss:3.30161 train_time:1001.194s step_avg:348.03ms
+step:2875/3150 val_loss:3.29923 train_time:1010.298s step_avg:364.18ms
+step:2900/3150 val_loss:3.29638 train_time:1019.016s step_avg:348.70ms
+step:2925/3150 val_loss:3.29355 train_time:1027.739s step_avg:348.92ms
+step:2950/3150 val_loss:3.29113 train_time:1036.465s step_avg:349.06ms
+step:2975/3150 val_loss:3.28882 train_time:1045.190s step_avg:348.97ms
+step:3000/3150 val_loss:3.28662 train_time:1053.910s step_avg:348.82ms
+step:3025/3150 val_loss:3.28422 train_time:1062.633s step_avg:348.91ms
+step:3050/3150 val_loss:3.28214 train_time:1071.728s step_avg:363.79ms
+step:3075/3150 val_loss:3.28044 train_time:1080.436s step_avg:348.35ms
+step:3100/3150 val_loss:3.27892 train_time:1089.150s step_avg:348.54ms
+step:3125/3150 val_loss:3.27780 train_time:1097.872s step_avg:348.87ms
+step:3150/3150 val_loss:3.27722 train_time:1106.591s step_avg:348.78ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.65914 train_time:44.028s step_avg:352.22ms
+step:250/3150 val_loss:4.11831 train_time:88.001s step_avg:351.79ms
+step:375/3150 val_loss:3.93586 train_time:131.621s step_avg:348.96ms
+step:500/3150 val_loss:3.83261 train_time:175.588s step_avg:351.74ms
+step:625/3150 val_loss:3.77336 train_time:219.709s step_avg:352.97ms
+step:750/3150 val_loss:3.71184 train_time:263.426s step_avg:349.74ms
+step:875/3150 val_loss:3.66491 train_time:307.516s step_avg:352.72ms
+step:1000/3150 val_loss:3.62215 train_time:351.616s step_avg:352.81ms
+step:1125/3150 val_loss:3.59019 train_time:395.346s step_avg:349.84ms
+step:1250/3150 val_loss:3.55736 train_time:439.447s step_avg:352.81ms
+step:1375/3150 val_loss:3.53194 train_time:483.544s step_avg:352.78ms
+step:1500/3150 val_loss:3.50450 train_time:527.302s step_avg:350.06ms
+step:1625/3150 val_loss:3.48403 train_time:571.410s step_avg:352.86ms
+step:1750/3150 val_loss:3.46091 train_time:615.516s step_avg:352.85ms
+step:1875/3150 val_loss:3.44104 train_time:659.276s step_avg:350.08ms
+step:2000/3150 val_loss:3.42101 train_time:703.485s step_avg:353.68ms
+step:2125/3150 val_loss:3.40261 train_time:747.687s step_avg:353.61ms
+step:2250/3150 val_loss:3.38440 train_time:791.434s step_avg:349.98ms
+step:2375/3150 val_loss:3.36709 train_time:835.527s step_avg:352.74ms
+step:2500/3150 val_loss:3.34508 train_time:879.462s step_avg:351.47ms
+step:2625/3150 val_loss:3.32875 train_time:922.981s step_avg:348.16ms
+step:2750/3150 val_loss:3.31352 train_time:966.878s step_avg:351.18ms
+step:2850/3150 val_loss:3.30209 train_time:1001.694s step_avg:348.16ms
+step:2875/3150 val_loss:3.29968 train_time:1010.778s step_avg:363.37ms
+step:2900/3150 val_loss:3.29706 train_time:1019.485s step_avg:348.27ms
+step:2925/3150 val_loss:3.29405 train_time:1028.193s step_avg:348.35ms
+step:2950/3150 val_loss:3.29168 train_time:1036.898s step_avg:348.19ms
+step:2975/3150 val_loss:3.28937 train_time:1045.605s step_avg:348.28ms
+step:3000/3150 val_loss:3.28731 train_time:1054.313s step_avg:348.32ms
+step:3025/3150 val_loss:3.28492 train_time:1063.021s step_avg:348.29ms
+step:3050/3150 val_loss:3.28283 train_time:1072.107s step_avg:363.46ms
+step:3075/3150 val_loss:3.28117 train_time:1080.809s step_avg:348.07ms
+step:3100/3150 val_loss:3.27966 train_time:1089.514s step_avg:348.20ms
+step:3125/3150 val_loss:3.27852 train_time:1098.217s step_avg:348.13ms
+step:3150/3150 val_loss:3.27796 train_time:1106.923s step_avg:348.25ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67825 train_time:43.676s step_avg:349.41ms
+step:250/3150 val_loss:4.12753 train_time:87.640s step_avg:351.71ms
+step:375/3150 val_loss:3.93541 train_time:131.190s step_avg:348.40ms
+step:500/3150 val_loss:3.83470 train_time:175.100s step_avg:351.28ms
+step:625/3150 val_loss:3.77354 train_time:219.213s step_avg:352.90ms
+step:750/3150 val_loss:3.71259 train_time:262.979s step_avg:350.13ms
+step:875/3150 val_loss:3.66350 train_time:307.085s step_avg:352.85ms
+step:1000/3150 val_loss:3.62243 train_time:351.184s step_avg:352.79ms
+step:1125/3150 val_loss:3.59021 train_time:394.912s step_avg:349.82ms
+step:1250/3150 val_loss:3.55730 train_time:439.053s step_avg:353.12ms
+step:1375/3150 val_loss:3.53155 train_time:483.203s step_avg:353.20ms
+step:1500/3150 val_loss:3.50411 train_time:526.971s step_avg:350.15ms
+step:1625/3150 val_loss:3.48426 train_time:571.133s step_avg:353.30ms
+step:1750/3150 val_loss:3.46136 train_time:615.282s step_avg:353.19ms
+step:1875/3150 val_loss:3.44098 train_time:659.087s step_avg:350.44ms
+step:2000/3150 val_loss:3.42052 train_time:703.141s step_avg:352.43ms
+step:2125/3150 val_loss:3.40230 train_time:747.217s step_avg:352.61ms
+step:2250/3150 val_loss:3.38362 train_time:790.898s step_avg:349.45ms
+step:2375/3150 val_loss:3.36623 train_time:834.974s step_avg:352.61ms
+step:2500/3150 val_loss:3.34459 train_time:878.877s step_avg:351.22ms
+step:2625/3150 val_loss:3.32787 train_time:922.374s step_avg:347.97ms
+step:2750/3150 val_loss:3.31280 train_time:965.941s step_avg:348.54ms
+step:2850/3150 val_loss:3.30145 train_time:1000.737s step_avg:347.96ms
+step:2875/3150 val_loss:3.29883 train_time:1009.819s step_avg:363.26ms
+step:2900/3150 val_loss:3.29622 train_time:1018.520s step_avg:348.04ms
+step:2925/3150 val_loss:3.29334 train_time:1027.225s step_avg:348.21ms
+step:2950/3150 val_loss:3.29096 train_time:1035.928s step_avg:348.13ms
+step:2975/3150 val_loss:3.28866 train_time:1044.631s step_avg:348.12ms
+step:3000/3150 val_loss:3.28646 train_time:1053.333s step_avg:348.05ms
+step:3025/3150 val_loss:3.28408 train_time:1062.034s step_avg:348.07ms
+step:3050/3150 val_loss:3.28195 train_time:1070.806s step_avg:350.85ms
+step:3075/3150 val_loss:3.28039 train_time:1079.512s step_avg:348.24ms
+step:3100/3150 val_loss:3.27888 train_time:1088.216s step_avg:348.17ms
+step:3125/3150 val_loss:3.27773 train_time:1096.920s step_avg:348.16ms
+step:3150/3150 val_loss:3.27717 train_time:1105.624s step_avg:348.16ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67657 train_time:43.989s step_avg:351.91ms
+step:250/3150 val_loss:4.13130 train_time:87.984s step_avg:351.96ms
+step:375/3150 val_loss:3.94305 train_time:131.571s step_avg:348.69ms
+step:500/3150 val_loss:3.83501 train_time:175.549s step_avg:351.83ms
+step:625/3150 val_loss:3.77602 train_time:219.659s step_avg:352.88ms
+step:750/3150 val_loss:3.71590 train_time:263.407s step_avg:349.99ms
+step:875/3150 val_loss:3.66572 train_time:307.563s step_avg:353.24ms
+step:1000/3150 val_loss:3.62626 train_time:351.689s step_avg:353.01ms
+step:1125/3150 val_loss:3.59219 train_time:395.436s step_avg:349.97ms
+step:1250/3150 val_loss:3.55890 train_time:439.519s step_avg:352.66ms
+step:1375/3150 val_loss:3.53415 train_time:483.650s step_avg:353.05ms
+step:1500/3150 val_loss:3.50469 train_time:527.428s step_avg:350.23ms
+step:1625/3150 val_loss:3.48459 train_time:571.549s step_avg:352.97ms
+step:1750/3150 val_loss:3.46257 train_time:615.654s step_avg:352.84ms
+step:1875/3150 val_loss:3.44263 train_time:659.425s step_avg:350.17ms
+step:2000/3150 val_loss:3.42206 train_time:703.525s step_avg:352.80ms
+step:2125/3150 val_loss:3.40359 train_time:747.630s step_avg:352.84ms
+step:2250/3150 val_loss:3.38494 train_time:791.356s step_avg:349.81ms
+step:2375/3150 val_loss:3.36747 train_time:835.448s step_avg:352.73ms
+step:2500/3150 val_loss:3.34625 train_time:879.392s step_avg:351.55ms
+step:2625/3150 val_loss:3.32944 train_time:922.911s step_avg:348.15ms
+step:2750/3150 val_loss:3.31413 train_time:966.815s step_avg:351.23ms
+step:2850/3150 val_loss:3.30274 train_time:1001.627s step_avg:348.11ms
+step:2875/3150 val_loss:3.30017 train_time:1010.724s step_avg:363.88ms
+step:2900/3150 val_loss:3.29759 train_time:1019.428s step_avg:348.16ms
+step:2925/3150 val_loss:3.29479 train_time:1028.132s step_avg:348.15ms
+step:2950/3150 val_loss:3.29242 train_time:1036.835s step_avg:348.14ms
+step:2975/3150 val_loss:3.29005 train_time:1045.539s step_avg:348.16ms
+step:3000/3150 val_loss:3.28784 train_time:1054.246s step_avg:348.27ms
+step:3025/3150 val_loss:3.28547 train_time:1062.953s step_avg:348.28ms
+step:3050/3150 val_loss:3.28332 train_time:1072.038s step_avg:363.42ms
+step:3075/3150 val_loss:3.28164 train_time:1080.741s step_avg:348.12ms
+step:3100/3150 val_loss:3.28018 train_time:1089.445s step_avg:348.16ms
+step:3125/3150 val_loss:3.27904 train_time:1098.149s step_avg:348.16ms
+step:3150/3150 val_loss:3.27847 train_time:1106.851s step_avg:348.08ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67713 train_time:43.997s step_avg:351.98ms
+step:250/3150 val_loss:4.12773 train_time:87.949s step_avg:351.61ms
+step:375/3150 val_loss:3.94020 train_time:131.616s step_avg:349.34ms
+step:500/3150 val_loss:3.83505 train_time:175.597s step_avg:351.85ms
+step:625/3150 val_loss:3.77447 train_time:219.726s step_avg:353.03ms
+step:750/3150 val_loss:3.71570 train_time:263.441s step_avg:349.72ms
+step:875/3150 val_loss:3.66492 train_time:307.536s step_avg:352.76ms
+step:1000/3150 val_loss:3.62688 train_time:351.666s step_avg:353.04ms
+step:1125/3150 val_loss:3.59088 train_time:395.390s step_avg:349.79ms
+step:1250/3150 val_loss:3.55883 train_time:439.480s step_avg:352.72ms
+step:1375/3150 val_loss:3.53422 train_time:483.569s step_avg:352.71ms
+step:1500/3150 val_loss:3.50664 train_time:527.277s step_avg:349.67ms
+step:1625/3150 val_loss:3.48583 train_time:571.460s step_avg:353.46ms
+step:1750/3150 val_loss:3.46400 train_time:615.653s step_avg:353.55ms
+step:1875/3150 val_loss:3.44344 train_time:659.380s step_avg:349.81ms
+step:2000/3150 val_loss:3.42334 train_time:703.502s step_avg:352.97ms
+step:2125/3150 val_loss:3.40481 train_time:747.579s step_avg:352.62ms
+step:2250/3150 val_loss:3.38625 train_time:791.286s step_avg:349.66ms
+step:2375/3150 val_loss:3.36893 train_time:835.364s step_avg:352.63ms
+step:2500/3150 val_loss:3.34743 train_time:879.359s step_avg:351.96ms
+step:2625/3150 val_loss:3.33033 train_time:922.910s step_avg:348.41ms
+step:2750/3150 val_loss:3.31554 train_time:966.540s step_avg:349.03ms
+step:2850/3150 val_loss:3.30408 train_time:1001.357s step_avg:348.18ms
+step:2875/3150 val_loss:3.30146 train_time:1010.441s step_avg:363.32ms
+step:2900/3150 val_loss:3.29877 train_time:1019.139s step_avg:347.92ms
+step:2925/3150 val_loss:3.29599 train_time:1027.839s step_avg:348.03ms
+step:2950/3150 val_loss:3.29349 train_time:1036.542s step_avg:348.10ms
+step:2975/3150 val_loss:3.29124 train_time:1045.242s step_avg:348.00ms
+step:3000/3150 val_loss:3.28911 train_time:1053.941s step_avg:347.98ms
+step:3025/3150 val_loss:3.28657 train_time:1062.643s step_avg:348.06ms
+step:3050/3150 val_loss:3.28449 train_time:1071.415s step_avg:350.87ms
+step:3075/3150 val_loss:3.28284 train_time:1080.115s step_avg:348.00ms
+step:3100/3150 val_loss:3.28132 train_time:1088.815s step_avg:348.04ms
+step:3125/3150 val_loss:3.28021 train_time:1097.515s step_avg:347.99ms
+step:3150/3150 val_loss:3.27964 train_time:1106.214s step_avg:347.96ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.69295 train_time:44.023s step_avg:352.19ms
+step:250/3150 val_loss:4.13535 train_time:88.007s step_avg:351.87ms
+step:375/3150 val_loss:3.94774 train_time:131.569s step_avg:348.50ms
+step:500/3150 val_loss:3.83810 train_time:175.501s step_avg:351.46ms
+step:625/3150 val_loss:3.78022 train_time:219.591s step_avg:352.72ms
+step:750/3150 val_loss:3.71688 train_time:263.306s step_avg:349.72ms
+step:875/3150 val_loss:3.66560 train_time:307.398s step_avg:352.73ms
+step:1000/3150 val_loss:3.62413 train_time:351.488s step_avg:352.72ms
+step:1125/3150 val_loss:3.59266 train_time:395.293s step_avg:350.44ms
+step:1250/3150 val_loss:3.55905 train_time:439.450s step_avg:353.26ms
+step:1375/3150 val_loss:3.53465 train_time:483.588s step_avg:353.10ms
+step:1500/3150 val_loss:3.50560 train_time:527.421s step_avg:350.67ms
+step:1625/3150 val_loss:3.48599 train_time:571.539s step_avg:352.94ms
+step:1750/3150 val_loss:3.46214 train_time:615.610s step_avg:352.56ms
+step:1875/3150 val_loss:3.44202 train_time:659.315s step_avg:349.64ms
+step:2000/3150 val_loss:3.42178 train_time:703.435s step_avg:352.96ms
+step:2125/3150 val_loss:3.40322 train_time:747.514s step_avg:352.63ms
+step:2250/3150 val_loss:3.38435 train_time:791.269s step_avg:350.03ms
+step:2375/3150 val_loss:3.36721 train_time:835.349s step_avg:352.64ms
+step:2500/3150 val_loss:3.34567 train_time:879.256s step_avg:351.25ms
+step:2625/3150 val_loss:3.32877 train_time:922.824s step_avg:348.55ms
+step:2750/3150 val_loss:3.31369 train_time:966.777s step_avg:351.62ms
+step:2850/3150 val_loss:3.30210 train_time:1001.652s step_avg:348.75ms
+step:2875/3150 val_loss:3.29945 train_time:1010.457s step_avg:352.19ms
+step:2900/3150 val_loss:3.29687 train_time:1019.165s step_avg:348.34ms
+step:2925/3150 val_loss:3.29408 train_time:1027.875s step_avg:348.39ms
+step:2950/3150 val_loss:3.29158 train_time:1036.583s step_avg:348.34ms
+step:2975/3150 val_loss:3.28941 train_time:1045.293s step_avg:348.38ms
+step:3000/3150 val_loss:3.28714 train_time:1054.000s step_avg:348.28ms
+step:3025/3150 val_loss:3.28469 train_time:1062.708s step_avg:348.35ms
+step:3050/3150 val_loss:3.28260 train_time:1071.790s step_avg:363.28ms
+step:3075/3150 val_loss:3.28091 train_time:1080.496s step_avg:348.24ms
+step:3100/3150 val_loss:3.27941 train_time:1089.200s step_avg:348.15ms
+step:3125/3150 val_loss:3.27832 train_time:1097.907s step_avg:348.28ms
+step:3150/3150 val_loss:3.27774 train_time:1106.613s step_avg:348.22ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66833 train_time:43.978s step_avg:351.82ms
+step:250/3150 val_loss:4.12617 train_time:87.901s step_avg:351.39ms
+step:375/3150 val_loss:3.94050 train_time:131.432s step_avg:348.25ms
+step:500/3150 val_loss:3.83292 train_time:175.335s step_avg:351.22ms
+step:625/3150 val_loss:3.77764 train_time:219.422s step_avg:352.70ms
+step:750/3150 val_loss:3.71505 train_time:263.129s step_avg:349.66ms
+step:875/3150 val_loss:3.66484 train_time:307.280s step_avg:353.21ms
+step:1000/3150 val_loss:3.62262 train_time:351.404s step_avg:352.99ms
+step:1125/3150 val_loss:3.59107 train_time:395.096s step_avg:349.54ms
+step:1250/3150 val_loss:3.55855 train_time:439.144s step_avg:352.38ms
+step:1375/3150 val_loss:3.53165 train_time:483.223s step_avg:352.63ms
+step:1500/3150 val_loss:3.50233 train_time:526.929s step_avg:349.65ms
+step:1625/3150 val_loss:3.48337 train_time:570.999s step_avg:352.55ms
+step:1750/3150 val_loss:3.46151 train_time:615.057s step_avg:352.47ms
+step:1875/3150 val_loss:3.44104 train_time:658.738s step_avg:349.45ms
+step:2000/3150 val_loss:3.42101 train_time:702.815s step_avg:352.62ms
+step:2125/3150 val_loss:3.40318 train_time:746.979s step_avg:353.31ms
+step:2250/3150 val_loss:3.38395 train_time:790.732s step_avg:350.03ms
+step:2375/3150 val_loss:3.36686 train_time:834.824s step_avg:352.73ms
+step:2500/3150 val_loss:3.34564 train_time:878.745s step_avg:351.37ms
+step:2625/3150 val_loss:3.32826 train_time:922.243s step_avg:347.99ms
+step:2750/3150 val_loss:3.31321 train_time:966.130s step_avg:351.10ms
+step:2850/3150 val_loss:3.30174 train_time:1000.941s step_avg:348.11ms
+step:2875/3150 val_loss:3.29923 train_time:1010.023s step_avg:363.27ms
+step:2900/3150 val_loss:3.29653 train_time:1018.724s step_avg:348.03ms
+step:2925/3150 val_loss:3.29374 train_time:1027.430s step_avg:348.23ms
+step:2950/3150 val_loss:3.29127 train_time:1036.146s step_avg:348.64ms
+step:2975/3150 val_loss:3.28912 train_time:1044.870s step_avg:348.97ms
+step:3000/3150 val_loss:3.28685 train_time:1053.584s step_avg:348.56ms
+step:3025/3150 val_loss:3.28442 train_time:1062.292s step_avg:348.31ms
+step:3050/3150 val_loss:3.28235 train_time:1071.372s step_avg:363.21ms
+step:3075/3150 val_loss:3.28068 train_time:1080.077s step_avg:348.20ms
+step:3100/3150 val_loss:3.27917 train_time:1088.781s step_avg:348.15ms
+step:3125/3150 val_loss:3.27803 train_time:1097.487s step_avg:348.25ms
+step:3150/3150 val_loss:3.27748 train_time:1106.194s step_avg:348.29ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67858 train_time:43.994s step_avg:351.95ms
+step:250/3150 val_loss:4.13469 train_time:87.943s step_avg:351.60ms
+step:375/3150 val_loss:3.94142 train_time:131.476s step_avg:348.26ms
+step:500/3150 val_loss:3.83661 train_time:175.359s step_avg:351.06ms
+step:625/3150 val_loss:3.77694 train_time:219.495s step_avg:353.09ms
+step:750/3150 val_loss:3.71419 train_time:263.207s step_avg:349.70ms
+step:875/3150 val_loss:3.66488 train_time:307.284s step_avg:352.61ms
+step:1000/3150 val_loss:3.62270 train_time:351.361s step_avg:352.62ms
+step:1125/3150 val_loss:3.59021 train_time:395.067s step_avg:349.65ms
+step:1250/3150 val_loss:3.55664 train_time:439.134s step_avg:352.53ms
+step:1375/3150 val_loss:3.53087 train_time:482.909s step_avg:350.20ms
+step:1500/3150 val_loss:3.50562 train_time:526.645s step_avg:349.89ms
+step:1625/3150 val_loss:3.48441 train_time:570.775s step_avg:353.04ms
+step:1750/3150 val_loss:3.46086 train_time:614.879s step_avg:352.83ms
+step:1875/3150 val_loss:3.44022 train_time:658.599s step_avg:349.76ms
+step:2000/3150 val_loss:3.42131 train_time:702.677s step_avg:352.62ms
+step:2125/3150 val_loss:3.40233 train_time:746.907s step_avg:353.85ms
+step:2250/3150 val_loss:3.38375 train_time:790.695s step_avg:350.30ms
+step:2375/3150 val_loss:3.36640 train_time:834.792s step_avg:352.78ms
+step:2500/3150 val_loss:3.34488 train_time:878.725s step_avg:351.47ms
+step:2625/3150 val_loss:3.32812 train_time:922.251s step_avg:348.20ms
+step:2750/3150 val_loss:3.31275 train_time:966.155s step_avg:351.23ms
+step:2850/3150 val_loss:3.30156 train_time:1000.980s step_avg:348.25ms
+step:2875/3150 val_loss:3.29909 train_time:1009.768s step_avg:351.52ms
+step:2900/3150 val_loss:3.29640 train_time:1018.473s step_avg:348.22ms
+step:2925/3150 val_loss:3.29350 train_time:1027.181s step_avg:348.29ms
+step:2950/3150 val_loss:3.29109 train_time:1035.886s step_avg:348.23ms
+step:2975/3150 val_loss:3.28882 train_time:1044.590s step_avg:348.15ms
+step:3000/3150 val_loss:3.28669 train_time:1053.297s step_avg:348.28ms
+step:3025/3150 val_loss:3.28416 train_time:1062.003s step_avg:348.24ms
+step:3050/3150 val_loss:3.28206 train_time:1071.086s step_avg:363.30ms
+step:3075/3150 val_loss:3.28042 train_time:1079.796s step_avg:348.41ms
+step:3100/3150 val_loss:3.27893 train_time:1088.503s step_avg:348.29ms
+step:3125/3150 val_loss:3.27778 train_time:1097.210s step_avg:348.28ms
+step:3150/3150 val_loss:3.27719 train_time:1105.917s step_avg:348.25ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.69622 train_time:44.076s step_avg:352.60ms
+step:250/3150 val_loss:4.13735 train_time:88.038s step_avg:351.70ms
+step:375/3150 val_loss:3.94532 train_time:131.602s step_avg:348.51ms
+step:500/3150 val_loss:3.84214 train_time:175.481s step_avg:351.04ms
+step:625/3150 val_loss:3.78029 train_time:219.571s step_avg:352.72ms
+step:750/3150 val_loss:3.71521 train_time:263.286s step_avg:349.72ms
+step:875/3150 val_loss:3.66499 train_time:307.412s step_avg:353.01ms
+step:1000/3150 val_loss:3.62479 train_time:351.546s step_avg:353.07ms
+step:1125/3150 val_loss:3.59180 train_time:395.259s step_avg:349.70ms
+step:1250/3150 val_loss:3.55798 train_time:439.315s step_avg:352.45ms
+step:1375/3150 val_loss:3.53245 train_time:483.438s step_avg:352.99ms
+step:1500/3150 val_loss:3.50548 train_time:527.290s step_avg:350.82ms
+step:1625/3150 val_loss:3.48532 train_time:571.410s step_avg:352.96ms
+step:1750/3150 val_loss:3.46327 train_time:615.516s step_avg:352.85ms
+step:1875/3150 val_loss:3.44210 train_time:659.269s step_avg:350.02ms
+step:2000/3150 val_loss:3.42226 train_time:703.379s step_avg:352.88ms
+step:2125/3150 val_loss:3.40442 train_time:747.556s step_avg:353.42ms
+step:2250/3150 val_loss:3.38571 train_time:791.268s step_avg:349.70ms
+step:2375/3150 val_loss:3.36849 train_time:835.364s step_avg:352.77ms
+step:2500/3150 val_loss:3.34706 train_time:879.303s step_avg:351.51ms
+step:2625/3150 val_loss:3.32995 train_time:922.886s step_avg:348.67ms
+step:2750/3150 val_loss:3.31500 train_time:966.795s step_avg:351.27ms
+step:2850/3150 val_loss:3.30385 train_time:1001.611s step_avg:348.16ms
+step:2875/3150 val_loss:3.30129 train_time:1010.701s step_avg:363.58ms
+step:2900/3150 val_loss:3.29862 train_time:1019.405s step_avg:348.16ms
+step:2925/3150 val_loss:3.29582 train_time:1028.110s step_avg:348.21ms
+step:2950/3150 val_loss:3.29333 train_time:1036.816s step_avg:348.22ms
+step:2975/3150 val_loss:3.29100 train_time:1045.519s step_avg:348.12ms
+step:3000/3150 val_loss:3.28883 train_time:1054.223s step_avg:348.17ms
+step:3025/3150 val_loss:3.28642 train_time:1062.928s step_avg:348.20ms
+step:3050/3150 val_loss:3.28431 train_time:1072.009s step_avg:363.26ms
+step:3075/3150 val_loss:3.28265 train_time:1080.712s step_avg:348.10ms
+step:3100/3150 val_loss:3.28116 train_time:1089.418s step_avg:348.23ms
+step:3125/3150 val_loss:3.28004 train_time:1098.121s step_avg:348.13ms
+step:3150/3150 val_loss:3.27946 train_time:1106.825s step_avg:348.17ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66469 train_time:59.211s step_avg:473.68ms
+step:250/3150 val_loss:4.12927 train_time:103.577s step_avg:354.93ms
+step:375/3150 val_loss:3.94039 train_time:147.561s step_avg:351.88ms
+step:500/3150 val_loss:3.83365 train_time:191.814s step_avg:354.02ms
+step:625/3150 val_loss:3.77639 train_time:236.245s step_avg:355.45ms
+step:750/3150 val_loss:3.71713 train_time:280.348s step_avg:352.83ms
+step:875/3150 val_loss:3.66649 train_time:324.748s step_avg:355.20ms
+step:1000/3150 val_loss:3.62480 train_time:369.132s step_avg:355.07ms
+step:1125/3150 val_loss:3.59176 train_time:413.125s step_avg:351.95ms
+step:1250/3150 val_loss:3.55814 train_time:457.528s step_avg:355.22ms
+step:1375/3150 val_loss:3.53318 train_time:501.966s step_avg:355.50ms
+step:1500/3150 val_loss:3.50551 train_time:546.007s step_avg:352.33ms
+step:1625/3150 val_loss:3.48609 train_time:590.422s step_avg:355.33ms
+step:1750/3150 val_loss:3.46292 train_time:634.823s step_avg:355.21ms
+step:1875/3150 val_loss:3.44218 train_time:678.837s step_avg:352.11ms
+step:2000/3150 val_loss:3.42179 train_time:723.213s step_avg:355.01ms
+step:2125/3150 val_loss:3.40375 train_time:767.589s step_avg:355.00ms
+step:2250/3150 val_loss:3.38516 train_time:811.597s step_avg:352.07ms
+step:2375/3150 val_loss:3.36763 train_time:855.966s step_avg:354.95ms
+step:2500/3150 val_loss:3.34580 train_time:900.195s step_avg:353.84ms
+step:2625/3150 val_loss:3.32911 train_time:943.996s step_avg:350.41ms
+step:2750/3150 val_loss:3.31398 train_time:988.211s step_avg:353.72ms
+step:2850/3150 val_loss:3.30246 train_time:1023.327s step_avg:351.16ms
+step:2875/3150 val_loss:3.29996 train_time:1032.478s step_avg:366.04ms
+step:2900/3150 val_loss:3.29733 train_time:1041.250s step_avg:350.86ms
+step:2925/3150 val_loss:3.29438 train_time:1050.027s step_avg:351.12ms
+step:2950/3150 val_loss:3.29193 train_time:1058.807s step_avg:351.18ms
+step:2975/3150 val_loss:3.28972 train_time:1067.578s step_avg:350.85ms
+step:3000/3150 val_loss:3.28759 train_time:1076.349s step_avg:350.84ms
+step:3025/3150 val_loss:3.28507 train_time:1085.123s step_avg:350.95ms
+step:3050/3150 val_loss:3.28304 train_time:1094.271s step_avg:365.92ms
+step:3075/3150 val_loss:3.28139 train_time:1103.035s step_avg:350.57ms
+step:3100/3150 val_loss:3.27990 train_time:1111.797s step_avg:350.45ms
+step:3125/3150 val_loss:3.27872 train_time:1120.558s step_avg:350.47ms
+step:3150/3150 val_loss:3.27816 train_time:1129.317s step_avg:350.34ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67348 train_time:44.320s step_avg:354.56ms
+step:250/3150 val_loss:4.12755 train_time:88.634s step_avg:354.51ms
+step:375/3150 val_loss:3.93954 train_time:132.521s step_avg:351.10ms
+step:500/3150 val_loss:3.83241 train_time:176.778s step_avg:354.06ms
+step:625/3150 val_loss:3.77505 train_time:221.200s step_avg:355.38ms
+step:750/3150 val_loss:3.71316 train_time:265.233s step_avg:352.27ms
+step:875/3150 val_loss:3.66370 train_time:309.638s step_avg:355.24ms
+step:1000/3150 val_loss:3.62204 train_time:354.052s step_avg:355.32ms
+step:1125/3150 val_loss:3.58922 train_time:398.093s step_avg:352.33ms
+step:1250/3150 val_loss:3.55594 train_time:442.562s step_avg:355.75ms
+step:1375/3150 val_loss:3.52999 train_time:487.019s step_avg:355.66ms
+step:1500/3150 val_loss:3.50320 train_time:531.043s step_avg:352.19ms
+step:1625/3150 val_loss:3.48260 train_time:575.438s step_avg:355.16ms
+step:1750/3150 val_loss:3.45931 train_time:619.836s step_avg:355.18ms
+step:1875/3150 val_loss:3.43894 train_time:663.853s step_avg:352.14ms
+step:2000/3150 val_loss:3.41895 train_time:708.247s step_avg:355.15ms
+step:2125/3150 val_loss:3.40047 train_time:752.639s step_avg:355.14ms
+step:2250/3150 val_loss:3.38181 train_time:796.634s step_avg:351.96ms
+step:2375/3150 val_loss:3.36465 train_time:841.043s step_avg:355.27ms
+step:2500/3150 val_loss:3.34263 train_time:885.299s step_avg:354.05ms
+step:2625/3150 val_loss:3.32589 train_time:929.096s step_avg:350.37ms
+step:2750/3150 val_loss:3.31090 train_time:973.277s step_avg:353.45ms
+step:2850/3150 val_loss:3.29952 train_time:1008.315s step_avg:350.38ms
+step:2875/3150 val_loss:3.29680 train_time:1017.451s step_avg:365.46ms
+step:2900/3150 val_loss:3.29401 train_time:1026.219s step_avg:350.72ms
+step:2925/3150 val_loss:3.29123 train_time:1034.977s step_avg:350.32ms
+step:2950/3150 val_loss:3.28892 train_time:1043.745s step_avg:350.72ms
+step:2975/3150 val_loss:3.28666 train_time:1052.511s step_avg:350.61ms
+step:3000/3150 val_loss:3.28454 train_time:1061.277s step_avg:350.64ms
+step:3025/3150 val_loss:3.28200 train_time:1070.043s step_avg:350.67ms
+step:3050/3150 val_loss:3.27991 train_time:1079.176s step_avg:365.31ms
+step:3075/3150 val_loss:3.27823 train_time:1087.933s step_avg:350.28ms
+step:3100/3150 val_loss:3.27672 train_time:1096.692s step_avg:350.35ms
+step:3125/3150 val_loss:3.27559 train_time:1105.458s step_avg:350.68ms
+step:3150/3150 val_loss:3.27503 train_time:1114.232s step_avg:350.93ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66786 train_time:44.396s step_avg:355.17ms
+step:250/3150 val_loss:4.12207 train_time:88.718s step_avg:354.57ms
+step:375/3150 val_loss:3.93842 train_time:132.593s step_avg:351.00ms
+step:500/3150 val_loss:3.83082 train_time:176.799s step_avg:353.65ms
+step:625/3150 val_loss:3.77304 train_time:221.216s step_avg:355.33ms
+step:750/3150 val_loss:3.71374 train_time:265.278s step_avg:352.50ms
+step:875/3150 val_loss:3.66248 train_time:309.661s step_avg:355.06ms
+step:1000/3150 val_loss:3.62264 train_time:354.035s step_avg:354.99ms
+step:1125/3150 val_loss:3.58978 train_time:398.088s step_avg:352.43ms
+step:1250/3150 val_loss:3.55717 train_time:442.480s step_avg:355.13ms
+step:1375/3150 val_loss:3.53056 train_time:486.923s step_avg:355.54ms
+step:1500/3150 val_loss:3.50370 train_time:530.964s step_avg:352.32ms
+step:1625/3150 val_loss:3.48404 train_time:575.364s step_avg:355.21ms
+step:1750/3150 val_loss:3.46040 train_time:619.792s step_avg:355.42ms
+step:1875/3150 val_loss:3.44037 train_time:663.794s step_avg:352.02ms
+step:2000/3150 val_loss:3.42052 train_time:708.152s step_avg:354.86ms
+step:2125/3150 val_loss:3.40195 train_time:752.501s step_avg:354.79ms
+step:2250/3150 val_loss:3.38325 train_time:796.544s step_avg:352.34ms
+step:2375/3150 val_loss:3.36610 train_time:840.982s step_avg:355.50ms
+step:2500/3150 val_loss:3.34443 train_time:885.243s step_avg:354.09ms
+step:2625/3150 val_loss:3.32795 train_time:929.052s step_avg:350.47ms
+step:2750/3150 val_loss:3.31271 train_time:973.224s step_avg:353.38ms
+step:2850/3150 val_loss:3.30100 train_time:1008.264s step_avg:350.40ms
+step:2875/3150 val_loss:3.29845 train_time:1017.405s step_avg:365.62ms
+step:2900/3150 val_loss:3.29581 train_time:1026.171s step_avg:350.64ms
+step:2925/3150 val_loss:3.29301 train_time:1034.939s step_avg:350.72ms
+step:2950/3150 val_loss:3.29058 train_time:1043.698s step_avg:350.35ms
+step:2975/3150 val_loss:3.28823 train_time:1052.458s step_avg:350.41ms
+step:3000/3150 val_loss:3.28614 train_time:1061.223s step_avg:350.62ms
+step:3025/3150 val_loss:3.28360 train_time:1069.989s step_avg:350.61ms
+step:3050/3150 val_loss:3.28158 train_time:1079.135s step_avg:365.86ms
+step:3075/3150 val_loss:3.27989 train_time:1087.896s step_avg:350.46ms
+step:3100/3150 val_loss:3.27837 train_time:1096.668s step_avg:350.88ms
+step:3125/3150 val_loss:3.27723 train_time:1105.438s step_avg:350.80ms
+step:3150/3150 val_loss:3.27665 train_time:1114.204s step_avg:350.62ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.68875 train_time:44.264s step_avg:354.11ms
+step:250/3150 val_loss:4.13547 train_time:88.493s step_avg:353.83ms
+step:375/3150 val_loss:3.94014 train_time:132.344s step_avg:350.81ms
+step:500/3150 val_loss:3.83533 train_time:176.555s step_avg:353.69ms
+step:625/3150 val_loss:3.77622 train_time:220.949s step_avg:355.16ms
+step:750/3150 val_loss:3.71441 train_time:264.968s step_avg:352.15ms
+step:875/3150 val_loss:3.66450 train_time:309.370s step_avg:355.21ms
+step:1000/3150 val_loss:3.62255 train_time:353.784s step_avg:355.31ms
+step:1125/3150 val_loss:3.59150 train_time:397.843s step_avg:352.47ms
+step:1250/3150 val_loss:3.55951 train_time:442.221s step_avg:355.03ms
+step:1375/3150 val_loss:3.53402 train_time:486.291s step_avg:352.56ms
+step:1500/3150 val_loss:3.50600 train_time:530.285s step_avg:351.95ms
+step:1625/3150 val_loss:3.48536 train_time:574.663s step_avg:355.03ms
+step:1750/3150 val_loss:3.46312 train_time:619.063s step_avg:355.19ms
+step:1875/3150 val_loss:3.44260 train_time:663.095s step_avg:352.26ms
+step:2000/3150 val_loss:3.42299 train_time:707.513s step_avg:355.35ms
+step:2125/3150 val_loss:3.40472 train_time:751.942s step_avg:355.43ms
+step:2250/3150 val_loss:3.38550 train_time:796.065s step_avg:352.99ms
+step:2375/3150 val_loss:3.36831 train_time:840.514s step_avg:355.59ms
+step:2500/3150 val_loss:3.34696 train_time:884.802s step_avg:354.30ms
+step:2625/3150 val_loss:3.33012 train_time:928.654s step_avg:350.82ms
+step:2750/3150 val_loss:3.31500 train_time:972.870s step_avg:353.72ms
+step:2850/3150 val_loss:3.30360 train_time:1007.920s step_avg:350.50ms
+step:2875/3150 val_loss:3.30099 train_time:1017.063s step_avg:365.71ms
+step:2900/3150 val_loss:3.29838 train_time:1025.820s step_avg:350.30ms
+step:2925/3150 val_loss:3.29537 train_time:1034.586s step_avg:350.63ms
+step:2950/3150 val_loss:3.29298 train_time:1043.353s step_avg:350.69ms
+step:2975/3150 val_loss:3.29063 train_time:1052.119s step_avg:350.62ms
+step:3000/3150 val_loss:3.28852 train_time:1060.876s step_avg:350.30ms
+step:3025/3150 val_loss:3.28610 train_time:1069.637s step_avg:350.44ms
+step:3050/3150 val_loss:3.28402 train_time:1078.782s step_avg:365.78ms
+step:3075/3150 val_loss:3.28238 train_time:1087.551s step_avg:350.77ms
+step:3100/3150 val_loss:3.28089 train_time:1096.320s step_avg:350.75ms
+step:3125/3150 val_loss:3.27976 train_time:1105.083s step_avg:350.52ms
+step:3150/3150 val_loss:3.27920 train_time:1113.846s step_avg:350.53ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67944 train_time:44.263s step_avg:354.11ms
+step:250/3150 val_loss:4.12089 train_time:88.484s step_avg:353.76ms
+step:375/3150 val_loss:3.93860 train_time:132.396s step_avg:351.30ms
+step:500/3150 val_loss:3.83278 train_time:176.620s step_avg:353.79ms
+step:625/3150 val_loss:3.77390 train_time:221.002s step_avg:355.06ms
+step:750/3150 val_loss:3.71318 train_time:264.997s step_avg:351.96ms
+step:875/3150 val_loss:3.66446 train_time:309.428s step_avg:355.44ms
+step:1000/3150 val_loss:3.62372 train_time:353.835s step_avg:355.26ms
+step:1125/3150 val_loss:3.59070 train_time:397.912s step_avg:352.62ms
+step:1250/3150 val_loss:3.55714 train_time:442.336s step_avg:355.39ms
+step:1375/3150 val_loss:3.53283 train_time:486.760s step_avg:355.39ms
+step:1500/3150 val_loss:3.50481 train_time:530.793s step_avg:352.26ms
+step:1625/3150 val_loss:3.48513 train_time:575.222s step_avg:355.43ms
+step:1750/3150 val_loss:3.46296 train_time:619.655s step_avg:355.46ms
+step:1875/3150 val_loss:3.44234 train_time:663.728s step_avg:352.59ms
+step:2000/3150 val_loss:3.42248 train_time:708.111s step_avg:355.07ms
+step:2125/3150 val_loss:3.40395 train_time:752.462s step_avg:354.81ms
+step:2250/3150 val_loss:3.38508 train_time:796.519s step_avg:352.45ms
+step:2375/3150 val_loss:3.36775 train_time:840.924s step_avg:355.24ms
+step:2500/3150 val_loss:3.34624 train_time:885.157s step_avg:353.87ms
+step:2625/3150 val_loss:3.32902 train_time:928.993s step_avg:350.69ms
+step:2750/3150 val_loss:3.31385 train_time:973.264s step_avg:354.17ms
+step:2850/3150 val_loss:3.30281 train_time:1008.402s step_avg:351.37ms
+step:2875/3150 val_loss:3.30000 train_time:1017.542s step_avg:365.62ms
+step:2900/3150 val_loss:3.29733 train_time:1026.309s step_avg:350.66ms
+step:2925/3150 val_loss:3.29452 train_time:1035.079s step_avg:350.82ms
+step:2950/3150 val_loss:3.29193 train_time:1043.845s step_avg:350.61ms
+step:2975/3150 val_loss:3.28970 train_time:1052.621s step_avg:351.05ms
+step:3000/3150 val_loss:3.28761 train_time:1061.387s step_avg:350.65ms
+step:3025/3150 val_loss:3.28523 train_time:1070.155s step_avg:350.73ms
+step:3050/3150 val_loss:3.28308 train_time:1079.295s step_avg:365.59ms
+step:3075/3150 val_loss:3.28141 train_time:1088.054s step_avg:350.37ms
+step:3100/3150 val_loss:3.27989 train_time:1096.816s step_avg:350.49ms
+step:3125/3150 val_loss:3.27879 train_time:1105.580s step_avg:350.54ms
+step:3150/3150 val_loss:3.27821 train_time:1114.345s step_avg:350.61ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66771 train_time:46.434s step_avg:371.47ms
+step:250/3150 val_loss:4.12484 train_time:90.508s step_avg:352.59ms
+step:375/3150 val_loss:3.93970 train_time:134.193s step_avg:349.48ms
+step:500/3150 val_loss:3.83360 train_time:178.140s step_avg:351.58ms
+step:625/3150 val_loss:3.77543 train_time:222.238s step_avg:352.78ms
+step:750/3150 val_loss:3.71225 train_time:265.929s step_avg:349.52ms
+step:875/3150 val_loss:3.66294 train_time:310.028s step_avg:352.80ms
+step:1000/3150 val_loss:3.62227 train_time:354.148s step_avg:352.96ms
+step:1125/3150 val_loss:3.59077 train_time:397.859s step_avg:349.69ms
+step:1250/3150 val_loss:3.55657 train_time:442.026s step_avg:353.34ms
+step:1375/3150 val_loss:3.53176 train_time:486.096s step_avg:352.56ms
+step:1500/3150 val_loss:3.50248 train_time:529.788s step_avg:349.54ms
+step:1625/3150 val_loss:3.48310 train_time:573.861s step_avg:352.59ms
+step:1750/3150 val_loss:3.46063 train_time:617.969s step_avg:352.86ms
+step:1875/3150 val_loss:3.44021 train_time:661.659s step_avg:349.52ms
+step:2000/3150 val_loss:3.42028 train_time:705.713s step_avg:352.43ms
+step:2125/3150 val_loss:3.40181 train_time:749.762s step_avg:352.39ms
+step:2250/3150 val_loss:3.38347 train_time:793.439s step_avg:349.42ms
+step:2375/3150 val_loss:3.36665 train_time:837.490s step_avg:352.41ms
+step:2500/3150 val_loss:3.34485 train_time:881.392s step_avg:351.21ms
+step:2625/3150 val_loss:3.32807 train_time:924.891s step_avg:347.99ms
+step:2750/3150 val_loss:3.31284 train_time:968.771s step_avg:351.04ms
+step:2850/3150 val_loss:3.30132 train_time:1003.579s step_avg:348.08ms
+step:2875/3150 val_loss:3.29877 train_time:1012.661s step_avg:363.28ms
+step:2900/3150 val_loss:3.29603 train_time:1021.370s step_avg:348.37ms
+step:2925/3150 val_loss:3.29317 train_time:1030.085s step_avg:348.60ms
+step:2950/3150 val_loss:3.29077 train_time:1038.802s step_avg:348.67ms
+step:2975/3150 val_loss:3.28851 train_time:1047.512s step_avg:348.40ms
+step:3000/3150 val_loss:3.28642 train_time:1056.221s step_avg:348.37ms
+step:3025/3150 val_loss:3.28391 train_time:1064.926s step_avg:348.18ms
+step:3050/3150 val_loss:3.28182 train_time:1074.002s step_avg:363.07ms
+step:3075/3150 val_loss:3.28022 train_time:1082.709s step_avg:348.28ms
+step:3100/3150 val_loss:3.27869 train_time:1091.414s step_avg:348.20ms
+step:3125/3150 val_loss:3.27757 train_time:1100.117s step_avg:348.11ms
+step:3150/3150 val_loss:3.27698 train_time:1108.820s step_avg:348.10ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.68203 train_time:44.034s step_avg:352.27ms
+step:250/3150 val_loss:4.13236 train_time:87.977s step_avg:351.54ms
+step:375/3150 val_loss:3.94280 train_time:131.506s step_avg:348.23ms
+step:500/3150 val_loss:3.83559 train_time:175.440s step_avg:351.47ms
+step:625/3150 val_loss:3.77781 train_time:219.564s step_avg:352.99ms
+step:750/3150 val_loss:3.71549 train_time:263.285s step_avg:349.77ms
+step:875/3150 val_loss:3.66733 train_time:307.388s step_avg:352.83ms
+step:1000/3150 val_loss:3.62474 train_time:351.503s step_avg:352.92ms
+step:1125/3150 val_loss:3.59195 train_time:395.231s step_avg:349.82ms
+step:1250/3150 val_loss:3.55945 train_time:439.313s step_avg:352.66ms
+step:1375/3150 val_loss:3.53338 train_time:483.378s step_avg:352.52ms
+step:1500/3150 val_loss:3.50551 train_time:527.077s step_avg:349.60ms
+step:1625/3150 val_loss:3.48535 train_time:571.157s step_avg:352.64ms
+step:1750/3150 val_loss:3.46296 train_time:615.294s step_avg:353.10ms
+step:1875/3150 val_loss:3.44230 train_time:658.995s step_avg:349.60ms
+step:2000/3150 val_loss:3.42178 train_time:702.783s step_avg:350.30ms
+step:2125/3150 val_loss:3.40377 train_time:746.850s step_avg:352.54ms
+step:2250/3150 val_loss:3.38482 train_time:790.539s step_avg:349.51ms
+step:2375/3150 val_loss:3.36751 train_time:834.592s step_avg:352.43ms
+step:2500/3150 val_loss:3.34585 train_time:878.484s step_avg:351.14ms
+step:2625/3150 val_loss:3.32915 train_time:921.969s step_avg:347.87ms
+step:2750/3150 val_loss:3.31416 train_time:965.827s step_avg:350.87ms
+step:2850/3150 val_loss:3.30287 train_time:1000.629s step_avg:348.02ms
+step:2875/3150 val_loss:3.30028 train_time:1009.713s step_avg:363.38ms
+step:2900/3150 val_loss:3.29764 train_time:1018.421s step_avg:348.31ms
+step:2925/3150 val_loss:3.29470 train_time:1027.128s step_avg:348.27ms
+step:2950/3150 val_loss:3.29231 train_time:1035.833s step_avg:348.20ms
+step:2975/3150 val_loss:3.28994 train_time:1044.541s step_avg:348.33ms
+step:3000/3150 val_loss:3.28785 train_time:1053.249s step_avg:348.30ms
+step:3025/3150 val_loss:3.28536 train_time:1061.956s step_avg:348.28ms
+step:3050/3150 val_loss:3.28328 train_time:1071.048s step_avg:363.71ms
+step:3075/3150 val_loss:3.28163 train_time:1079.753s step_avg:348.20ms
+step:3100/3150 val_loss:3.28017 train_time:1088.456s step_avg:348.13ms
+step:3125/3150 val_loss:3.27901 train_time:1097.160s step_avg:348.13ms
+step:3150/3150 val_loss:3.27844 train_time:1105.865s step_avg:348.22ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66927 train_time:43.994s step_avg:351.95ms
+step:250/3150 val_loss:4.13055 train_time:87.928s step_avg:351.47ms
+step:375/3150 val_loss:3.94202 train_time:131.462s step_avg:348.28ms
+step:500/3150 val_loss:3.83520 train_time:175.382s step_avg:351.35ms
+step:625/3150 val_loss:3.77823 train_time:219.465s step_avg:352.67ms
+step:750/3150 val_loss:3.71737 train_time:263.183s step_avg:349.74ms
+step:875/3150 val_loss:3.66631 train_time:307.275s step_avg:352.74ms
+step:1000/3150 val_loss:3.62540 train_time:351.377s step_avg:352.81ms
+step:1125/3150 val_loss:3.59338 train_time:395.100s step_avg:349.79ms
+step:1250/3150 val_loss:3.56051 train_time:439.194s step_avg:352.75ms
+step:1375/3150 val_loss:3.53462 train_time:483.290s step_avg:352.77ms
+step:1500/3150 val_loss:3.50573 train_time:527.072s step_avg:350.25ms
+step:1625/3150 val_loss:3.48658 train_time:571.233s step_avg:353.29ms
+step:1750/3150 val_loss:3.46343 train_time:615.358s step_avg:353.00ms
+step:1875/3150 val_loss:3.44386 train_time:659.111s step_avg:350.02ms
+step:2000/3150 val_loss:3.42387 train_time:703.163s step_avg:352.42ms
+step:2125/3150 val_loss:3.40529 train_time:747.225s step_avg:352.49ms
+step:2250/3150 val_loss:3.38614 train_time:790.899s step_avg:349.39ms
+step:2375/3150 val_loss:3.36909 train_time:834.948s step_avg:352.39ms
+step:2500/3150 val_loss:3.34765 train_time:878.857s step_avg:351.27ms
+step:2625/3150 val_loss:3.33055 train_time:922.361s step_avg:348.04ms
+step:2750/3150 val_loss:3.31562 train_time:966.241s step_avg:351.04ms
+step:2850/3150 val_loss:3.30431 train_time:1001.053s step_avg:348.12ms
+step:2875/3150 val_loss:3.30162 train_time:1010.135s step_avg:363.27ms
+step:2900/3150 val_loss:3.29902 train_time:1018.840s step_avg:348.23ms
+step:2925/3150 val_loss:3.29623 train_time:1027.547s step_avg:348.26ms
+step:2950/3150 val_loss:3.29384 train_time:1036.260s step_avg:348.53ms
+step:2975/3150 val_loss:3.29155 train_time:1044.979s step_avg:348.76ms
+step:3000/3150 val_loss:3.28931 train_time:1053.696s step_avg:348.68ms
+step:3025/3150 val_loss:3.28685 train_time:1062.407s step_avg:348.45ms
+step:3050/3150 val_loss:3.28485 train_time:1071.494s step_avg:363.47ms
+step:3075/3150 val_loss:3.28322 train_time:1080.208s step_avg:348.54ms
+step:3100/3150 val_loss:3.28170 train_time:1088.919s step_avg:348.44ms
+step:3125/3150 val_loss:3.28060 train_time:1097.628s step_avg:348.37ms
+step:3150/3150 val_loss:3.28003 train_time:1106.336s step_avg:348.30ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.67821 train_time:43.998s step_avg:351.98ms
+step:250/3150 val_loss:4.12522 train_time:87.944s step_avg:351.57ms
+step:375/3150 val_loss:3.93912 train_time:131.462s step_avg:348.14ms
+step:500/3150 val_loss:3.83306 train_time:175.379s step_avg:351.34ms
+step:625/3150 val_loss:3.77485 train_time:219.509s step_avg:353.04ms
+step:750/3150 val_loss:3.71297 train_time:263.249s step_avg:349.92ms
+step:875/3150 val_loss:3.66539 train_time:307.348s step_avg:352.79ms
+step:1000/3150 val_loss:3.62543 train_time:351.431s step_avg:352.67ms
+step:1125/3150 val_loss:3.58903 train_time:395.156s step_avg:349.80ms
+step:1250/3150 val_loss:3.55807 train_time:439.250s step_avg:352.76ms
+step:1375/3150 val_loss:3.53051 train_time:483.357s step_avg:352.85ms
+step:1500/3150 val_loss:3.50391 train_time:527.057s step_avg:349.60ms
+step:1625/3150 val_loss:3.48462 train_time:571.110s step_avg:352.42ms
+step:1750/3150 val_loss:3.46154 train_time:614.864s step_avg:350.04ms
+step:1875/3150 val_loss:3.44175 train_time:658.584s step_avg:349.75ms
+step:2000/3150 val_loss:3.42162 train_time:702.342s step_avg:350.07ms
+step:2125/3150 val_loss:3.40323 train_time:746.398s step_avg:352.45ms
+step:2250/3150 val_loss:3.38455 train_time:790.074s step_avg:349.41ms
+step:2375/3150 val_loss:3.36715 train_time:834.128s step_avg:352.44ms
+step:2500/3150 val_loss:3.34554 train_time:878.013s step_avg:351.08ms
+step:2625/3150 val_loss:3.32854 train_time:921.499s step_avg:347.89ms
+step:2750/3150 val_loss:3.31371 train_time:965.381s step_avg:351.05ms
+step:2850/3150 val_loss:3.30246 train_time:1000.203s step_avg:348.23ms
+step:2875/3150 val_loss:3.29985 train_time:1009.286s step_avg:363.30ms
+step:2900/3150 val_loss:3.29715 train_time:1017.989s step_avg:348.15ms
+step:2925/3150 val_loss:3.29433 train_time:1026.691s step_avg:348.07ms
+step:2950/3150 val_loss:3.29194 train_time:1035.396s step_avg:348.19ms
+step:2975/3150 val_loss:3.28967 train_time:1044.098s step_avg:348.08ms
+step:3000/3150 val_loss:3.28752 train_time:1052.799s step_avg:348.05ms
+step:3025/3150 val_loss:3.28495 train_time:1061.500s step_avg:348.03ms
+step:3050/3150 val_loss:3.28291 train_time:1070.569s step_avg:362.77ms
+step:3075/3150 val_loss:3.28123 train_time:1079.267s step_avg:347.93ms
+step:3100/3150 val_loss:3.27977 train_time:1087.970s step_avg:348.13ms
+step:3125/3150 val_loss:3.27865 train_time:1096.685s step_avg:348.57ms
+step:3150/3150 val_loss:3.27807 train_time:1105.397s step_avg:348.49ms
+step:0/3150 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3150 val_loss:4.66896 train_time:44.001s step_avg:352.01ms
+step:250/3150 val_loss:4.12050 train_time:88.034s step_avg:352.26ms
+step:375/3150 val_loss:3.93571 train_time:131.597s step_avg:348.50ms
+step:500/3150 val_loss:3.83179 train_time:175.522s step_avg:351.41ms
+step:625/3150 val_loss:3.77277 train_time:219.625s step_avg:352.82ms
+step:750/3150 val_loss:3.71430 train_time:263.408s step_avg:350.27ms
+step:875/3150 val_loss:3.66415 train_time:307.562s step_avg:353.23ms
+step:1000/3150 val_loss:3.62249 train_time:351.676s step_avg:352.91ms
+step:1125/3150 val_loss:3.59021 train_time:395.468s step_avg:350.33ms
+step:1250/3150 val_loss:3.55782 train_time:439.607s step_avg:353.11ms
+step:1375/3150 val_loss:3.53196 train_time:483.735s step_avg:353.03ms
+step:1500/3150 val_loss:3.50619 train_time:527.433s step_avg:349.58ms
+step:1625/3150 val_loss:3.48458 train_time:571.500s step_avg:352.54ms
+step:1750/3150 val_loss:3.46205 train_time:615.570s step_avg:352.56ms
+step:1875/3150 val_loss:3.44099 train_time:659.278s step_avg:349.66ms
+step:2000/3150 val_loss:3.42126 train_time:703.352s step_avg:352.60ms
+step:2125/3150 val_loss:3.40315 train_time:747.422s step_avg:352.56ms
+step:2250/3150 val_loss:3.38436 train_time:791.118s step_avg:349.57ms
+step:2375/3150 val_loss:3.36702 train_time:835.170s step_avg:352.41ms
+step:2500/3150 val_loss:3.34549 train_time:879.076s step_avg:351.25ms
+step:2625/3150 val_loss:3.32837 train_time:922.641s step_avg:348.52ms
+step:2750/3150 val_loss:3.31335 train_time:966.582s step_avg:351.53ms
+step:2850/3150 val_loss:3.30215 train_time:1001.424s step_avg:348.42ms
+step:2875/3150 val_loss:3.29959 train_time:1010.514s step_avg:363.57ms
+step:2900/3150 val_loss:3.29687 train_time:1019.224s step_avg:348.41ms
+step:2925/3150 val_loss:3.29405 train_time:1027.933s step_avg:348.38ms
+step:2950/3150 val_loss:3.29162 train_time:1036.644s step_avg:348.41ms
+step:2975/3150 val_loss:3.28939 train_time:1045.352s step_avg:348.33ms
+step:3000/3150 val_loss:3.28718 train_time:1054.062s step_avg:348.39ms
+step:3025/3150 val_loss:3.28472 train_time:1062.766s step_avg:348.19ms
+step:3050/3150 val_loss:3.28266 train_time:1071.844s step_avg:363.11ms
+step:3075/3150 val_loss:3.28098 train_time:1080.546s step_avg:348.06ms
+step:3100/3150 val_loss:3.27951 train_time:1089.248s step_avg:348.08ms
+step:3125/3150 val_loss:3.27841 train_time:1097.946s step_avg:347.93ms
+step:3150/3150 val_loss:3.27785 train_time:1106.646s step_avg:348.01ms


### PR DESCRIPTION
## EMA-Nesterov + Muon (3125 steps, n = 20)

We apply EMA-Nesterov ([paper](https://arxiv.org/abs/2605.25395)) onto the Muon from leaderbaord entry [#12](https://github.com/KellerJordan/modded-nanogpt/blob/master/records/track_3_optimization/results/1bd8db7a-f3a3-4195-856d-cab7e0816443.txt) and reduces the training steps to 3.28 validation loss from 3325 to 3125. 

## Algorithm

EMA-Nesterov modifies the Nesterov's lookahead algorithm into using an EMA lookahead direction. Under any base optimizer function $A_t$ that is designed to take the current state ${\bf x}^t$ and return the next state ${\bf x}^{t+1}$, with lookahead step sizes $\beta_t$ and an EMA rate $\gamma \in (0,1)$, we initialize ${\bf m}^0 = {\bf 0}$ and perform

$${\bf x}^{t+1} = A_t({\bf x}^t + \beta_t {\bf m}^t),$$
$${\bf m}^{t+1} = \gamma {\bf m}^t + (1-\gamma)({\bf x}^{t+1} - {\bf x}^t).$$


In this submission, we choose $A_t$ as the Muon optimizer from [#12](https://github.com/KellerJordan/modded-nanogpt/blob/master/records/track_3_optimization/results/1bd8db7a-f3a3-4195-856d-cab7e0816443.txt), $\gamma = 0.99$ and 
$$\beta_t = 0 \quad  \quad \quad \quad \quad  \quad ~ \text{for} \quad t\in [0, 500) \cup [2400, 3150],$$
$$\beta_t = 0.6 \cdot \frac{\alpha_t}{ \max_r \alpha_r } \quad \text{for} \quad t\in [500, 2400),$$
where $\alpha_t$ is the learning rate of $A_t$.

## Results
With $n=20$ random runs, at iteration $t=3125$ we achieved the validation loss of mean $\mu= 3.279$ such that $(3.28 - \mu) * \sqrt{n} = 0.00646 > 0.004$ that satisfies with the statistical significance requirement.

<img width="1164" height="625" alt="ema_nesterov+muon" src="https://github.com/user-attachments/assets/7062006e-8abd-4f90-991c-96ca5af2f78a" />
