### PR TITLE
Track 3: 3275 steps (n=8) Arbor Muon

### DIFF
--- a/records/track_3_optimization/results/20260523_arbor_muon/3c2d1c4b-2d42-4201-9130-89db37f833db.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/3c2d1c4b-2d42-4201-9130-89db37f833db.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.62333 train_time:117.289s step_avg:938.31ms
+step:250/3350 val_loss:4.09944 train_time:217.867s step_avg:804.62ms
+step:375/3350 val_loss:3.91918 train_time:317.925s step_avg:800.47ms
+step:500/3350 val_loss:3.81827 train_time:417.655s step_avg:797.84ms
+step:625/3350 val_loss:3.75041 train_time:517.709s step_avg:800.43ms
+step:750/3350 val_loss:3.70667 train_time:618.033s step_avg:802.60ms
+step:875/3350 val_loss:3.66537 train_time:717.389s step_avg:794.85ms
+step:1000/3350 val_loss:3.63544 train_time:817.457s step_avg:800.54ms
+step:1125/3350 val_loss:3.60782 train_time:917.697s step_avg:801.93ms
+step:1250/3350 val_loss:3.57349 train_time:1017.263s step_avg:796.52ms
+step:1375/3350 val_loss:3.54833 train_time:1117.411s step_avg:801.19ms
+step:1500/3350 val_loss:3.52044 train_time:1217.501s step_avg:800.72ms
+step:1625/3350 val_loss:3.50103 train_time:1317.502s step_avg:800.01ms
+step:1750/3350 val_loss:3.47937 train_time:1417.543s step_avg:800.32ms
+step:1875/3350 val_loss:3.46017 train_time:1517.786s step_avg:801.94ms
+step:2000/3350 val_loss:3.44075 train_time:1617.836s step_avg:800.40ms
+step:2125/3350 val_loss:3.42336 train_time:1717.485s step_avg:797.20ms
+step:2250/3350 val_loss:3.40604 train_time:1817.885s step_avg:803.19ms
+step:2375/3350 val_loss:3.39015 train_time:1917.663s step_avg:798.23ms
+step:2500/3350 val_loss:3.37397 train_time:2017.366s step_avg:797.63ms
+step:2625/3350 val_loss:3.35656 train_time:2117.691s step_avg:802.60ms
+step:2750/3350 val_loss:3.34074 train_time:2217.539s step_avg:798.79ms
+step:2875/3350 val_loss:3.32472 train_time:2317.509s step_avg:799.76ms
+step:3000/3350 val_loss:3.30898 train_time:2417.533s step_avg:800.19ms
+step:3025/3350 val_loss:3.30522 train_time:2437.551s step_avg:800.72ms
+step:3050/3350 val_loss:3.30225 train_time:2457.603s step_avg:802.09ms
+step:3075/3350 val_loss:3.29930 train_time:2477.613s step_avg:800.39ms
+step:3100/3350 val_loss:3.29651 train_time:2497.603s step_avg:799.60ms
+step:3125/3350 val_loss:3.29391 train_time:2517.588s step_avg:799.42ms
+step:3150/3350 val_loss:3.29076 train_time:2537.578s step_avg:799.60ms
+step:3175/3350 val_loss:3.28812 train_time:2557.517s step_avg:797.56ms
+step:3200/3350 val_loss:3.28547 train_time:2577.446s step_avg:797.14ms
+step:3225/3350 val_loss:3.28324 train_time:2597.377s step_avg:797.26ms
+step:3250/3350 val_loss:3.28118 train_time:2617.349s step_avg:798.88ms
+step:3275/3350 val_loss:3.27932 train_time:2637.338s step_avg:799.55ms
+step:3300/3350 val_loss:3.27774 train_time:2657.374s step_avg:801.42ms
+step:3325/3350 val_loss:3.27652 train_time:2677.446s step_avg:802.90ms
+step:3350/3350 val_loss:3.27594 train_time:2697.563s step_avg:804.69ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/61236c55-c417-4d10-99a4-158d474be62f.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/61236c55-c417-4d10-99a4-158d474be62f.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.64176 train_time:116.879s step_avg:935.03ms
+step:250/3350 val_loss:4.10046 train_time:217.616s step_avg:805.90ms
+step:375/3350 val_loss:3.92038 train_time:317.579s step_avg:799.71ms
+step:500/3350 val_loss:3.81789 train_time:417.397s step_avg:798.55ms
+step:625/3350 val_loss:3.74897 train_time:517.922s step_avg:804.20ms
+step:750/3350 val_loss:3.70510 train_time:617.696s step_avg:798.20ms
+step:875/3350 val_loss:3.66434 train_time:717.468s step_avg:798.17ms
+step:1000/3350 val_loss:3.63090 train_time:817.781s step_avg:802.51ms
+step:1125/3350 val_loss:3.60251 train_time:917.432s step_avg:797.21ms
+step:1250/3350 val_loss:3.57126 train_time:1017.214s step_avg:798.26ms
+step:1375/3350 val_loss:3.54598 train_time:1117.223s step_avg:800.07ms
+step:1500/3350 val_loss:3.52089 train_time:1217.215s step_avg:799.94ms
+step:1625/3350 val_loss:3.50040 train_time:1316.873s step_avg:797.26ms
+step:1750/3350 val_loss:3.47807 train_time:1416.768s step_avg:799.16ms
+step:1875/3350 val_loss:3.45723 train_time:1517.005s step_avg:801.89ms
+step:2000/3350 val_loss:3.43911 train_time:1616.464s step_avg:795.68ms
+step:2125/3350 val_loss:3.42194 train_time:1716.535s step_avg:800.57ms
+step:2250/3350 val_loss:3.40402 train_time:1816.707s step_avg:801.38ms
+step:2375/3350 val_loss:3.38851 train_time:1916.211s step_avg:796.03ms
+step:2500/3350 val_loss:3.37212 train_time:2016.266s step_avg:800.45ms
+step:2625/3350 val_loss:3.35478 train_time:2116.258s step_avg:799.94ms
+step:2750/3350 val_loss:3.33909 train_time:2216.018s step_avg:798.08ms
+step:2875/3350 val_loss:3.32319 train_time:2315.801s step_avg:798.27ms
+step:3000/3350 val_loss:3.30737 train_time:2415.893s step_avg:800.73ms
+step:3025/3350 val_loss:3.30347 train_time:2435.941s step_avg:801.92ms
+step:3050/3350 val_loss:3.30071 train_time:2455.992s step_avg:802.05ms
+step:3075/3350 val_loss:3.29768 train_time:2475.958s step_avg:798.61ms
+step:3100/3350 val_loss:3.29486 train_time:2495.877s step_avg:796.79ms
+step:3125/3350 val_loss:3.29220 train_time:2515.761s step_avg:795.35ms
+step:3150/3350 val_loss:3.28918 train_time:2535.622s step_avg:794.43ms
+step:3175/3350 val_loss:3.28655 train_time:2555.521s step_avg:795.97ms
+step:3200/3350 val_loss:3.28398 train_time:2575.441s step_avg:796.80ms
+step:3225/3350 val_loss:3.28161 train_time:2595.397s step_avg:798.22ms
+step:3250/3350 val_loss:3.27956 train_time:2615.437s step_avg:801.62ms
+step:3275/3350 val_loss:3.27781 train_time:2635.504s step_avg:802.66ms
+step:3300/3350 val_loss:3.27620 train_time:2655.614s step_avg:804.38ms
+step:3325/3350 val_loss:3.27499 train_time:2675.710s step_avg:803.86ms
+step:3350/3350 val_loss:3.27440 train_time:2695.776s step_avg:802.63ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/a2a53de7-8356-4cd3-9ef3-120851c0ea36.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/a2a53de7-8356-4cd3-9ef3-120851c0ea36.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.64214 train_time:116.646s step_avg:933.17ms
+step:250/3350 val_loss:4.10380 train_time:216.736s step_avg:800.72ms
+step:375/3350 val_loss:3.91898 train_time:317.202s step_avg:803.73ms
+step:500/3350 val_loss:3.81513 train_time:416.807s step_avg:796.84ms
+step:625/3350 val_loss:3.74915 train_time:516.951s step_avg:801.15ms
+step:750/3350 val_loss:3.70333 train_time:617.061s step_avg:800.88ms
+step:875/3350 val_loss:3.66285 train_time:716.801s step_avg:797.92ms
+step:1000/3350 val_loss:3.63097 train_time:816.494s step_avg:797.54ms
+step:1125/3350 val_loss:3.60335 train_time:916.355s step_avg:798.89ms
+step:1250/3350 val_loss:3.57106 train_time:1016.454s step_avg:800.80ms
+step:1375/3350 val_loss:3.54734 train_time:1115.791s step_avg:794.69ms
+step:1500/3350 val_loss:3.51627 train_time:1215.729s step_avg:799.51ms
+step:1625/3350 val_loss:3.49873 train_time:1315.832s step_avg:800.82ms
+step:1750/3350 val_loss:3.47544 train_time:1415.189s step_avg:794.86ms
+step:1875/3350 val_loss:3.45584 train_time:1515.248s step_avg:800.47ms
+step:2000/3350 val_loss:3.43753 train_time:1615.175s step_avg:799.42ms
+step:2125/3350 val_loss:3.42016 train_time:1714.874s step_avg:797.59ms
+step:2250/3350 val_loss:3.40246 train_time:1814.647s step_avg:798.18ms
+step:2375/3350 val_loss:3.38681 train_time:1914.694s step_avg:800.38ms
+step:2500/3350 val_loss:3.36995 train_time:2014.457s step_avg:798.10ms
+step:2625/3350 val_loss:3.35290 train_time:2113.919s step_avg:795.70ms
+step:2750/3350 val_loss:3.33720 train_time:2214.264s step_avg:802.76ms
+step:2875/3350 val_loss:3.32103 train_time:2313.881s step_avg:796.94ms
+step:3000/3350 val_loss:3.30560 train_time:2413.369s step_avg:795.91ms
+step:3025/3350 val_loss:3.30165 train_time:2433.404s step_avg:801.37ms
+step:3050/3350 val_loss:3.29863 train_time:2453.491s step_avg:803.50ms
+step:3075/3350 val_loss:3.29590 train_time:2473.549s step_avg:802.32ms
+step:3100/3350 val_loss:3.29294 train_time:2493.568s step_avg:800.76ms
+step:3125/3350 val_loss:3.29025 train_time:2513.542s step_avg:798.95ms
+step:3150/3350 val_loss:3.28724 train_time:2533.498s step_avg:798.24ms
+step:3175/3350 val_loss:3.28467 train_time:2553.422s step_avg:796.97ms
+step:3200/3350 val_loss:3.28206 train_time:2573.332s step_avg:796.41ms
+step:3225/3350 val_loss:3.27983 train_time:2593.253s step_avg:796.82ms
+step:3250/3350 val_loss:3.27771 train_time:2613.200s step_avg:797.90ms
+step:3275/3350 val_loss:3.27592 train_time:2633.155s step_avg:798.18ms
+step:3300/3350 val_loss:3.27438 train_time:2653.125s step_avg:798.80ms
+step:3325/3350 val_loss:3.27317 train_time:2673.098s step_avg:798.93ms
+step:3350/3350 val_loss:3.27258 train_time:2693.078s step_avg:799.19ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/b7450fd2-8c51-4e4a-bbfc-d5c6199fea01.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/b7450fd2-8c51-4e4a-bbfc-d5c6199fea01.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.64931 train_time:116.828s step_avg:934.63ms
+step:250/3350 val_loss:4.10669 train_time:217.069s step_avg:801.92ms
+step:375/3350 val_loss:3.91917 train_time:316.691s step_avg:796.97ms
+step:500/3350 val_loss:3.81575 train_time:416.998s step_avg:802.46ms
+step:625/3350 val_loss:3.74804 train_time:516.753s step_avg:798.04ms
+step:750/3350 val_loss:3.70162 train_time:616.480s step_avg:797.82ms
+step:875/3350 val_loss:3.66291 train_time:716.389s step_avg:799.27ms
+step:1000/3350 val_loss:3.63023 train_time:816.496s step_avg:800.86ms
+step:1125/3350 val_loss:3.60367 train_time:915.940s step_avg:795.55ms
+step:1250/3350 val_loss:3.57007 train_time:1015.735s step_avg:798.36ms
+step:1375/3350 val_loss:3.54412 train_time:1116.005s step_avg:802.16ms
+step:1500/3350 val_loss:3.51809 train_time:1215.251s step_avg:793.97ms
+step:1625/3350 val_loss:3.49820 train_time:1315.209s step_avg:799.66ms
+step:1750/3350 val_loss:3.47689 train_time:1415.314s step_avg:800.84ms
+step:1875/3350 val_loss:3.45582 train_time:1514.835s step_avg:796.17ms
+step:2000/3350 val_loss:3.43734 train_time:1614.884s step_avg:800.39ms
+step:2125/3350 val_loss:3.41995 train_time:1714.939s step_avg:800.44ms
+step:2250/3350 val_loss:3.40212 train_time:1814.722s step_avg:798.26ms
+step:2375/3350 val_loss:3.38618 train_time:1914.465s step_avg:797.94ms
+step:2500/3350 val_loss:3.36989 train_time:2014.774s step_avg:802.48ms
+step:2625/3350 val_loss:3.35228 train_time:2114.773s step_avg:799.99ms
+step:2750/3350 val_loss:3.33645 train_time:2214.153s step_avg:795.04ms
+step:2875/3350 val_loss:3.32070 train_time:2314.614s step_avg:803.69ms
+step:3000/3350 val_loss:3.30491 train_time:2414.435s step_avg:798.57ms
+step:3025/3350 val_loss:3.30094 train_time:2434.321s step_avg:795.42ms
+step:3050/3350 val_loss:3.29803 train_time:2454.299s step_avg:799.11ms
+step:3075/3350 val_loss:3.29501 train_time:2474.262s step_avg:798.52ms
+step:3100/3350 val_loss:3.29221 train_time:2494.251s step_avg:799.58ms
+step:3125/3350 val_loss:3.28960 train_time:2514.346s step_avg:803.77ms
+step:3150/3350 val_loss:3.28667 train_time:2534.404s step_avg:802.35ms
+step:3175/3350 val_loss:3.28402 train_time:2554.463s step_avg:802.34ms
+step:3200/3350 val_loss:3.28148 train_time:2574.518s step_avg:802.19ms
+step:3225/3350 val_loss:3.27918 train_time:2594.541s step_avg:800.95ms
+step:3250/3350 val_loss:3.27715 train_time:2614.597s step_avg:802.21ms
+step:3275/3350 val_loss:3.27527 train_time:2634.581s step_avg:799.39ms
+step:3300/3350 val_loss:3.27364 train_time:2654.564s step_avg:799.29ms
+step:3325/3350 val_loss:3.27243 train_time:2674.543s step_avg:799.16ms
+step:3350/3350 val_loss:3.27184 train_time:2694.519s step_avg:799.05ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/d2caf758-5139-479a-b920-4b64a317a4f0.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/d2caf758-5139-479a-b920-4b64a317a4f0.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.63386 train_time:116.882s step_avg:935.05ms
+step:250/3350 val_loss:4.09149 train_time:217.665s step_avg:806.27ms
+step:375/3350 val_loss:3.91688 train_time:317.721s step_avg:800.45ms
+step:500/3350 val_loss:3.81402 train_time:417.392s step_avg:797.36ms
+step:625/3350 val_loss:3.74630 train_time:517.465s step_avg:800.59ms
+step:750/3350 val_loss:3.70255 train_time:617.426s step_avg:799.69ms
+step:875/3350 val_loss:3.66312 train_time:717.273s step_avg:798.78ms
+step:1000/3350 val_loss:3.62935 train_time:817.035s step_avg:798.09ms
+step:1125/3350 val_loss:3.60220 train_time:917.306s step_avg:802.17ms
+step:1250/3350 val_loss:3.57040 train_time:1016.983s step_avg:797.42ms
+step:1375/3350 val_loss:3.54549 train_time:1116.556s step_avg:796.59ms
+step:1500/3350 val_loss:3.51650 train_time:1216.846s step_avg:802.32ms
+step:1625/3350 val_loss:3.49819 train_time:1316.368s step_avg:796.18ms
+step:1750/3350 val_loss:3.47692 train_time:1416.153s step_avg:798.28ms
+step:1875/3350 val_loss:3.45676 train_time:1516.154s step_avg:800.01ms
+step:2000/3350 val_loss:3.43773 train_time:1615.901s step_avg:797.98ms
+step:2125/3350 val_loss:3.42056 train_time:1715.689s step_avg:798.30ms
+step:2250/3350 val_loss:3.40323 train_time:1815.629s step_avg:799.52ms
+step:2375/3350 val_loss:3.38814 train_time:1915.805s step_avg:801.41ms
+step:2500/3350 val_loss:3.37132 train_time:2015.118s step_avg:794.50ms
+step:2625/3350 val_loss:3.35430 train_time:2115.096s step_avg:799.83ms
+step:2750/3350 val_loss:3.33806 train_time:2215.200s step_avg:800.83ms
+step:2875/3350 val_loss:3.32227 train_time:2314.598s step_avg:795.18ms
+step:3000/3350 val_loss:3.30661 train_time:2414.611s step_avg:800.10ms
+step:3025/3350 val_loss:3.30280 train_time:2434.637s step_avg:801.06ms
+step:3050/3350 val_loss:3.29994 train_time:2454.698s step_avg:802.44ms
+step:3075/3350 val_loss:3.29705 train_time:2474.674s step_avg:799.06ms
+step:3100/3350 val_loss:3.29413 train_time:2494.624s step_avg:798.00ms
+step:3125/3350 val_loss:3.29160 train_time:2514.556s step_avg:797.28ms
+step:3150/3350 val_loss:3.28857 train_time:2534.478s step_avg:796.87ms
+step:3175/3350 val_loss:3.28593 train_time:2554.413s step_avg:797.41ms
+step:3200/3350 val_loss:3.28338 train_time:2574.359s step_avg:797.84ms
+step:3225/3350 val_loss:3.28117 train_time:2594.318s step_avg:798.37ms
+step:3250/3350 val_loss:3.27908 train_time:2614.324s step_avg:800.23ms
+step:3275/3350 val_loss:3.27730 train_time:2634.283s step_avg:798.34ms
+step:3300/3350 val_loss:3.27575 train_time:2654.255s step_avg:798.91ms
+step:3325/3350 val_loss:3.27452 train_time:2674.234s step_avg:799.13ms
+step:3350/3350 val_loss:3.27396 train_time:2694.240s step_avg:800.25ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/ddfb2756-b259-47fc-9aad-076a6b1e7ea9.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/ddfb2756-b259-47fc-9aad-076a6b1e7ea9.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.62668 train_time:116.151s step_avg:929.21ms
+step:250/3350 val_loss:4.09835 train_time:216.392s step_avg:801.92ms
+step:375/3350 val_loss:3.91606 train_time:316.207s step_avg:798.52ms
+step:500/3350 val_loss:3.81620 train_time:416.177s step_avg:799.76ms
+step:625/3350 val_loss:3.74639 train_time:516.412s step_avg:801.88ms
+step:750/3350 val_loss:3.70117 train_time:615.720s step_avg:794.47ms
+step:875/3350 val_loss:3.66227 train_time:715.745s step_avg:800.20ms
+step:1000/3350 val_loss:3.63122 train_time:815.883s step_avg:801.10ms
+step:1125/3350 val_loss:3.60435 train_time:915.169s step_avg:794.29ms
+step:1250/3350 val_loss:3.57072 train_time:1015.276s step_avg:800.85ms
+step:1375/3350 val_loss:3.54591 train_time:1115.180s step_avg:799.23ms
+step:1500/3350 val_loss:3.51745 train_time:1214.805s step_avg:797.00ms
+step:1625/3350 val_loss:3.49852 train_time:1314.830s step_avg:800.20ms
+step:1750/3350 val_loss:3.47612 train_time:1414.816s step_avg:799.89ms
+step:1875/3350 val_loss:3.45664 train_time:1514.566s step_avg:798.00ms
+step:2000/3350 val_loss:3.43682 train_time:1614.176s step_avg:796.88ms
+step:2125/3350 val_loss:3.42025 train_time:1714.539s step_avg:802.90ms
+step:2250/3350 val_loss:3.40254 train_time:1814.262s step_avg:797.78ms
+step:2375/3350 val_loss:3.38657 train_time:1913.783s step_avg:796.17ms
+step:2500/3350 val_loss:3.37015 train_time:2014.166s step_avg:803.06ms
+step:2625/3350 val_loss:3.35343 train_time:2113.715s step_avg:796.40ms
+step:2750/3350 val_loss:3.33742 train_time:2213.576s step_avg:798.89ms
+step:2875/3350 val_loss:3.32129 train_time:2313.759s step_avg:801.47ms
+step:3000/3350 val_loss:3.30541 train_time:2413.588s step_avg:798.63ms
+step:3025/3350 val_loss:3.30165 train_time:2433.539s step_avg:798.05ms
+step:3050/3350 val_loss:3.29876 train_time:2453.523s step_avg:799.35ms
+step:3075/3350 val_loss:3.29580 train_time:2473.459s step_avg:797.41ms
+step:3100/3350 val_loss:3.29295 train_time:2493.386s step_avg:797.10ms
+step:3125/3350 val_loss:3.29028 train_time:2513.349s step_avg:798.50ms
+step:3150/3350 val_loss:3.28732 train_time:2533.319s step_avg:798.82ms
+step:3175/3350 val_loss:3.28473 train_time:2553.320s step_avg:800.03ms
+step:3200/3350 val_loss:3.28213 train_time:2573.397s step_avg:803.10ms
+step:3225/3350 val_loss:3.27978 train_time:2593.488s step_avg:803.63ms
+step:3250/3350 val_loss:3.27771 train_time:2613.645s step_avg:806.29ms
+step:3275/3350 val_loss:3.27584 train_time:2633.719s step_avg:802.96ms
+step:3300/3350 val_loss:3.27430 train_time:2653.749s step_avg:801.16ms
+step:3325/3350 val_loss:3.27309 train_time:2673.693s step_avg:797.76ms
+step:3350/3350 val_loss:3.27251 train_time:2693.576s step_avg:795.33ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/e4e2aa9c-3e6a-479e-b4c5-dea09a08f960.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/e4e2aa9c-3e6a-479e-b4c5-dea09a08f960.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.63290 train_time:115.952s step_avg:927.61ms
+step:250/3350 val_loss:4.09516 train_time:216.780s step_avg:806.63ms
+step:375/3350 val_loss:3.91562 train_time:316.220s step_avg:795.52ms
+step:500/3350 val_loss:3.81519 train_time:416.277s step_avg:800.45ms
+step:625/3350 val_loss:3.74959 train_time:516.291s step_avg:800.11ms
+step:750/3350 val_loss:3.70156 train_time:615.829s step_avg:796.30ms
+step:875/3350 val_loss:3.66441 train_time:715.572s step_avg:797.94ms
+step:1000/3350 val_loss:3.63291 train_time:815.453s step_avg:799.05ms
+step:1125/3350 val_loss:3.60423 train_time:915.258s step_avg:798.44ms
+step:1250/3350 val_loss:3.57207 train_time:1014.639s step_avg:795.05ms
+step:1375/3350 val_loss:3.54809 train_time:1114.649s step_avg:800.08ms
+step:1500/3350 val_loss:3.51899 train_time:1214.602s step_avg:799.62ms
+step:1625/3350 val_loss:3.49955 train_time:1313.817s step_avg:793.71ms
+step:1750/3350 val_loss:3.47835 train_time:1413.987s step_avg:801.36ms
+step:1875/3350 val_loss:3.45808 train_time:1513.771s step_avg:798.27ms
+step:2000/3350 val_loss:3.43952 train_time:1613.156s step_avg:795.08ms
+step:2125/3350 val_loss:3.42220 train_time:1713.176s step_avg:800.16ms
+step:2250/3350 val_loss:3.40467 train_time:1812.883s step_avg:797.66ms
+step:2375/3350 val_loss:3.38829 train_time:1912.561s step_avg:797.42ms
+step:2500/3350 val_loss:3.37236 train_time:2012.305s step_avg:797.95ms
+step:2625/3350 val_loss:3.35535 train_time:2112.519s step_avg:801.71ms
+step:2750/3350 val_loss:3.33948 train_time:2212.166s step_avg:797.18ms
+step:2875/3350 val_loss:3.32316 train_time:2311.843s step_avg:797.42ms
+step:3000/3350 val_loss:3.30764 train_time:2412.229s step_avg:803.08ms
+step:3025/3350 val_loss:3.30372 train_time:2432.196s step_avg:798.69ms
+step:3050/3350 val_loss:3.30082 train_time:2452.153s step_avg:798.27ms
+step:3075/3350 val_loss:3.29793 train_time:2472.019s step_avg:794.64ms
+step:3100/3350 val_loss:3.29496 train_time:2491.878s step_avg:794.36ms
+step:3125/3350 val_loss:3.29233 train_time:2511.752s step_avg:794.99ms
+step:3150/3350 val_loss:3.28931 train_time:2531.668s step_avg:796.61ms
+step:3175/3350 val_loss:3.28666 train_time:2551.623s step_avg:798.23ms
+step:3200/3350 val_loss:3.28410 train_time:2571.642s step_avg:800.73ms
+step:3225/3350 val_loss:3.28183 train_time:2591.708s step_avg:802.68ms
+step:3250/3350 val_loss:3.27976 train_time:2611.859s step_avg:806.02ms
+step:3275/3350 val_loss:3.27795 train_time:2631.967s step_avg:804.34ms
+step:3300/3350 val_loss:3.27635 train_time:2652.006s step_avg:801.53ms
+step:3325/3350 val_loss:3.27516 train_time:2672.017s step_avg:800.47ms
+step:3350/3350 val_loss:3.27458 train_time:2691.991s step_avg:798.93ms

