### PR TITLE
Track 3: Aurora EMA reference in 2860 steps (n=16)

### DIFF
--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/15223178-b211-42d7-a6ba-b969c3148973.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/15223178-b211-42d7-a6ba-b969c3148973.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T02:45:21Z
+Using seed=13
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46759 train_time:96.577s step_avg:772.61ms ema_beta:0
+step:250/2900 val_loss:4.10422 train_time:190.022s step_avg:760.09ms ema_beta:0
+step:375/2900 val_loss:3.95821 train_time:283.594s step_avg:756.25ms ema_beta:0.3
+step:500/2900 val_loss:3.82025 train_time:377.307s step_avg:754.61ms ema_beta:0.3
+step:625/2900 val_loss:3.76212 train_time:471.082s step_avg:753.73ms ema_beta:0.3
+step:750/2900 val_loss:3.72042 train_time:564.758s step_avg:753.01ms ema_beta:0.3
+step:875/2900 val_loss:3.68226 train_time:658.553s step_avg:752.63ms ema_beta:0.3
+step:1000/2900 val_loss:3.64224 train_time:752.292s step_avg:752.29ms ema_beta:0.3
+step:1125/2900 val_loss:3.62134 train_time:846.041s step_avg:752.04ms ema_beta:0.3
+step:1250/2900 val_loss:3.58557 train_time:939.667s step_avg:751.73ms ema_beta:0.3
+step:1375/2900 val_loss:3.55943 train_time:1033.419s step_avg:751.58ms ema_beta:0.3
+step:1500/2900 val_loss:3.52925 train_time:1126.975s step_avg:751.32ms ema_beta:0.3
+step:1625/2900 val_loss:3.50672 train_time:1220.681s step_avg:751.19ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47355 train_time:1314.296s step_avg:751.03ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44640 train_time:1408.032s step_avg:750.95ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41169 train_time:1501.522s step_avg:750.76ms ema_beta:0
+step:2125/2900 val_loss:3.38491 train_time:1594.816s step_avg:750.50ms ema_beta:0
+step:2250/2900 val_loss:3.36103 train_time:1688.022s step_avg:750.23ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34033 train_time:1781.731s step_avg:750.20ms ema_beta:0
+step:2500/2900 val_loss:3.32059 train_time:1874.964s step_avg:749.99ms ema_beta:0
+step:2625/2900 val_loss:3.30300 train_time:1968.625s step_avg:749.95ms ema_beta:0
+step:2750/2900 val_loss:3.28852 train_time:2062.380s step_avg:749.96ms ema_beta:0
+step:2850/2900 val_loss:3.27897 train_time:2137.538s step_avg:750.01ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27837 train_time:2145.235s step_avg:750.08ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/242f921c-734e-4617-b361-7978de6c12d4.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/242f921c-734e-4617-b361-7978de6c12d4.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T23:02:27Z
+Using seed=7
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46269 train_time:96.264s step_avg:770.11ms ema_beta:0
+step:250/2900 val_loss:4.09670 train_time:189.103s step_avg:756.41ms ema_beta:0
+step:375/2900 val_loss:3.94463 train_time:281.909s step_avg:751.76ms ema_beta:0.3
+step:500/2900 val_loss:3.81908 train_time:374.693s step_avg:749.39ms ema_beta:0.3
+step:625/2900 val_loss:3.75991 train_time:467.520s step_avg:748.03ms ema_beta:0.3
+step:750/2900 val_loss:3.71928 train_time:560.252s step_avg:747.00ms ema_beta:0.3
+step:875/2900 val_loss:3.68135 train_time:653.550s step_avg:746.91ms ema_beta:0.3
+step:1000/2900 val_loss:3.63954 train_time:746.908s step_avg:746.91ms ema_beta:0.3
+step:1125/2900 val_loss:3.61450 train_time:840.470s step_avg:747.08ms ema_beta:0.3
+step:1250/2900 val_loss:3.58464 train_time:934.042s step_avg:747.23ms ema_beta:0.3
+step:1375/2900 val_loss:3.55972 train_time:1027.769s step_avg:747.47ms ema_beta:0.3
+step:1500/2900 val_loss:3.52876 train_time:1121.453s step_avg:747.64ms ema_beta:0.3
+step:1625/2900 val_loss:3.50601 train_time:1215.275s step_avg:747.86ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47359 train_time:1308.984s step_avg:747.99ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44461 train_time:1402.736s step_avg:748.13ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41107 train_time:1496.387s step_avg:748.19ms ema_beta:0
+step:2125/2900 val_loss:3.38405 train_time:1590.104s step_avg:748.28ms ema_beta:0
+step:2250/2900 val_loss:3.36006 train_time:1683.829s step_avg:748.37ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.33959 train_time:1778.224s step_avg:748.73ms ema_beta:0
+step:2500/2900 val_loss:3.31963 train_time:1872.003s step_avg:748.80ms ema_beta:0
+step:2625/2900 val_loss:3.30199 train_time:1965.482s step_avg:748.76ms ema_beta:0
+step:2750/2900 val_loss:3.28746 train_time:2058.588s step_avg:748.58ms ema_beta:0
+step:2850/2900 val_loss:3.27801 train_time:2132.926s step_avg:748.40ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27746 train_time:2140.400s step_avg:748.39ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/58808330-3c1f-4d8b-8108-2f62a646063f.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/58808330-3c1f-4d8b-8108-2f62a646063f.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T21:11:36Z
+Using seed=4
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.48680 train_time:96.126s step_avg:769.00ms ema_beta:0
+step:250/2900 val_loss:4.11145 train_time:189.403s step_avg:757.61ms ema_beta:0
+step:375/2900 val_loss:3.94450 train_time:282.875s step_avg:754.33ms ema_beta:0.3
+step:500/2900 val_loss:3.82474 train_time:376.413s step_avg:752.83ms ema_beta:0.3
+step:625/2900 val_loss:3.76326 train_time:469.643s step_avg:751.43ms ema_beta:0.3
+step:750/2900 val_loss:3.72224 train_time:562.634s step_avg:750.18ms ema_beta:0.3
+step:875/2900 val_loss:3.68184 train_time:655.659s step_avg:749.33ms ema_beta:0.3
+step:1000/2900 val_loss:3.64286 train_time:748.602s step_avg:748.60ms ema_beta:0.3
+step:1125/2900 val_loss:3.61869 train_time:841.561s step_avg:748.05ms ema_beta:0.3
+step:1250/2900 val_loss:3.58826 train_time:934.396s step_avg:747.52ms ema_beta:0.3
+step:1375/2900 val_loss:3.56208 train_time:1027.259s step_avg:747.10ms ema_beta:0.3
+step:1500/2900 val_loss:3.53516 train_time:1119.926s step_avg:746.62ms ema_beta:0.3
+step:1625/2900 val_loss:3.50748 train_time:1212.763s step_avg:746.32ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47559 train_time:1305.825s step_avg:746.19ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44660 train_time:1399.210s step_avg:746.25ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41253 train_time:1492.702s step_avg:746.35ms ema_beta:0
+step:2125/2900 val_loss:3.38579 train_time:1585.859s step_avg:746.29ms ema_beta:0
+step:2250/2900 val_loss:3.36205 train_time:1678.522s step_avg:746.01ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34132 train_time:1771.565s step_avg:745.92ms ema_beta:0
+step:2500/2900 val_loss:3.32174 train_time:1864.088s step_avg:745.64ms ema_beta:0
+step:2625/2900 val_loss:3.30415 train_time:1956.639s step_avg:745.39ms ema_beta:0
+step:2750/2900 val_loss:3.28976 train_time:2049.144s step_avg:745.14ms ema_beta:0
+step:2850/2900 val_loss:3.28017 train_time:2123.105s step_avg:744.95ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27961 train_time:2130.539s step_avg:744.94ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/5c30823b-1631-41f6-901b-7d2bb3f1b53b.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/5c30823b-1631-41f6-901b-7d2bb3f1b53b.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T23:39:36Z
+Using seed=8
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.47225 train_time:96.304s step_avg:770.43ms ema_beta:0
+step:250/2900 val_loss:4.10427 train_time:189.231s step_avg:756.93ms ema_beta:0
+step:375/2900 val_loss:3.94774 train_time:282.120s step_avg:752.32ms ema_beta:0.3
+step:500/2900 val_loss:3.82375 train_time:375.358s step_avg:750.72ms ema_beta:0.3
+step:625/2900 val_loss:3.76160 train_time:468.835s step_avg:750.14ms ema_beta:0.3
+step:750/2900 val_loss:3.71934 train_time:562.416s step_avg:749.89ms ema_beta:0.3
+step:875/2900 val_loss:3.68290 train_time:656.267s step_avg:750.02ms ema_beta:0.3
+step:1000/2900 val_loss:3.64228 train_time:750.035s step_avg:750.04ms ema_beta:0.3
+step:1125/2900 val_loss:3.61673 train_time:843.952s step_avg:750.18ms ema_beta:0.3
+step:1250/2900 val_loss:3.58638 train_time:937.799s step_avg:750.24ms ema_beta:0.3
+step:1375/2900 val_loss:3.56100 train_time:1031.759s step_avg:750.37ms ema_beta:0.3
+step:1500/2900 val_loss:3.52823 train_time:1125.556s step_avg:750.37ms ema_beta:0.3
+step:1625/2900 val_loss:3.50573 train_time:1219.547s step_avg:750.49ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47449 train_time:1313.405s step_avg:750.52ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44599 train_time:1407.308s step_avg:750.56ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41274 train_time:1501.126s step_avg:750.56ms ema_beta:0
+step:2125/2900 val_loss:3.38550 train_time:1595.014s step_avg:750.59ms ema_beta:0
+step:2250/2900 val_loss:3.36192 train_time:1688.984s step_avg:750.66ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34090 train_time:1783.404s step_avg:750.91ms ema_beta:0
+step:2500/2900 val_loss:3.32143 train_time:1876.322s step_avg:750.53ms ema_beta:0
+step:2625/2900 val_loss:3.30389 train_time:1968.965s step_avg:750.08ms ema_beta:0
+step:2750/2900 val_loss:3.28948 train_time:2061.489s step_avg:749.63ms ema_beta:0
+step:2850/2900 val_loss:3.27986 train_time:2135.586s step_avg:749.33ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27929 train_time:2143.035s step_avg:749.31ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/6f0d30bb-483d-4803-9460-153a0071250d.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/6f0d30bb-483d-4803-9460-153a0071250d.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T20:34:16Z
+Using seed=3
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.48485 train_time:96.915s step_avg:775.32ms ema_beta:0
+step:250/2900 val_loss:4.09863 train_time:190.762s step_avg:763.05ms ema_beta:0
+step:375/2900 val_loss:3.95061 train_time:284.608s step_avg:758.96ms ema_beta:0.3
+step:500/2900 val_loss:3.82498 train_time:378.452s step_avg:756.90ms ema_beta:0.3
+step:625/2900 val_loss:3.76631 train_time:472.345s step_avg:755.75ms ema_beta:0.3
+step:750/2900 val_loss:3.72008 train_time:566.061s step_avg:754.75ms ema_beta:0.3
+step:875/2900 val_loss:3.68240 train_time:659.894s step_avg:754.16ms ema_beta:0.3
+step:1000/2900 val_loss:3.64273 train_time:753.700s step_avg:753.70ms ema_beta:0.3
+step:1125/2900 val_loss:3.61834 train_time:847.740s step_avg:753.55ms ema_beta:0.3
+step:1250/2900 val_loss:3.58563 train_time:941.809s step_avg:753.45ms ema_beta:0.3
+step:1375/2900 val_loss:3.56141 train_time:1036.073s step_avg:753.51ms ema_beta:0.3
+step:1500/2900 val_loss:3.53039 train_time:1130.130s step_avg:753.42ms ema_beta:0.3
+step:1625/2900 val_loss:3.50705 train_time:1224.302s step_avg:753.42ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47505 train_time:1318.217s step_avg:753.27ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44598 train_time:1412.151s step_avg:753.15ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41266 train_time:1505.908s step_avg:752.95ms ema_beta:0
+step:2125/2900 val_loss:3.38596 train_time:1599.753s step_avg:752.82ms ema_beta:0
+step:2250/2900 val_loss:3.36204 train_time:1693.553s step_avg:752.69ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34170 train_time:1788.358s step_avg:752.99ms ema_beta:0
+step:2500/2900 val_loss:3.32171 train_time:1883.121s step_avg:753.25ms ema_beta:0
+step:2625/2900 val_loss:3.30409 train_time:1976.322s step_avg:752.88ms ema_beta:0
+step:2750/2900 val_loss:3.28977 train_time:2069.252s step_avg:752.46ms ema_beta:0
+step:2850/2900 val_loss:3.28030 train_time:2143.519s step_avg:752.11ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27978 train_time:2150.981s step_avg:752.09ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/73926855-fa53-46d9-aa5e-0797b6550f93.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/73926855-fa53-46d9-aa5e-0797b6550f93.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T01:31:12Z
+Using seed=11
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46218 train_time:96.865s step_avg:774.92ms ema_beta:0
+step:250/2900 val_loss:4.10860 train_time:190.910s step_avg:763.64ms ema_beta:0
+step:375/2900 val_loss:3.94701 train_time:284.595s step_avg:758.92ms ema_beta:0.3
+step:500/2900 val_loss:3.82500 train_time:377.836s step_avg:755.67ms ema_beta:0.3
+step:625/2900 val_loss:3.76805 train_time:470.985s step_avg:753.58ms ema_beta:0.3
+step:750/2900 val_loss:3.72468 train_time:563.849s step_avg:751.80ms ema_beta:0.3
+step:875/2900 val_loss:3.68317 train_time:656.727s step_avg:750.55ms ema_beta:0.3
+step:1000/2900 val_loss:3.64572 train_time:749.449s step_avg:749.45ms ema_beta:0.3
+step:1125/2900 val_loss:3.62097 train_time:842.229s step_avg:748.65ms ema_beta:0.3
+step:1250/2900 val_loss:3.58772 train_time:935.079s step_avg:748.06ms ema_beta:0.3
+step:1375/2900 val_loss:3.56340 train_time:1028.429s step_avg:747.95ms ema_beta:0.3
+step:1500/2900 val_loss:3.53078 train_time:1121.842s step_avg:747.89ms ema_beta:0.3
+step:1625/2900 val_loss:3.51036 train_time:1215.673s step_avg:748.11ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47655 train_time:1309.668s step_avg:748.38ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44842 train_time:1403.337s step_avg:748.45ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41376 train_time:1496.411s step_avg:748.21ms ema_beta:0
+step:2125/2900 val_loss:3.38699 train_time:1589.235s step_avg:747.88ms ema_beta:0
+step:2250/2900 val_loss:3.36301 train_time:1681.790s step_avg:747.46ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34253 train_time:1774.796s step_avg:747.28ms ema_beta:0
+step:2500/2900 val_loss:3.32301 train_time:1867.205s step_avg:746.88ms ema_beta:0
+step:2625/2900 val_loss:3.30533 train_time:1959.687s step_avg:746.55ms ema_beta:0
+step:2750/2900 val_loss:3.29084 train_time:2052.120s step_avg:746.23ms ema_beta:0
+step:2850/2900 val_loss:3.28116 train_time:2126.157s step_avg:746.02ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.28060 train_time:2133.645s step_avg:746.03ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/7b578310-381e-469b-94f7-8bfe3dd47bb9.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/7b578310-381e-469b-94f7-8bfe3dd47bb9.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T19:56:54Z
+Using seed=2
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46457 train_time:97.674s step_avg:781.39ms ema_beta:0
+step:250/2900 val_loss:4.09776 train_time:191.176s step_avg:764.70ms ema_beta:0
+step:375/2900 val_loss:3.95187 train_time:284.973s step_avg:759.93ms ema_beta:0.3
+step:500/2900 val_loss:3.81962 train_time:378.887s step_avg:757.77ms ema_beta:0.3
+step:625/2900 val_loss:3.76012 train_time:473.044s step_avg:756.87ms ema_beta:0.3
+step:750/2900 val_loss:3.71902 train_time:568.234s step_avg:757.64ms ema_beta:0.3
+step:875/2900 val_loss:3.67908 train_time:662.830s step_avg:757.52ms ema_beta:0.3
+step:1000/2900 val_loss:3.64067 train_time:757.687s step_avg:757.69ms ema_beta:0.3
+step:1125/2900 val_loss:3.61611 train_time:851.878s step_avg:757.23ms ema_beta:0.3
+step:1250/2900 val_loss:3.58431 train_time:945.896s step_avg:756.72ms ema_beta:0.3
+step:1375/2900 val_loss:3.55961 train_time:1039.936s step_avg:756.32ms ema_beta:0.3
+step:1500/2900 val_loss:3.52911 train_time:1133.781s step_avg:755.85ms ema_beta:0.3
+step:1625/2900 val_loss:3.50439 train_time:1227.720s step_avg:755.52ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47206 train_time:1321.539s step_avg:755.17ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44320 train_time:1415.363s step_avg:754.86ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41019 train_time:1508.982s step_avg:754.49ms ema_beta:0
+step:2125/2900 val_loss:3.38348 train_time:1602.497s step_avg:754.12ms ema_beta:0
+step:2250/2900 val_loss:3.35927 train_time:1695.816s step_avg:753.70ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.33877 train_time:1789.669s step_avg:753.54ms ema_beta:0
+step:2500/2900 val_loss:3.31890 train_time:1882.988s step_avg:753.20ms ema_beta:0
+step:2625/2900 val_loss:3.30124 train_time:1976.449s step_avg:752.93ms ema_beta:0
+step:2750/2900 val_loss:3.28692 train_time:2069.974s step_avg:752.72ms ema_beta:0
+step:2850/2900 val_loss:3.27738 train_time:2144.937s step_avg:752.61ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27675 train_time:2152.486s step_avg:752.62ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/8b1ae377-e835-4c90-a6b8-75afaf085b04.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/8b1ae377-e835-4c90-a6b8-75afaf085b04.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T03:59:46Z
+Using seed=15
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.47045 train_time:96.639s step_avg:773.11ms ema_beta:0
+step:250/2900 val_loss:4.10867 train_time:190.245s step_avg:760.98ms ema_beta:0
+step:375/2900 val_loss:3.94923 train_time:284.071s step_avg:757.52ms ema_beta:0.3
+step:500/2900 val_loss:3.82757 train_time:378.118s step_avg:756.24ms ema_beta:0.3
+step:625/2900 val_loss:3.76493 train_time:472.681s step_avg:756.29ms ema_beta:0.3
+step:750/2900 val_loss:3.72556 train_time:567.948s step_avg:757.26ms ema_beta:0.3
+step:875/2900 val_loss:3.68565 train_time:662.308s step_avg:756.92ms ema_beta:0.3
+step:1000/2900 val_loss:3.64454 train_time:755.458s step_avg:755.46ms ema_beta:0.3
+step:1125/2900 val_loss:3.62182 train_time:848.505s step_avg:754.23ms ema_beta:0.3
+step:1250/2900 val_loss:3.58720 train_time:941.467s step_avg:753.17ms ema_beta:0.3
+step:1375/2900 val_loss:3.56227 train_time:1034.733s step_avg:752.53ms ema_beta:0.3
+step:1500/2900 val_loss:3.53072 train_time:1128.036s step_avg:752.02ms ema_beta:0.3
+step:1625/2900 val_loss:3.50770 train_time:1221.559s step_avg:751.73ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47492 train_time:1315.188s step_avg:751.54ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44707 train_time:1408.969s step_avg:751.45ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41263 train_time:1502.239s step_avg:751.12ms ema_beta:0
+step:2125/2900 val_loss:3.38598 train_time:1595.524s step_avg:750.83ms ema_beta:0
+step:2250/2900 val_loss:3.36209 train_time:1688.786s step_avg:750.57ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34163 train_time:1782.730s step_avg:750.62ms ema_beta:0
+step:2500/2900 val_loss:3.32169 train_time:1876.226s step_avg:750.49ms ema_beta:0
+step:2625/2900 val_loss:3.30404 train_time:1969.777s step_avg:750.39ms ema_beta:0
+step:2750/2900 val_loss:3.28976 train_time:2063.259s step_avg:750.28ms ema_beta:0
+step:2850/2900 val_loss:3.28026 train_time:2138.091s step_avg:750.21ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27966 train_time:2145.619s step_avg:750.22ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/9df54a64-b0d7-4132-9da6-32ec2caad7a2.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/9df54a64-b0d7-4132-9da6-32ec2caad7a2.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T03:22:35Z
+Using seed=14
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.47589 train_time:96.475s step_avg:771.80ms ema_beta:0
+step:250/2900 val_loss:4.09788 train_time:189.653s step_avg:758.61ms ema_beta:0
+step:375/2900 val_loss:3.95060 train_time:282.576s step_avg:753.53ms ema_beta:0.3
+step:500/2900 val_loss:3.82287 train_time:375.384s step_avg:750.77ms ema_beta:0.3
+step:625/2900 val_loss:3.76286 train_time:468.259s step_avg:749.21ms ema_beta:0.3
+step:750/2900 val_loss:3.72167 train_time:560.991s step_avg:747.99ms ema_beta:0.3
+step:875/2900 val_loss:3.68676 train_time:654.234s step_avg:747.70ms ema_beta:0.3
+step:1000/2900 val_loss:3.64433 train_time:747.613s step_avg:747.61ms ema_beta:0.3
+step:1125/2900 val_loss:3.61980 train_time:841.240s step_avg:747.77ms ema_beta:0.3
+step:1250/2900 val_loss:3.58671 train_time:934.981s step_avg:747.99ms ema_beta:0.3
+step:1375/2900 val_loss:3.56150 train_time:1028.928s step_avg:748.31ms ema_beta:0.3
+step:1500/2900 val_loss:3.53086 train_time:1122.776s step_avg:748.52ms ema_beta:0.3
+step:1625/2900 val_loss:3.50770 train_time:1216.769s step_avg:748.78ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47507 train_time:1310.705s step_avg:748.97ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44665 train_time:1404.711s step_avg:749.18ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41307 train_time:1498.467s step_avg:749.23ms ema_beta:0
+step:2125/2900 val_loss:3.38620 train_time:1592.133s step_avg:749.24ms ema_beta:0
+step:2250/2900 val_loss:3.36259 train_time:1685.623s step_avg:749.17ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34173 train_time:1779.635s step_avg:749.32ms ema_beta:0
+step:2500/2900 val_loss:3.32193 train_time:1873.127s step_avg:749.25ms ema_beta:0
+step:2625/2900 val_loss:3.30421 train_time:1966.719s step_avg:749.23ms ema_beta:0
+step:2750/2900 val_loss:3.28983 train_time:2060.157s step_avg:749.15ms ema_beta:0
+step:2850/2900 val_loss:3.28028 train_time:2134.968s step_avg:749.11ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27969 train_time:2142.510s step_avg:749.13ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/README.md
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/README.md
@@ -1,0 +1,70 @@
+# Aurora EMA Reference 2860 Results
+
+This result uses the Aurora/EMA-Nesterov base from PR #309 with a fixed
+reference-interpolated output rule. It captures reference weights at step 2375,
+uses `gamma=-0.075` from step 2850 onward, and reports the fixed stopping point
+K=2860.
+
+The archived script hardcodes the submitted hyperparameter defaults. It reads
+`--seed` to select the random seed for a reproducibility run; other command-line
+arguments only control logging.
+
+## Configuration
+
+| field | value |
+|---|---|
+| train steps | 2900 |
+| fixed stopping point K | 2860 |
+| schedule steps | 2980 |
+| LR power | 1.2 |
+| base method | Aurora/EMA-Nesterov from PR #309 |
+| CGI alpha | 0.0 |
+| zero non-projection biases | true |
+| reference capture step | 2375 |
+| reference apply start step | 2850 |
+| reference gamma | -0.075 |
+| EMA-Nesterov stepsize | 0.3 |
+| EMA-Nesterov lookahead EMA | 0.99 |
+| EMA-Nesterov prefill steps | 300 |
+| EMA-Nesterov rest step | 1950 |
+
+## Reliability
+
+Across 16 non-cherry-picked seeds at the fixed stopping point K=2860, the mean
+validation loss is 3.278939375. The Track 3 significance rule is:
+
+`(3.28 - mean) * sqrt(n) >= 0.004`
+
+For these runs:
+
+`(3.28 - 3.278939375) * sqrt(16) = 0.00424250 >= 0.004`
+
+| seed | val loss at K=2860 | logfile |
+|---:|---:|---|
+| 0 | 3.27765 | `c4b5e2ad-f59c-4809-86ff-913338ae7a2c.txt` |
+| 1 | 3.27965 | `d715cb87-fbdf-44cb-8798-b505f8e8b71a.txt` |
+| 2 | 3.27675 | `7b578310-381e-469b-94f7-8bfe3dd47bb9.txt` |
+| 3 | 3.27978 | `6f0d30bb-483d-4803-9460-153a0071250d.txt` |
+| 4 | 3.27961 | `58808330-3c1f-4d8b-8108-2f62a646063f.txt` |
+| 5 | 3.27999 | `bb2723d5-cf02-440a-ad69-cdc5dbe6c251.txt` |
+| 6 | 3.27696 | `cb2d26ac-e884-44e4-98b1-b4a15aafd415.txt` |
+| 7 | 3.27746 | `242f921c-734e-4617-b361-7978de6c12d4.txt` |
+| 8 | 3.27929 | `5c30823b-1631-41f6-901b-7d2bb3f1b53b.txt` |
+| 9 | 3.27910 | `e782d1d7-8f24-4373-b443-5fd33a56995b.txt` |
+| 10 | 3.28025 | `a5ad12b6-e74e-4612-b76b-66db831fc95f.txt` |
+| 11 | 3.28060 | `73926855-fa53-46d9-aa5e-0797b6550f93.txt` |
+| 12 | 3.27822 | `de02a52e-eeac-41e8-85e2-387b2d960e2b.txt` |
+| 13 | 3.27837 | `15223178-b211-42d7-a6ba-b969c3148973.txt` |
+| 14 | 3.27969 | `9df54a64-b0d7-4132-9da6-32ec2caad7a2.txt` |
+| 15 | 3.27966 | `8b1ae377-e835-4c90-a6b8-75afaf085b04.txt` |
+| **Mean** | **3.278939375** | |
+
+All logs report `step:2860/2900`; no per-run early stopping is used.
+
+## Reproduction
+
+Run one seed from the repo root with the Track 3 quickstart environment:
+
+```bash
+torchrun --standalone --nproc_per_node=$(nvidia-smi -L | wc -l) records/track_3_optimization/results/20260525_aurora_ema_ref/train_gpt_simple_aurora_ema_ref.py --seed 0
+```

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/a5ad12b6-e74e-4612-b76b-66db831fc95f.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/a5ad12b6-e74e-4612-b76b-66db831fc95f.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T00:53:53Z
+Using seed=10
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46544 train_time:96.315s step_avg:770.52ms ema_beta:0
+step:250/2900 val_loss:4.11146 train_time:189.648s step_avg:758.59ms ema_beta:0
+step:375/2900 val_loss:3.95016 train_time:283.199s step_avg:755.20ms ema_beta:0.3
+step:500/2900 val_loss:3.82788 train_time:376.889s step_avg:753.78ms ema_beta:0.3
+step:625/2900 val_loss:3.76421 train_time:470.738s step_avg:753.18ms ema_beta:0.3
+step:750/2900 val_loss:3.72367 train_time:564.595s step_avg:752.79ms ema_beta:0.3
+step:875/2900 val_loss:3.68763 train_time:658.749s step_avg:752.86ms ema_beta:0.3
+step:1000/2900 val_loss:3.64513 train_time:752.940s step_avg:752.94ms ema_beta:0.3
+step:1125/2900 val_loss:3.62149 train_time:847.651s step_avg:753.47ms ema_beta:0.3
+step:1250/2900 val_loss:3.58887 train_time:942.113s step_avg:753.69ms ema_beta:0.3
+step:1375/2900 val_loss:3.56420 train_time:1036.218s step_avg:753.61ms ema_beta:0.3
+step:1500/2900 val_loss:3.53138 train_time:1130.218s step_avg:753.48ms ema_beta:0.3
+step:1625/2900 val_loss:3.50863 train_time:1224.343s step_avg:753.44ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47561 train_time:1318.327s step_avg:753.33ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44723 train_time:1412.355s step_avg:753.26ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41387 train_time:1506.163s step_avg:753.08ms ema_beta:0
+step:2125/2900 val_loss:3.38670 train_time:1599.835s step_avg:752.86ms ema_beta:0
+step:2250/2900 val_loss:3.36313 train_time:1693.365s step_avg:752.61ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34191 train_time:1787.373s step_avg:752.58ms ema_beta:0
+step:2500/2900 val_loss:3.32231 train_time:1880.891s step_avg:752.36ms ema_beta:0
+step:2625/2900 val_loss:3.30485 train_time:1974.456s step_avg:752.17ms ema_beta:0
+step:2750/2900 val_loss:3.29040 train_time:2068.020s step_avg:752.01ms ema_beta:0
+step:2850/2900 val_loss:3.28085 train_time:2142.925s step_avg:751.90ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.28025 train_time:2150.483s step_avg:751.92ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/bb2723d5-cf02-440a-ad69-cdc5dbe6c251.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/bb2723d5-cf02-440a-ad69-cdc5dbe6c251.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T21:48:34Z
+Using seed=5
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46937 train_time:96.227s step_avg:769.82ms ema_beta:0
+step:250/2900 val_loss:4.10447 train_time:189.588s step_avg:758.35ms ema_beta:0
+step:375/2900 val_loss:3.95172 train_time:282.827s step_avg:754.20ms ema_beta:0.3
+step:500/2900 val_loss:3.82447 train_time:375.855s step_avg:751.71ms ema_beta:0.3
+step:625/2900 val_loss:3.76496 train_time:468.786s step_avg:750.06ms ema_beta:0.3
+step:750/2900 val_loss:3.72212 train_time:561.582s step_avg:748.78ms ema_beta:0.3
+step:875/2900 val_loss:3.68428 train_time:654.464s step_avg:747.96ms ema_beta:0.3
+step:1000/2900 val_loss:3.64497 train_time:747.194s step_avg:747.19ms ema_beta:0.3
+step:1125/2900 val_loss:3.62185 train_time:840.035s step_avg:746.70ms ema_beta:0.3
+step:1250/2900 val_loss:3.58891 train_time:932.773s step_avg:746.22ms ema_beta:0.3
+step:1375/2900 val_loss:3.56185 train_time:1025.772s step_avg:746.02ms ema_beta:0.3
+step:1500/2900 val_loss:3.53156 train_time:1118.928s step_avg:745.95ms ema_beta:0.3
+step:1625/2900 val_loss:3.50834 train_time:1212.496s step_avg:746.15ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47582 train_time:1305.926s step_avg:746.24ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44795 train_time:1399.090s step_avg:746.18ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41398 train_time:1491.920s step_avg:745.96ms ema_beta:0
+step:2125/2900 val_loss:3.38689 train_time:1584.507s step_avg:745.65ms ema_beta:0
+step:2250/2900 val_loss:3.36274 train_time:1676.933s step_avg:745.30ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34202 train_time:1769.869s step_avg:745.21ms ema_beta:0
+step:2500/2900 val_loss:3.32221 train_time:1862.354s step_avg:744.94ms ema_beta:0
+step:2625/2900 val_loss:3.30459 train_time:1955.462s step_avg:744.94ms ema_beta:0
+step:2750/2900 val_loss:3.29016 train_time:2048.622s step_avg:744.95ms ema_beta:0
+step:2850/2900 val_loss:3.28062 train_time:2123.340s step_avg:745.03ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27999 train_time:2130.875s step_avg:745.06ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/c4b5e2ad-f59c-4809-86ff-913338ae7a2c.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/c4b5e2ad-f59c-4809-86ff-913338ae7a2c.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T18:42:23Z
+Using seed=0
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.45173 train_time:95.992s step_avg:767.94ms ema_beta:0
+step:250/2900 val_loss:4.11143 train_time:189.304s step_avg:757.22ms ema_beta:0
+step:375/2900 val_loss:3.94558 train_time:282.814s step_avg:754.17ms ema_beta:0.3
+step:500/2900 val_loss:3.82165 train_time:376.621s step_avg:753.24ms ema_beta:0.3
+step:625/2900 val_loss:3.76236 train_time:470.748s step_avg:753.20ms ema_beta:0.3
+step:750/2900 val_loss:3.72005 train_time:564.820s step_avg:753.09ms ema_beta:0.3
+step:875/2900 val_loss:3.68288 train_time:659.090s step_avg:753.25ms ema_beta:0.3
+step:1000/2900 val_loss:3.64236 train_time:753.062s step_avg:753.06ms ema_beta:0.3
+step:1125/2900 val_loss:3.61693 train_time:846.992s step_avg:752.88ms ema_beta:0.3
+step:1250/2900 val_loss:3.58550 train_time:940.829s step_avg:752.66ms ema_beta:0.3
+step:1375/2900 val_loss:3.56002 train_time:1034.638s step_avg:752.46ms ema_beta:0.3
+step:1500/2900 val_loss:3.52802 train_time:1128.256s step_avg:752.17ms ema_beta:0.3
+step:1625/2900 val_loss:3.50539 train_time:1221.968s step_avg:751.98ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47303 train_time:1315.544s step_avg:751.74ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44553 train_time:1409.198s step_avg:751.57ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41075 train_time:1502.588s step_avg:751.29ms ema_beta:0
+step:2125/2900 val_loss:3.38406 train_time:1595.891s step_avg:751.01ms ema_beta:0
+step:2250/2900 val_loss:3.36020 train_time:1689.025s step_avg:750.68ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.33937 train_time:1782.691s step_avg:750.61ms ema_beta:0
+step:2500/2900 val_loss:3.31996 train_time:1875.858s step_avg:750.34ms ema_beta:0
+step:2625/2900 val_loss:3.30233 train_time:1969.101s step_avg:750.13ms ema_beta:0
+step:2750/2900 val_loss:3.28789 train_time:2062.269s step_avg:749.92ms ema_beta:0
+step:2850/2900 val_loss:3.27826 train_time:2136.807s step_avg:749.76ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27765 train_time:2144.312s step_avg:749.76ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/cb2d26ac-e884-44e4-98b1-b4a15aafd415.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/cb2d26ac-e884-44e4-98b1-b4a15aafd415.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T22:25:33Z
+Using seed=6
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.48121 train_time:96.704s step_avg:773.63ms ema_beta:0
+step:250/2900 val_loss:4.11023 train_time:190.032s step_avg:760.13ms ema_beta:0
+step:375/2900 val_loss:3.94351 train_time:282.983s step_avg:754.62ms ema_beta:0.3
+step:500/2900 val_loss:3.82100 train_time:375.796s step_avg:751.59ms ema_beta:0.3
+step:625/2900 val_loss:3.76251 train_time:468.641s step_avg:749.82ms ema_beta:0.3
+step:750/2900 val_loss:3.72055 train_time:561.350s step_avg:748.47ms ema_beta:0.3
+step:875/2900 val_loss:3.68009 train_time:654.249s step_avg:747.71ms ema_beta:0.3
+step:1000/2900 val_loss:3.64074 train_time:747.018s step_avg:747.02ms ema_beta:0.3
+step:1125/2900 val_loss:3.61516 train_time:839.846s step_avg:746.53ms ema_beta:0.3
+step:1250/2900 val_loss:3.58425 train_time:932.563s step_avg:746.05ms ema_beta:0.3
+step:1375/2900 val_loss:3.55929 train_time:1025.445s step_avg:745.78ms ema_beta:0.3
+step:1500/2900 val_loss:3.52824 train_time:1118.202s step_avg:745.47ms ema_beta:0.3
+step:1625/2900 val_loss:3.50444 train_time:1211.086s step_avg:745.28ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47266 train_time:1303.847s step_avg:745.06ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44421 train_time:1396.696s step_avg:744.90ms ema_beta:0.22383
+step:2000/2900 val_loss:3.40988 train_time:1489.349s step_avg:744.67ms ema_beta:0
+step:2125/2900 val_loss:3.38328 train_time:1582.008s step_avg:744.47ms ema_beta:0
+step:2250/2900 val_loss:3.35926 train_time:1674.681s step_avg:744.30ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.33865 train_time:1767.810s step_avg:744.34ms ema_beta:0
+step:2500/2900 val_loss:3.31911 train_time:1860.349s step_avg:744.14ms ema_beta:0
+step:2625/2900 val_loss:3.30157 train_time:1952.972s step_avg:743.99ms ema_beta:0
+step:2750/2900 val_loss:3.28717 train_time:2045.506s step_avg:743.82ms ema_beta:0
+step:2850/2900 val_loss:3.27757 train_time:2119.579s step_avg:743.71ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27696 train_time:2127.046s step_avg:743.72ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/d715cb87-fbdf-44cb-8798-b505f8e8b71a.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/d715cb87-fbdf-44cb-8798-b505f8e8b71a.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-24T19:19:36Z
+Using seed=1
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.47500 train_time:96.639s step_avg:773.12ms ema_beta:0
+step:250/2900 val_loss:4.11315 train_time:190.043s step_avg:760.17ms ema_beta:0
+step:375/2900 val_loss:3.94997 train_time:283.406s step_avg:755.75ms ema_beta:0.3
+step:500/2900 val_loss:3.82560 train_time:376.791s step_avg:753.58ms ema_beta:0.3
+step:625/2900 val_loss:3.76353 train_time:470.438s step_avg:752.70ms ema_beta:0.3
+step:750/2900 val_loss:3.72067 train_time:564.127s step_avg:752.17ms ema_beta:0.3
+step:875/2900 val_loss:3.68345 train_time:658.100s step_avg:752.11ms ema_beta:0.3
+step:1000/2900 val_loss:3.64489 train_time:752.074s step_avg:752.07ms ema_beta:0.3
+step:1125/2900 val_loss:3.61884 train_time:846.356s step_avg:752.32ms ema_beta:0.3
+step:1250/2900 val_loss:3.58794 train_time:940.736s step_avg:752.59ms ema_beta:0.3
+step:1375/2900 val_loss:3.56240 train_time:1035.361s step_avg:752.99ms ema_beta:0.3
+step:1500/2900 val_loss:3.53051 train_time:1130.103s step_avg:753.40ms ema_beta:0.3
+step:1625/2900 val_loss:3.50765 train_time:1224.486s step_avg:753.53ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47676 train_time:1318.502s step_avg:753.43ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44720 train_time:1412.490s step_avg:753.33ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41347 train_time:1506.229s step_avg:753.11ms ema_beta:0
+step:2125/2900 val_loss:3.38640 train_time:1599.764s step_avg:752.83ms ema_beta:0
+step:2250/2900 val_loss:3.36224 train_time:1693.105s step_avg:752.49ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34175 train_time:1786.965s step_avg:752.41ms ema_beta:0
+step:2500/2900 val_loss:3.32194 train_time:1880.261s step_avg:752.10ms ema_beta:0
+step:2625/2900 val_loss:3.30424 train_time:1973.607s step_avg:751.85ms ema_beta:0
+step:2750/2900 val_loss:3.28990 train_time:2066.917s step_avg:751.61ms ema_beta:0
+step:2850/2900 val_loss:3.28022 train_time:2141.560s step_avg:751.42ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27965 train_time:2149.079s step_avg:751.43ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/de02a52e-eeac-41e8-85e2-387b2d960e2b.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/de02a52e-eeac-41e8-85e2-387b2d960e2b.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T02:08:13Z
+Using seed=12
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.47275 train_time:96.546s step_avg:772.37ms ema_beta:0
+step:250/2900 val_loss:4.10733 train_time:189.984s step_avg:759.94ms ema_beta:0
+step:375/2900 val_loss:3.95467 train_time:283.483s step_avg:755.96ms ema_beta:0.3
+step:500/2900 val_loss:3.82244 train_time:377.150s step_avg:754.30ms ema_beta:0.3
+step:625/2900 val_loss:3.76241 train_time:470.979s step_avg:753.57ms ema_beta:0.3
+step:750/2900 val_loss:3.72110 train_time:564.714s step_avg:752.95ms ema_beta:0.3
+step:875/2900 val_loss:3.68139 train_time:658.771s step_avg:752.88ms ema_beta:0.3
+step:1000/2900 val_loss:3.64233 train_time:752.844s step_avg:752.84ms ema_beta:0.3
+step:1125/2900 val_loss:3.61891 train_time:846.296s step_avg:752.26ms ema_beta:0.3
+step:1250/2900 val_loss:3.58613 train_time:939.446s step_avg:751.56ms ema_beta:0.3
+step:1375/2900 val_loss:3.56070 train_time:1032.625s step_avg:751.00ms ema_beta:0.3
+step:1500/2900 val_loss:3.53055 train_time:1125.478s step_avg:750.32ms ema_beta:0.3
+step:1625/2900 val_loss:3.50509 train_time:1218.431s step_avg:749.80ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47484 train_time:1311.301s step_avg:749.31ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44608 train_time:1404.130s step_avg:748.87ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41189 train_time:1497.139s step_avg:748.57ms ema_beta:0
+step:2125/2900 val_loss:3.38514 train_time:1590.315s step_avg:748.38ms ema_beta:0
+step:2250/2900 val_loss:3.36080 train_time:1683.340s step_avg:748.15ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34015 train_time:1776.999s step_avg:748.21ms ema_beta:0
+step:2500/2900 val_loss:3.32042 train_time:1870.335s step_avg:748.13ms ema_beta:0
+step:2625/2900 val_loss:3.30283 train_time:1963.854s step_avg:748.14ms ema_beta:0
+step:2750/2900 val_loss:3.28848 train_time:2057.369s step_avg:748.13ms ema_beta:0
+step:2850/2900 val_loss:3.27882 train_time:2132.196s step_avg:748.14ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27822 train_time:2139.730s step_avg:748.16ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/e782d1d7-8f24-4373-b443-5fd33a56995b.txt
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/e782d1d7-8f24-4373-b443-5fd33a56995b.txt
@@ -1,0 +1,893 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.11.0+cu129 compiled for CUDA 12.9
+Running on device_name=NVIDIA L40S with world_size=8
+Run UTC timestamp=2026-05-25T00:16:47Z
+Using seed=9
+Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation
+Schedule horizon train_steps=2900, schedule_steps=2980, reported_step=2860
+Using ref_capture_step=2375 ref_apply_start_step=2850 ref_gamma=-0.075
+Using CGI_ALPHA=0.0 ZERO_NONPROJ_BIASES=True
+Using contra_muon_coeff=-0.2 contra_to_normal_end_step=2500
+Using mu=0.95 muon_lr=0.0375
+Using target_uw=0.3825 radial_outward_scale=0.5 radial_inward_scale=1.0
+Using SOAP on MLP fc/proj and attention V: soap_beta2=0.9 v_soap_blend=0.95
+Using EMA-Nesterov stepsize=0.3 lookahead_ema=0.99 prefill_steps=300 rest_step=1950
+====================================================================================================
+Using run_stop_step=2860 train_steps=2900
+step:125/2900 val_loss:4.46945 train_time:96.138s step_avg:769.11ms ema_beta:0
+step:250/2900 val_loss:4.10703 train_time:189.004s step_avg:756.01ms ema_beta:0
+step:375/2900 val_loss:3.94967 train_time:282.199s step_avg:752.53ms ema_beta:0.3
+step:500/2900 val_loss:3.82447 train_time:375.560s step_avg:751.12ms ema_beta:0.3
+step:625/2900 val_loss:3.76674 train_time:469.302s step_avg:750.88ms ema_beta:0.3
+step:750/2900 val_loss:3.71922 train_time:563.167s step_avg:750.89ms ema_beta:0.3
+step:875/2900 val_loss:3.68215 train_time:657.292s step_avg:751.19ms ema_beta:0.3
+step:1000/2900 val_loss:3.64378 train_time:750.781s step_avg:750.78ms ema_beta:0.3
+step:1125/2900 val_loss:3.62005 train_time:844.100s step_avg:750.31ms ema_beta:0.3
+step:1250/2900 val_loss:3.58594 train_time:937.135s step_avg:749.71ms ema_beta:0.3
+step:1375/2900 val_loss:3.55974 train_time:1030.154s step_avg:749.20ms ema_beta:0.3
+step:1500/2900 val_loss:3.52933 train_time:1123.297s step_avg:748.86ms ema_beta:0.3
+step:1625/2900 val_loss:3.50588 train_time:1216.537s step_avg:748.64ms ema_beta:0.28579
+step:1750/2900 val_loss:3.47523 train_time:1309.690s step_avg:748.39ms ema_beta:0.2545
+step:1875/2900 val_loss:3.44655 train_time:1402.972s step_avg:748.25ms ema_beta:0.22383
+step:2000/2900 val_loss:3.41208 train_time:1496.248s step_avg:748.12ms ema_beta:0
+step:2125/2900 val_loss:3.38507 train_time:1589.627s step_avg:748.06ms ema_beta:0
+step:2250/2900 val_loss:3.36110 train_time:1683.190s step_avg:748.08ms ema_beta:0
+captured_ref_extrap_state step:2375
+step:2375/2900 val_loss:3.34064 train_time:1777.284s step_avg:748.33ms ema_beta:0
+step:2500/2900 val_loss:3.32154 train_time:1870.472s step_avg:748.19ms ema_beta:0
+step:2625/2900 val_loss:3.30349 train_time:1963.378s step_avg:747.95ms ema_beta:0
+step:2750/2900 val_loss:3.28916 train_time:2056.015s step_avg:747.64ms ema_beta:0
+step:2850/2900 val_loss:3.27970 train_time:2130.265s step_avg:747.46ms ema_beta:0 ref_gamma:-0.075 ref_step:2375
+step:2860/2900 val_loss:3.27910 train_time:2137.766s step_avg:747.47ms ema_beta:0 ref_gamma:-0.075 ref_step:2375