--- a/records/track_3_optimization/results/20260523_arbor_muon/fb5674bb-ea69-47b1-a3af-95b8cb11aff4.txt
+++ b/records/track_3_optimization/results/20260523_arbor_muon/fb5674bb-ea69-47b1-a3af-95b8cb11aff4.txt
@@ -411,3 +411,46 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.6.0+cu124 compiled for CUDA 12.4 on NVIDIA A100 80GB PCIe with world_size 4
+====================================================================================================
+step:0/3350 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3350 val_loss:4.62834 train_time:116.908s step_avg:935.26ms
+step:250/3350 val_loss:4.09941 train_time:217.050s step_avg:801.14ms
+step:375/3350 val_loss:3.91799 train_time:316.809s step_avg:798.07ms
+step:500/3350 val_loss:3.81780 train_time:417.236s step_avg:803.42ms
+step:625/3350 val_loss:3.74780 train_time:516.634s step_avg:795.19ms
+step:750/3350 val_loss:3.70422 train_time:616.298s step_avg:797.31ms
+step:875/3350 val_loss:3.66383 train_time:716.577s step_avg:802.23ms
+step:1000/3350 val_loss:3.63288 train_time:815.943s step_avg:794.93ms
+step:1125/3350 val_loss:3.60317 train_time:915.673s step_avg:797.84ms
+step:1250/3350 val_loss:3.57246 train_time:1015.693s step_avg:800.16ms
+step:1375/3350 val_loss:3.54653 train_time:1115.300s step_avg:796.86ms
+step:1500/3350 val_loss:3.51884 train_time:1215.007s step_avg:797.66ms
+step:1625/3350 val_loss:3.49976 train_time:1314.932s step_avg:799.40ms
+step:1750/3350 val_loss:3.47758 train_time:1414.972s step_avg:800.32ms
+step:1875/3350 val_loss:3.45750 train_time:1514.363s step_avg:795.13ms
+step:2000/3350 val_loss:3.43906 train_time:1614.461s step_avg:800.79ms
+step:2125/3350 val_loss:3.42134 train_time:1714.562s step_avg:800.80ms
+step:2250/3350 val_loss:3.40424 train_time:1813.864s step_avg:794.42ms
+step:2375/3350 val_loss:3.38800 train_time:1914.068s step_avg:801.63ms
+step:2500/3350 val_loss:3.37196 train_time:2014.100s step_avg:800.26ms
+step:2625/3350 val_loss:3.35447 train_time:2113.640s step_avg:796.32ms
+step:2750/3350 val_loss:3.33882 train_time:2213.804s step_avg:801.31ms
+step:2875/3350 val_loss:3.32275 train_time:2313.781s step_avg:799.82ms
+step:3000/3350 val_loss:3.30711 train_time:2413.475s step_avg:797.56ms
+step:3025/3350 val_loss:3.30328 train_time:2433.412s step_avg:797.48ms
+step:3050/3350 val_loss:3.30039 train_time:2453.391s step_avg:799.14ms
+step:3075/3350 val_loss:3.29739 train_time:2473.357s step_avg:798.65ms
+step:3100/3350 val_loss:3.29461 train_time:2493.328s step_avg:798.84ms
+step:3125/3350 val_loss:3.29201 train_time:2513.348s step_avg:800.79ms
+step:3150/3350 val_loss:3.28900 train_time:2533.402s step_avg:802.18ms
+step:3175/3350 val_loss:3.28632 train_time:2553.478s step_avg:803.04ms
+step:3200/3350 val_loss:3.28383 train_time:2573.554s step_avg:803.04ms
+step:3225/3350 val_loss:3.28153 train_time:2593.616s step_avg:802.46ms
+step:3250/3350 val_loss:3.27940 train_time:2613.652s step_avg:801.44ms
+step:3275/3350 val_loss:3.27759 train_time:2633.582s step_avg:797.24ms
+step:3300/3350 val_loss:3.27607 train_time:2653.468s step_avg:795.43ms
+step:3325/3350 val_loss:3.27484 train_time:2673.326s step_avg:794.32ms
+step:3350/3350 val_loss:3.27426 train_time:2693.204s step_avg:795.11ms