--- a/records/track_3_optimization/results/20260525_aurora_ema_ref/train_gpt_simple_aurora_ema_ref.py
+++ b/records/track_3_optimization/results/20260525_aurora_ema_ref/train_gpt_simple_aurora_ema_ref.py
@@ -1,0 +1,851 @@
+"""
+Clean Track 3 submission script for the 2860-step PR309/Aurora/EMA-Nesterov
+reference-interpolation result.
+
+The code intentionally contains only the components active in the validated
+2860 method: PR309/Aurora base optimizer, EMA-Nesterov, CGI alpha fixed at 0,
+zero non-projection biases, and fixed reference interpolation at validation.
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import argparse
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+from torch.optim import AdamW
+import torch.nn.functional as F
+import torch.distributed as dist
+
+# cuDNN SDPA can fail to build an execution plan for this compiled causal-attention
+# layout on some PyTorch/CUDA/cuDNN combinations. Leave Flash/mem-efficient/math SDPA
+# enabled and only remove the cuDNN backend from consideration.
+torch.backends.cuda.enable_cudnn_sdp(False)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--log-dir", type=Path, default=Path("logs"))
+parser.add_argument("--log-file", type=Path, default=None)
+parser.add_argument("--progress-interval", type=int, default=100)
+args = parser.parse_args()
+
+SEED = args.seed
+LOG_DIR = args.log_dir
+LOG_FILE = args.log_file
+TRAIN_PROGRESS_INTERVAL = args.progress_interval
+
+# Fixed 2860 submission settings. The optimizer/schedule horizon is 2900
+# because this is the validated PR309/EMA setup; the run stops and reports at
+# the 2860 checkpoint.
+TRAIN_STEPS = 2900
+RUN_STOP_STEP = 2860
+SCHEDULE_STEPS = 2980
+LR_POWER = 1.2
+REF_CAPTURE_STEP = 2375
+REF_APPLY_START_STEP = 2850
+REF_GAMMA = -0.075
+
+ADAM_EMBED_POWER_C = 4.976805410800738e-05
+ADAM_PROJ_POWER_C = 5.184172302917436e-07
+ADAM_OTHER_POWER_C = 1.6589351369335795e-06
+MUON_POWER_C = 3.3169534699576625e-06
+
+CONTRA_MUON_COEFF = -0.2
+CONTRA_HOLD_END_STEP = 0
+CONTRA_TO_NORMAL_END_STEP = 2500
+MU = 0.95
+MUON_LR = 0.0375
+MUON_COOLDOWN_STEPS = 100
+
+TARGET_UW = 0.3825
+NOR_BETA2 = 1.0
+SOAP_BETA2 = 0.90
+SOAP_PRECONDITION_FREQUENCY = 10
+SOAP_DENOM_POWER = 0.50
+SOAP_BLEND = 1.00
+V_SOAP_BLEND = 0.95
+ATTN_SOAP_DENOM_FLOOR = 0.55
+RADIAL_OUTWARD_SCALE = 0.5
+RADIAL_INWARD_SCALE = 1.0
+
+CGI_ALPHA = 0.0
+ZERO_NONPROJ_BIASES = True
+DI_FC_ALPHA = 0.30
+
+EMA_NESTEROV_STEPSIZE = 0.3
+EMA_NESTEROV_LOOKAHEAD_EMA = 0.99
+EMA_NESTEROV_PREFILL_STEPS = 300
+EMA_NESTEROV_REST_STEP = TRAIN_STEPS - 950
+
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return (norm(x.float()) * self.gains).type_as(x)
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        # half-truncate RoPE (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = norm(q), norm(k)
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="sum")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def gram_frobenius_norm_estimate(G: Tensor, keepdim: bool = False, eps: float = 1e-10) -> Tensor:
+    X = G.float()
+    gram = X.mT @ X if X.size(-2) > X.size(-1) else X @ X.mT
+    return gram.norm(dim=(-2, -1), keepdim=keepdim).sqrt().clamp_min(eps)
+
+def _ns_inner(X: Tensor) -> Tensor:
+    a, b, c = 2, -1.5, 0.5
+    for _ in range(12):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X
+
+# v93: Aurora-on-mlp.proj (K=3 outer iterations with D row rescaling)
+_AURORA_K = 3
+_AURORA_BETA = 0.25
+_AURORA_EPS = 1e-7
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    assert G.ndim >= 2
+    is_originally_wide = G.size(-2) < G.size(-1)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    if is_originally_wide:
+        Xt = X.mT
+        Xt32 = Xt.to(torch.float32)
+        target_row_sq = Xt.size(-1) / Xt.size(-2)
+        row_norm = Xt32.norm(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS)
+        D = 1.0 / row_norm
+        U = None
+        for k in range(_AURORA_K):
+            scaled = (D * Xt32).to(Xt.dtype)
+            scaled_wide = scaled.mT
+            scaled_wide = scaled_wide / gram_frobenius_norm_estimate(scaled_wide, keepdim=True, eps=1e-7).to(scaled_wide.dtype)
+            U_wide = _ns_inner(scaled_wide)
+            U = U_wide.mT
+            if k < _AURORA_K - 1:
+                U32 = U.to(torch.float32)
+                row_sq = U32.pow(2).sum(dim=-1, keepdim=True).clamp_(min=_AURORA_EPS * _AURORA_EPS)
+                D = D * (target_row_sq / row_sq).pow(_AURORA_BETA)
+        X = U.mT
+    else:
+        X = X / gram_frobenius_norm_estimate(X, keepdim=True, eps=1e-7).to(X.dtype)
+        X = _ns_inner(X)
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+def scale_to_unit_operator_norm(G: Tensor, eps: float = 1e-10) -> Tensor:
+    return G / gram_frobenius_norm_estimate(G, eps=eps).to(G.dtype)
+
+def should_soap_param(name: str) -> bool:
+    return (
+        name.endswith(".mlp.fc.weight")
+        or name.endswith(".mlp.proj.weight")
+        or name.endswith(".attn.v.weight")
+    )
+
+def is_v_param(name: str) -> bool:
+    return name.endswith(".attn.v.weight")
+
+def is_attn_param(name: str) -> bool:
+    return is_v_param(name)
+
+def scale_radial_update(update: Tensor, param: Tensor, step: int, eps: float = 1e-12) -> Tensor:
+    update_f = update.float()
+    param_f = param.float()
+    denom = (param_f * param_f).sum().clamp_min(eps)
+    coeff = (update_f * param_f).sum() / denom
+    radial = coeff * param_f
+    tangential = update_f - radial
+    # p.add_(update, alpha=-lr), so actual movement is -update.
+    # Outward movement means (-update) is aligned with p, i.e. coeff < 0.
+    outward_scale = RADIAL_OUTWARD_SCALE
+    radial_scale = torch.where(
+        coeff < 0,
+        update_f.new_tensor(outward_scale),
+        update_f.new_tensor(RADIAL_INWARD_SCALE),
+    )
+    return (tangential + radial_scale * radial).to(update.dtype)
+
+def target_radius_after_update(param: Tensor, update: Tensor, lr: float, eps: float = 1e-8) -> Tensor:
+    param_f = param.float()
+    update_f = update.float()
+    before_norm = param_f.norm().clamp_min(eps)
+    # Use only the radial component's first-order radius change as the intended
+    # radius change; the post-step rescale below removes finite tangent drift.
+    radial_delta = -lr * (update_f * param_f).sum() / before_norm
+    return (before_norm + radial_delta).clamp_min(eps)
+
+def rescale_to_radius(param: Tensor, target_norm: Tensor, eps: float = 1e-8):
+    after_norm = param.float().norm().clamp_min(eps)
+    param.mul_((target_norm / after_norm).to(param.dtype))
+
+def soap_eigenbasis(mat: Tensor) -> Tensor:
+    try:
+        _, q = torch.linalg.eigh(mat + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+    except RuntimeError:
+        _, q = torch.linalg.eigh(mat.double() + 1e-30 * torch.eye(mat.size(0), device=mat.device))
+        q = q.float()
+    return torch.flip(q, [1])
+
+def soap_basis_qr(row_gg, col_gg, q_row, q_col, exp_avg_sq):
+    row_eig = torch.diag(q_row.T @ row_gg @ q_row)
+    row_sort = torch.argsort(row_eig, descending=True)
+    q_row = q_row[:, row_sort]
+    exp_avg_sq = exp_avg_sq.index_select(0, row_sort)
+    q_row, _ = torch.linalg.qr(row_gg @ q_row)
+
+    col_eig = torch.diag(q_col.T @ col_gg @ q_col)
+    col_sort = torch.argsort(col_eig, descending=True)
+    q_col = q_col[:, col_sort]
+    exp_avg_sq = exp_avg_sq.index_select(1, col_sort)
+    q_col, _ = torch.linalg.qr(col_gg @ q_col)
+    return q_row, q_col, exp_avg_sq
+
+def soap_precondition_momentum(update, state, beta2=SOAP_BETA2, eps=1e-8,
+                               blend=SOAP_BLEND, denom_floor_ratio=0.0):
+    update_f = update.float()
+    if state["q_row"] is None:
+        return update
+    q_row, q_col = state["q_row"], state["q_col"]
+    projected = q_row.T @ update_f @ q_col
+    state["exp_avg_sq"].mul_(beta2).add_(projected.square(), alpha=1 - beta2)
+    denom = state["exp_avg_sq"].clamp_min(eps * eps).pow(SOAP_DENOM_POWER)
+    if denom_floor_ratio > 0:
+        denom_floor = denom.float().square().mean().sqrt().mul(denom_floor_ratio).clamp_min(eps)
+        denom = denom.clamp_min(denom_floor.to(denom.dtype))
+    precond = q_row @ (projected / denom) @ q_col.T
+    if blend != 1.0:
+        precond = blend * precond + (1 - blend) * update_f
+    precond.mul_(gram_frobenius_norm_estimate(update_f, eps=eps) / gram_frobenius_norm_estimate(precond, eps=eps))
+    return precond.to(update.dtype)
+
+def soap_update_preconditioner(grad, state, shampoo_beta=SOAP_BETA2, precondition_frequency=SOAP_PRECONDITION_FREQUENCY):
+    grad_f = grad.float()
+    state["row_gg"].lerp_(grad_f @ grad_f.T, 1 - shampoo_beta)
+    state["col_gg"].lerp_(grad_f.T @ grad_f, 1 - shampoo_beta)
+    if state["q_row"] is None:
+        state["q_row"] = soap_eigenbasis(state["row_gg"])
+        state["q_col"] = soap_eigenbasis(state["col_gg"])
+    elif state["soap_step"] > 0 and state["soap_step"] % precondition_frequency == 0:
+        state["q_row"], state["q_col"], state["exp_avg_sq"] = soap_basis_qr(
+            state["row_gg"], state["col_gg"], state["q_row"], state["q_col"], state["exp_avg_sq"]
+        )
+    state["soap_step"] += 1
+
+def norm_preserving_soap_blend(raw: Tensor, soap: Tensor, eps: float = 1e-8) -> Tensor:
+    raw_norm = gram_frobenius_norm_estimate(raw, eps=eps)
+    soap_norm = gram_frobenius_norm_estimate(soap, eps=eps)
+    return (soap * (raw_norm / soap_norm).to(soap.dtype)).to(raw.dtype)
+
+def _linear_ramp(step: int, start_step: int, end_step: int) -> float:
+    if end_step <= start_step:
+        return 1.0 if step >= end_step else 0.0
+    return min(1.0, max(0.0, (step - start_step) / (end_step - start_step)))
+
+def contra_coeff_for_step(step: int) -> float:
+    contra_to_normal = _linear_ramp(step, CONTRA_HOLD_END_STEP, CONTRA_TO_NORMAL_END_STEP)
+    return CONTRA_MUON_COEFF * (1.0 - contra_to_normal)
+
+def muon_update(update, second_moment, step, beta2=NOR_BETA2):
+    normalized_grad = scale_to_unit_operator_norm(update.clone())
+    ns_update = zeropower_via_newtonschulz5(update)
+    update_norm_estimate = gram_frobenius_norm_estimate(ns_update)
+    contra_coeff = contra_coeff_for_step(step)
+    update = ns_update + contra_coeff * normalized_grad
+    update = update * update_norm_estimate / gram_frobenius_norm_estimate(update)
+    update *= max(1, update.size(-2) / update.size(-1))**0.5
+
+    if update.size(-2) >= update.size(-1):
+        per_row_var = (update * update).mean(dim=-1, keepdim=True)
+    else:
+        per_row_var = (update * update).mean(dim=-2, keepdim=True)
+    second_moment.lerp_(per_row_var.float(), 1 - beta2)
+    vnorm = gram_frobenius_norm_estimate(update)
+    update = update * second_moment.clamp_min(1e-10).rsqrt().to(update.dtype)
+    vnorm_new = gram_frobenius_norm_estimate(update)
+    return update * (vnorm / vnorm_new)
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, named_params, lr=0.02, mu=0.95):
+        assert isinstance(named_params, list) and len(named_params) >= 1
+        self.param_names = {p: n for n, p in named_params}
+        self.soap_params = {p for n, p in named_params if should_soap_param(n)}
+        self.attn_soap_params = {p for n, p in named_params if should_soap_param(n) and is_attn_param(n)}
+        self.v_params = {p for n, p in named_params if is_v_param(n)}
+        self.step_count = 0
+        params = sorted([p for _, p in named_params], key=lambda x: x.size(), reverse=True)
+        super().__init__(params, dict(lr=lr, mu=mu))
+
+    def _init_state(self, p):
+        state = self.state[p]
+        if state:
+            return state
+        state["momentum"] = torch.zeros_like(p)
+        if p in self.soap_params:
+            state["exp_avg_sq"] = torch.zeros_like(p, dtype=torch.float32)
+            state["row_gg"] = torch.zeros(p.size(0), p.size(0), dtype=torch.float32, device=p.device)
+            state["col_gg"] = torch.zeros(p.size(1), p.size(1), dtype=torch.float32, device=p.device)
+            state["q_row"] = None
+            state["q_col"] = None
+            state["soap_step"] = 0
+        if p.size(-2) >= p.size(-1):
+            state["second_moment"] = torch.zeros((*p.shape[:-1], 1), dtype=torch.float32, device=p.device)
+        else:
+            state["second_moment"] = torch.zeros((*p.shape[:-2], 1, p.shape[-1]), dtype=torch.float32, device=p.device)
+        return state
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            params = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    state = self._init_state(p)
+                    grad = p.grad
+                    state["momentum"].lerp_(grad, 1 - group["mu"])
+                    momentum_update = grad.lerp(state["momentum"], group["mu"])
+                    use_soap = p in self.soap_params
+                    if use_soap:
+                        if p in self.attn_soap_params:
+                            soap_update = soap_precondition_momentum(
+                                momentum_update,
+                                state,
+                                blend=V_SOAP_BLEND,
+                                denom_floor_ratio=ATTN_SOAP_DENOM_FLOOR,
+                            )
+                            momentum_update = norm_preserving_soap_blend(momentum_update, soap_update)
+                        else:
+                            momentum_update = soap_precondition_momentum(momentum_update, state, blend=SOAP_BLEND)
+                    update = muon_update(momentum_update, state["second_moment"], self.step_count)
+                    update = scale_radial_update(update, p, self.step_count)
+                    p_fro = p.float().norm().clamp_min(1e-8)
+                    u_fro = update.float().norm().clamp_min(1e-8)
+                    scale = torch.where(u_fro / p_fro < TARGET_UW, TARGET_UW * p_fro / u_fro, torch.ones_like(p_fro))
+                    update = update * scale.to(update.dtype)
+                    target_radius = target_radius_after_update(p, update, group["lr"])
+                    p.add_(update, alpha=-group["lr"])
+                    rescale_to_radius(p, target_radius)
+                    if use_soap:
+                        soap_update_preconditioner(grad, state)
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+        self.step_count += 1
+
+
+class EMA_Nesterov(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        inner_optimizer,
+        lookahead_stepsize=0.0,
+        use_scheduled_lookahead_stepsize=True,
+        lookahead_ema=0.9,
+        prefill_steps=0,
+        rest_steps=0,
+    ):
+        if lookahead_stepsize < 0.0:
+            raise ValueError(f"invalid lookahead_stepsize: {lookahead_stepsize}")
+
+        super().__init__(params, {})
+        self.inner_optimizer = inner_optimizer
+        self.use_scheduled_lookahead_stepsize = use_scheduled_lookahead_stepsize
+        self.lookahead_stepsize = lookahead_stepsize
+        self.lookahead_ema = lookahead_ema
+        self.prefill_steps = prefill_steps
+        self.rest_steps = rest_steps
+        self.it = 0
+        self.lookahead_status = False
+        self.current_lookahead_stepsize = 0.0
+        self.initialize_buffers()
+
+    @torch.no_grad()
+    def initialize_buffers(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                if "prev_params" not in param_state:
+                    param_state["prev_params"] = (p.clone(), self.it)
+                if "lookahead_buffer" not in param_state:
+                    param_state["lookahead_buffer"] = (torch.zeros_like(p), -1)
+
+    def get_lr_lambda(self):
+        inner = self.inner_optimizer[0] if isinstance(self.inner_optimizer, list) else self.inner_optimizer
+        return inner.param_groups[0]["lr"] / inner.param_groups[0]["initial_lr"]
+
+    @torch.no_grad()
+    def lookahead_step(self):
+        if self.use_scheduled_lookahead_stepsize:
+            lookahead_stepsize = self.lookahead_stepsize * self.get_lr_lambda()
+        else:
+            lookahead_stepsize = self.lookahead_stepsize
+        self.current_lookahead_stepsize = lookahead_stepsize
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                lookahead = self.state[p]["lookahead_buffer"][0]
+                p.add_(lookahead, alpha=lookahead_stepsize)
+
+    @torch.no_grad()
+    def accum_lookahead(self):
+        for group in self.param_groups:
+            for p in group["params"]:
+                param_state = self.state[p]
+                look = p.add(param_state["prev_params"][0], alpha=-1)
+                buf = param_state["lookahead_buffer"][0]
+                param_state["lookahead_buffer"] = (
+                    buf.lerp_(look, 1 - self.lookahead_ema),
+                    self.it,
+                )
+                param_state["prev_params"] = (param_state["prev_params"][0].copy_(p), self.it)
+
+    @torch.no_grad()
+    def nesterov_step(self):
+        if self.it + 1 > self.prefill_steps and self.it < self.rest_steps and not self.lookahead_status:
+            self.lookahead_step()
+        else:
+            self.current_lookahead_stepsize = 0.0
+        self.lookahead_status = True
+
+    @torch.no_grad()
+    def step(self):
+        if not self.lookahead_status:
+            raise ValueError("optimizer.nesterov_step() should be invoked before model forward pass")
+        if isinstance(self.inner_optimizer, list):
+            for opt in self.inner_optimizer:
+                opt.step()
+        else:
+            self.inner_optimizer.step()
+        self.accum_lookahead()
+        self.lookahead_status = False
+        self.it += 1
+
+
+########################################
+#                Setup                 #
+########################################
+
+# torchrun sets these env variables
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+# this code can be run equivalently with 1, 2, 4, or 8 gpus.
+assert 8 % dist.get_world_size() == 0
+
+# logging setup
+if dist.get_rank() == 0:
+    if LOG_FILE is None:
+        log_dir = LOG_DIR
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfile = str(log_dir / f"{uuid.uuid4()}.txt")
+    else:
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        logfile = str(LOG_FILE)
+    print(logfile, flush=True)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s, flush=True)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+# we begin by logging this file itself
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running on device_name={torch.cuda.get_device_name(device)} with world_size={dist.get_world_size()}")
+print0(f"Run UTC timestamp={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+print0(f"Using seed={SEED}")
+print0("Method=PR309/Aurora/EMA-Nesterov + CGI_ALPHA=0 + zero non-projection biases + fixed reference interpolation")
+print0(f"Schedule horizon train_steps={TRAIN_STEPS}, schedule_steps={SCHEDULE_STEPS}, reported_step={RUN_STOP_STEP}")
+print0(f"Using ref_capture_step={REF_CAPTURE_STEP} ref_apply_start_step={REF_APPLY_START_STEP} ref_gamma={REF_GAMMA}")
+print0(f"Using CGI_ALPHA={CGI_ALPHA} ZERO_NONPROJ_BIASES={ZERO_NONPROJ_BIASES}")
+print0(f"Using contra_muon_coeff={CONTRA_MUON_COEFF} contra_to_normal_end_step={CONTRA_TO_NORMAL_END_STEP}")
+print0(f"Using mu={MU} muon_lr={MUON_LR}")
+print0(f"Using target_uw={TARGET_UW} radial_outward_scale={RADIAL_OUTWARD_SCALE} radial_inward_scale={RADIAL_INWARD_SCALE}")
+print0(f"Using SOAP on MLP fc/proj and attention V: soap_beta2={SOAP_BETA2} v_soap_blend={V_SOAP_BLEND}")
+print0(f"Using EMA-Nesterov stepsize={EMA_NESTEROV_STEPSIZE} lookahead_ema={EMA_NESTEROV_LOOKAHEAD_EMA} prefill_steps={EMA_NESTEROV_PREFILL_STEPS} rest_step={EMA_NESTEROV_REST_STEP}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+########################################
+#       Init & Optim Hyperparams       #
+########################################
+
+# we want to minimize this while still reaching 3.28 val loss
+train_steps = TRAIN_STEPS
+run_stop_step = RUN_STOP_STEP
+val_regular_interval = 125
+extra_val_steps = {2850, 2860}
+print0(f"Using run_stop_step={run_stop_step} train_steps={train_steps}")
+
+# Depth-scaled MLP input projection init from the PR309/Aurora base.
+_NUM_BLOCKS = len(model.blocks)
+
+# Initialize active method components: zero projection matrices, zero all
+# non-projection biases, and apply the PR309 depth-scaled MLP-fc init.
+for name, p in model.named_parameters():
+    if "proj" in name:
+        p.data.zero_()
+    elif name.endswith("bias") and ZERO_NONPROJ_BIASES:
+        p.data.zero_()
+
+for l_idx, block in enumerate(model.blocks):
+    ramp = l_idx / (_NUM_BLOCKS - 1) if _NUM_BLOCKS > 1 else 0.0
+    block.mlp.fc.weight.data.mul_(1.0 - DI_FC_ALPHA * ramp)
+
+# CGI alpha is intentionally fixed to zero for this result; norm gains remain 1.
+
+# create the optimizer(s)
+optimizer1 = AdamW([dict(params=[model.embed.weight], lr=0.3),
+                    dict(params=[model.proj.weight], lr=1/320),
+                    dict(params=[p for p in model.parameters() if p.ndim < 2], lr=0.01)],
+                   betas=(0.8, 0.99), eps=1e-10, weight_decay=0, fused=True)
+# Skylight-001: NorMuon-lite (per-row variance) + u/w-floor=0.35 + lr=0.0375 + wd=0.025.
+optimizer2 = Muon([(n, p) for n, p in model.blocks.named_parameters() if p.ndim >= 2],
+                  lr=MUON_LR, mu=MU)
+hparam_optimizers = [optimizer1, optimizer2]
+optimizers = [EMA_Nesterov(
+    [p for p in model.parameters()],
+    hparam_optimizers,
+    lookahead_stepsize=EMA_NESTEROV_STEPSIZE,
+    use_scheduled_lookahead_stepsize=True,
+    lookahead_ema=EMA_NESTEROV_LOOKAHEAD_EMA,
+    prefill_steps=EMA_NESTEROV_PREFILL_STEPS,
+    rest_steps=EMA_NESTEROV_REST_STEP,
+)]
+assert set(p for opt in hparam_optimizers for group in opt.param_groups
+           for p in group["params"]) == set(model.parameters())
+for opt in hparam_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+optimizer1.param_groups[0]["power_c"] = ADAM_EMBED_POWER_C
+optimizer1.param_groups[1]["power_c"] = ADAM_PROJ_POWER_C
+optimizer1.param_groups[2]["power_c"] = ADAM_OTHER_POWER_C
+optimizer2.param_groups[0]["power_c"] = MUON_POWER_C
+
+# learning rate schedule: stable then decay
+def _lr(step, initial_lr, power_c, power=1.0):
+    t_end = SCHEDULE_STEPS
+    flat_lr = initial_lr
+    downward_lr = power_c * max(0.0, t_end - step) ** power
+    return min(flat_lr, downward_lr)
+
+# v49: v15 Muon mu schedule (warmup 0.85->0.95 over 300 steps, cooldown 0.95->0.85 over last 50)
+_MU_MIN = 0.85
+_MU_MAX = 0.95
+_MU_WARMUP_STEPS = 300
+_MU_COOLDOWN_STEPS = MUON_COOLDOWN_STEPS
+
+def _muon_mu_at_step(step, train_steps):
+    cd_start = train_steps - _MU_COOLDOWN_STEPS
+    if step < _MU_WARMUP_STEPS:
+        frac = step / max(_MU_WARMUP_STEPS, 1)
+        return _MU_MIN + frac * (_MU_MAX - _MU_MIN)
+    elif step > cd_start:
+        frac = (step - cd_start) / max(_MU_COOLDOWN_STEPS, 1)
+        return _MU_MAX - frac * (_MU_MAX - _MU_MIN)
+    else:
+        return _MU_MAX
+
+def set_hparams(step):
+    assert 0 <= step / SCHEDULE_STEPS < 1
+    mu = _muon_mu_at_step(step, TRAIN_STEPS)
+    for opt in hparam_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = _lr(step, group["initial_lr"], group["power_c"], LR_POWER)
+    for group in optimizer2.param_groups:
+        group["mu"] = mu
+
+
+
+
+ref_extrap_state = None
+ref_extrap_captured_step = None
+
+@torch.no_grad()
+def maybe_capture_ref_extrap_state(step: int):
+    global ref_extrap_state, ref_extrap_captured_step
+    if step != REF_CAPTURE_STEP or ref_extrap_state is not None:
+        return
+    ref_extrap_state = {
+        name: p.detach().cpu().clone()
+        for name, p in model.named_parameters()
+        if torch.is_floating_point(p)
+    }
+    ref_extrap_captured_step = step
+    print0(f"captured_ref_extrap_state step:{step}", console=True)
+
+def ref_extrap_gamma_for_step(step: int) -> float:
+    return REF_GAMMA if step >= REF_APPLY_START_STEP else 0.0
+
+@torch.no_grad()
+def apply_ref_extrap_weights(gamma: float):
+    if gamma == 0.0:
+        return []
+    if ref_extrap_state is None:
+        raise RuntimeError("reference interpolation requested before capture")
+    applied = []
+    for name, p in model.named_parameters():
+        ref = ref_extrap_state.get(name)
+        if ref is None or not torch.is_floating_point(p):
+            continue
+        ref = ref.to(device=p.device, dtype=p.dtype)
+        delta = (p.detach() - ref) * gamma
+        p.add_(delta)
+        applied.append((p, delta))
+    return applied
+
+@torch.no_grad()
+def restore_ref_extrap_weights(applied):
+    for p, delta in reversed(applied):
+        p.sub_(delta)
+
+@torch.no_grad()
+def compute_validation_loss():
+    val_loss = 0
+    assert len(val_inputs) % mbs == 0
+    for i in range(len(val_inputs) // mbs):
+        val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
+    return val_loss / val_tokens
+
+def ema_nesterov_suffix() -> str:
+    return f" ema_beta:{optimizers[0].current_lookahead_stepsize:.5g}"
+
+def ref_extrap_suffix(step: int) -> str:
+    gamma = ref_extrap_gamma_for_step(step)
+    if gamma == 0.0:
+        return ""
+    return f" ref_gamma:{gamma:g} ref_step:{ref_extrap_captured_step}"
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+# start the clock
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(run_stop_step + 1):
+
+    # --------------- VALIDATION SECTION -----------------
+    should_validate = (
+        step == train_steps
+        or step == run_stop_step
+        or (step > 0 and step % val_regular_interval == 0)
+        or step in extra_val_steps
+    )
+    if should_validate:
+        # stop the clock
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        ref_extrap_applied = apply_ref_extrap_weights(ref_extrap_gamma_for_step(step))
+        model.eval()
+        val_loss = compute_validation_loss()
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms"
+               + ema_nesterov_suffix()
+               + ref_extrap_suffix(step), console=True)
+        restore_ref_extrap_weights(ref_extrap_applied)
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == run_stop_step:
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    # accumulate across microbatches in case we are running with fewer than 8 gpus
+    assert len(inputs) % mbs == 0
+    for opt in optimizers:
+        if hasattr(opt, "nesterov_step"):
+            opt.nesterov_step()
+    for i in range(len(inputs) // mbs):
+        loss = model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs])
+        # NaN guard: catch divergence the step it happens, not 750 steps later.
+        if not torch.isfinite(loss).all():
+            raise RuntimeError(f"non-finite train loss at step {step} mb {i}: {loss.item()}")
+        loss.backward()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, name
+        dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+    # set optimization hyperparameters and take a step
+    set_hparams(step)
+    for opt in optimizers:
+        opt.step()
+    maybe_capture_ref_extrap_state(step + 1)
+    model.zero_grad(set_to_none=True)
+    if TRAIN_PROGRESS_INTERVAL > 0 and (step + 1) % TRAIN_PROGRESS_INTERVAL == 0:
+        approx_training_time = training_time + (time.perf_counter() - t0)
+        print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+               + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms",
+               console=True, log=False)
+
+dist.destroy_process_group()


### PR DESCRIPTION
## Summary

Adds a Track 3 submission using the Aurora/EMA-Nesterov base from PR #309 with a fixed reference-interpolated output rule.

This submission reaches the target at 2860 training steps and is a new lower step-count result for Track 3.

## Method

This submission is based on the Aurora/EMA-Nesterov optimizer setup from PR #309. It uses `CGI_ALPHA=0.0`, zeros non-projection biases, captures reference weights at step 2375, and reports a fixed reference-interpolated output with `gamma=-0.075` from step 2850 onward.

The submitted run stops at fixed stopping point K=2860. The stopping point, reference capture step, reference interpolation gamma, and reporting step are fixed across all seeds.

## Evidence

Across 16 non-cherry-picked seeds at fixed stopping point K=2860:

- Mean validation loss: 3.278939375
- Track 3 statistic: `(3.28 - 3.278939375) * sqrt(16) = 0.00424250`
- Required threshold: `>= 0.004`

Final losses:

| seed | final val loss |
|---:|---:|
| 0 | 3.27765 |
| 1 | 3.27965 |
| 2 | 3.27675 |
| 3 | 3.27978 |
| 4 | 3.27961 |
| 5 | 3.27999 |
| 6 | 3.27696 |
| 7 | 3.27746 |
| 8 | 3.27929 |
| 9 | 3.27910 |
| 10 | 3.28025 |
| 11 | 3.28060 |
| 12 | 3.27822 |
| 13 | 3.27837 |
| 14 | 3.27969 |
| 15 | 3.27966 |
| **mean** | **3.278939375** |

All logs report `step:2860/2900`; no per-run early stopping is used.

*Disclosure: this submission was made with the assistance of GPT-5.5.*