### PR DESCRIPTION
## Pre-NS Row/Column Equilibrated Muon for MLP (from Arbor) — 3275 steps

**Result:** 3275 steps, `3.2771 (n=8)✓`

### Method

Row/column RMS equilibration applied to MLP weight matrices (fc + proj) before Newton-Schulz orthogonalization. The key observation is that MLP weight gradients have high row/column variance anisotropy, which degrades Newton-Schulz convergence quality. Pre-balancing the update matrix before NS improves its input conditioning.

Specifically:
- 2-iteration row/column RMS equilibration with scale clamping `[0.25, 4.0]`
- Applied only to `mlp.fc` and `mlp.proj` weights (not attention)
- Post-NS update norm rescaling to preserve consistent update magnitude
- Stateless — no additional optimizer state beyond standard Muon momentum

**Difference from NorMuon (arxiv 2510.05491):** NorMuon applies row-wise normalization *after* NS using second-order momentum. This method applies row+column equilibration *before* NS with no persistent state, targeting NS input conditioning rather than output normalization.

### Changes

All changes are in `train_gpt_simple.py`, concentrated in the Optimizer section:
- Added `row_column_equilibrate_for_ns()` function
- Added `muon_update_equilibrated()` compiled update path
- Modified `Muon` class to support param groups with `equilibrate=True`
- MLP fc/proj weights use equilibrated path; attention weights use baseline Muon

### Hyperparameters

Same as result #12: `lr=.035 wd=.025 mu=.95` — no new hyperparameters introduced.

### Evidence

8 independent runs on 4×A100-80GB, all reaching `val_loss <= 3.28` by step 3275:

| Trial | val_loss @ step 3275 |
|-------|---------------------|
| 1     | 3.27584             |
| 2     | 3.27795             |
| 3     | 3.27932             |
| 4     | 3.27592             |
| 5     | 3.27759             |
| 6     | 3.27527             |
| 7     | 3.27781             |
| 8     | 3.27730             |
| **mean** | **3.27712**      |

Statistical significance: `(3.28 - 3.27712) × √8 = 0.00813 ≥ 0.004` ✓ (z = 6.26, p < 0.001)
