### PR TITLE
Optimizer Baseline: PSGD (3400 steps)

### DIFF
--- a/records/track_3_optimization/results/20260527_psgd/0770a040-2b18-4751-8630-88301f671292.txt
+++ b/records/track_3_optimization/results/20260527_psgd/0770a040-2b18-4751-8630-88301f671292.txt
@@ -1,0 +1,444 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+This script implements vanilla PSGD with Hyperball (and no trust-region based soft-clip update).
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read()
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="mean")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def init_psgd(grad: Tensor):
+    assert grad.ndim == 2
+    m, n = grad.shape
+    s = grad.float().abs().pow(4).mean().clamp(min=1e-24).pow(-1/32).item()
+    Q0 = torch.eye(m, dtype=torch.float32, device=grad.device) * s
+    Q1 = torch.eye(n, dtype=torch.float32, device=grad.device) * s
+    return Q0, Q1
+
+
+def spectral_norm(A: Tensor) -> Tensor:
+    # 1.5 power iterations; A is symmetric PSD at all call sites
+    scale = A.norm(float("inf"))
+    if scale == 0:
+        return scale
+    A = A / scale
+    x = A[:, (A * A).sum(0).argmax()]
+    x = A @ x
+    x = x / torch.linalg.vector_norm(x)
+    return scale * torch.linalg.vector_norm(A @ x)
+
+
+@torch.compile
+def psgd_update_precond(Q0: Tensor, Q1: Tensor, U: Tensor, v: Tensor, precond_lr=1.0) -> None:
+    # balance max absolute values of Q0, Q1
+    rescale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0.mul_(rescale_factor)
+    Q1.div_(rescale_factor)
+
+    # preconditioned update; A = Q0 U Q1^T
+    A = Q0 @ U @ Q1.mT
+    # preconditioned probe vector; B = Q0^{-T} v Q1^{-1}
+    B = torch.linalg.solve_triangular(Q0.mT, v, upper=False, left=True)
+    B = torch.linalg.solve_triangular(Q1, B, upper=True, left=False)
+
+    AAt = A @ A.mT
+    BBt = B @ B.mT
+    ell0 = spectral_norm(AAt + BBt)
+    Q0.sub_(precond_lr / ell0 * torch.triu(AAt - BBt) @ Q0)
+
+    AtA = A.mT @ A
+    BtB = B.mT @ B
+    ell1 = spectral_norm(AtA + BtB)
+    Q1.sub_(precond_lr / ell1 * torch.triu(AtA - BtB) @ Q1)
+
+
+class PSGDKron(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.025, precond_lr=1.0, beta1=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.numel(), reverse=True)
+        defaults = dict(lr=lr, precond_lr=precond_lr, beta1=beta1)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            beta1 = group["beta1"]
+            precond_lr = group["precond_lr"]
+            lr = group["lr"]
+            params = group["params"]
+            # pad so len is divisible by world_size
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    if grad is None:
+                        continue
+                    grad = grad.squeeze().float()
+                    state = self.state[p]
+                    if not state:
+                        state["Q0"], state["Q1"] = init_psgd(grad)
+                        state["step"] = 0
+                        state["exp_avg"] = torch.zeros_like(grad)
+                    state["step"] += 1
+                    # adam-style beta correction to warm up preconditioner
+                    state["exp_avg"].lerp_(grad, 1 - beta1)
+                    update = state["exp_avg"] / (1 - beta1 ** state["step"])
+
+                    v = torch.randn_like(update)
+                    nu = torch.randn_like(update)
+                    damping = torch.finfo(torch.float32).eps * update.abs()
+                    Q0, Q1 = state["Q0"], state["Q1"]
+                    psgd_update_precond(
+                        Q0, Q1, update + damping * nu, v,
+                        precond_lr=precond_lr,
+                    )
+
+                    step_update = (Q0.mT @ Q0) @ update @ (Q1.mT @ Q1)
+
+                    # hyperball: step on the sphere, preserve param norm
+                    step_update = step_update.view_as(p)
+                    p_norm = p.float().norm()
+                    u_norm = step_update.norm()
+                    new_p = p.float() - lr * step_update * (p_norm / (u_norm + 1e-10))
+                    new_p_norm = new_p.norm()
+                    p.copy_((new_p / (new_p_norm + 1e-10) * p_norm).to(p.dtype))
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+########################################
+#                Setup                 #
+########################################
+
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+assert 8 % dist.get_world_size() == 0
+
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#            Initialization            #
+########################################
+
+for name, param in model.named_parameters():
+    if param.ndim < 2:
+        continue
+    if "blocks" in name:
+        fan_in = param.size(1)
+        base_std = 1.0 / (3.0 * fan_in) ** 0.5
+        if "proj" in name and "mlp" in name:
+            std = base_std * 3.0
+        elif "fc" in name:
+            std = base_std * 1.5
+        elif "proj" in name and "attn" in name:
+            std = base_std * 1.25
+        else:
+            std = base_std * 1.0
+        param.data.normal_(0, std)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+
+hidden_matrix_params = [p for p in model.blocks.parameters() if p.ndim >= 2]
+embed_params = [model.embed.weight]
+head_params = [model.proj.weight]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+
+psgd_steady_lr = 0.025
+train_steps = 3400
+cooldown_frac = 1.0
+precond_lr = 1.0
+
+adam_base_lrs = [0.3, 1/320, 0.01]
+adam_param_groups = [dict(params=embed_params, lr=adam_base_lrs[0]),
+                    dict(params=head_params, lr=adam_base_lrs[1]),
+                    dict(params=scalar_params, lr=adam_base_lrs[2])]
+optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+optimizer2 = PSGDKron(hidden_matrix_params, lr=psgd_steady_lr, precond_lr=precond_lr, beta1=0.95)
+optimizers = [optimizer1, optimizer2]
+
+def get_psgd_lr(step: int):
+    cooldown_start = int(train_steps * (1 - cooldown_frac))
+    if step < cooldown_start:
+        return psgd_steady_lr
+    t = (step - cooldown_start) / (train_steps - cooldown_start)
+    return psgd_steady_lr * (1 - t)
+
+def get_adam_lr_scale(step: int):
+    adam_cooldown_start = int(train_steps * (1 - 0.5))
+    if step < adam_cooldown_start:
+        return 1.0
+    t = (step - adam_cooldown_start) / (train_steps - adam_cooldown_start)
+    return 1.0 - t * 0.9
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+val_interval = 125
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(train_steps + 1):
+
+    if step == train_steps or step % val_interval == 0:
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            num_val_mbs = len(val_inputs) // mbs
+            for i in range(num_val_mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        val_loss /= num_val_mbs
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms", console=True)
+        model.train()
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    inputs, targets = next(train_loader)
+    num_mbs = len(inputs) // mbs
+    for i in range(num_mbs):
+        (model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]) / num_mbs).backward()
+    for p in model.parameters():
+        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+    for group in optimizer2.param_groups:
+        group["lr"] = get_psgd_lr(step)
+    adam_scale = get_adam_lr_scale(step)
+    for group, base_lr in zip(optimizer1.param_groups, adam_base_lrs):
+        group["lr"] = base_lr * adam_scale
+
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+
+    approx_training_time = training_time + (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+           + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.12.0+cu130 compiled for CUDA 13.0 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3400 val_loss:10.96828 train_time:0.000s step_avg:0.19ms
+step:125/3400 val_loss:4.91966 train_time:25.772s step_avg:206.17ms
+step:250/3400 val_loss:4.23982 train_time:48.355s step_avg:193.42ms
+step:375/3400 val_loss:4.04405 train_time:70.871s step_avg:188.99ms
+step:500/3400 val_loss:3.95385 train_time:93.315s step_avg:186.63ms
+step:625/3400 val_loss:3.87216 train_time:115.810s step_avg:185.30ms
+step:750/3400 val_loss:3.82403 train_time:138.208s step_avg:184.28ms
+step:875/3400 val_loss:3.78783 train_time:160.620s step_avg:183.57ms
+step:1000/3400 val_loss:3.74245 train_time:182.953s step_avg:182.95ms
+step:1125/3400 val_loss:3.71481 train_time:205.283s step_avg:182.47ms
+step:1250/3400 val_loss:3.68549 train_time:227.625s step_avg:182.10ms
+step:1375/3400 val_loss:3.66314 train_time:249.942s step_avg:181.78ms
+step:1500/3400 val_loss:3.62978 train_time:272.348s step_avg:181.57ms
+step:1625/3400 val_loss:3.60264 train_time:294.674s step_avg:181.34ms
+step:1750/3400 val_loss:3.57783 train_time:316.976s step_avg:181.13ms
+step:1875/3400 val_loss:3.54989 train_time:339.225s step_avg:180.92ms
+step:2000/3400 val_loss:3.52189 train_time:361.532s step_avg:180.77ms
+step:2125/3400 val_loss:3.49761 train_time:383.860s step_avg:180.64ms
+step:2250/3400 val_loss:3.47170 train_time:406.109s step_avg:180.49ms
+step:2375/3400 val_loss:3.44782 train_time:428.414s step_avg:180.38ms
+step:2500/3400 val_loss:3.42390 train_time:450.689s step_avg:180.28ms
+step:2625/3400 val_loss:3.39814 train_time:472.977s step_avg:180.18ms
+step:2750/3400 val_loss:3.37512 train_time:495.306s step_avg:180.11ms
+step:2875/3400 val_loss:3.35331 train_time:517.575s step_avg:180.03ms
+step:3000/3400 val_loss:3.33047 train_time:539.814s step_avg:179.94ms
+step:3125/3400 val_loss:3.30830 train_time:562.129s step_avg:179.88ms
+step:3250/3400 val_loss:3.28918 train_time:584.403s step_avg:179.82ms
+step:3375/3400 val_loss:3.27624 train_time:606.688s step_avg:179.76ms
+step:3400/3400 val_loss:3.27503 train_time:611.138s step_avg:179.75ms

--- a/records/track_3_optimization/results/20260527_psgd/35c082e6-2e27-4805-920f-db3c3ec0bee6.txt
+++ b/records/track_3_optimization/results/20260527_psgd/35c082e6-2e27-4805-920f-db3c3ec0bee6.txt
@@ -1,0 +1,444 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+This script implements vanilla PSGD with Hyperball (and no trust-region based soft-clip update).
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read()
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="mean")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def init_psgd(grad: Tensor):
+    assert grad.ndim == 2
+    m, n = grad.shape
+    s = grad.float().abs().pow(4).mean().clamp(min=1e-24).pow(-1/32).item()
+    Q0 = torch.eye(m, dtype=torch.float32, device=grad.device) * s
+    Q1 = torch.eye(n, dtype=torch.float32, device=grad.device) * s
+    return Q0, Q1
+
+
+def spectral_norm(A: Tensor) -> Tensor:
+    # 1.5 power iterations; A is symmetric PSD at all call sites
+    scale = A.norm(float("inf"))
+    if scale == 0:
+        return scale
+    A = A / scale
+    x = A[:, (A * A).sum(0).argmax()]
+    x = A @ x
+    x = x / torch.linalg.vector_norm(x)
+    return scale * torch.linalg.vector_norm(A @ x)
+
+
+@torch.compile
+def psgd_update_precond(Q0: Tensor, Q1: Tensor, U: Tensor, v: Tensor, precond_lr=1.0) -> None:
+    # balance max absolute values of Q0, Q1
+    rescale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0.mul_(rescale_factor)
+    Q1.div_(rescale_factor)
+
+    # preconditioned update; A = Q0 U Q1^T
+    A = Q0 @ U @ Q1.mT
+    # preconditioned probe vector; B = Q0^{-T} v Q1^{-1}
+    B = torch.linalg.solve_triangular(Q0.mT, v, upper=False, left=True)
+    B = torch.linalg.solve_triangular(Q1, B, upper=True, left=False)
+
+    AAt = A @ A.mT
+    BBt = B @ B.mT
+    ell0 = spectral_norm(AAt + BBt)
+    Q0.sub_(precond_lr / ell0 * torch.triu(AAt - BBt) @ Q0)
+
+    AtA = A.mT @ A
+    BtB = B.mT @ B
+    ell1 = spectral_norm(AtA + BtB)
+    Q1.sub_(precond_lr / ell1 * torch.triu(AtA - BtB) @ Q1)
+
+
+class PSGDKron(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.025, precond_lr=1.0, beta1=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.numel(), reverse=True)
+        defaults = dict(lr=lr, precond_lr=precond_lr, beta1=beta1)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            beta1 = group["beta1"]
+            precond_lr = group["precond_lr"]
+            lr = group["lr"]
+            params = group["params"]
+            # pad so len is divisible by world_size
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    if grad is None:
+                        continue
+                    grad = grad.squeeze().float()
+                    state = self.state[p]
+                    if not state:
+                        state["Q0"], state["Q1"] = init_psgd(grad)
+                        state["step"] = 0
+                        state["exp_avg"] = torch.zeros_like(grad)
+                    state["step"] += 1
+                    # adam-style beta correction to warm up preconditioner
+                    state["exp_avg"].lerp_(grad, 1 - beta1)
+                    update = state["exp_avg"] / (1 - beta1 ** state["step"])
+
+                    v = torch.randn_like(update)
+                    nu = torch.randn_like(update)
+                    damping = torch.finfo(torch.float32).eps * update.abs()
+                    Q0, Q1 = state["Q0"], state["Q1"]
+                    psgd_update_precond(
+                        Q0, Q1, update + damping * nu, v,
+                        precond_lr=precond_lr,
+                    )
+
+                    step_update = (Q0.mT @ Q0) @ update @ (Q1.mT @ Q1)
+
+                    # hyperball: step on the sphere, preserve param norm
+                    step_update = step_update.view_as(p)
+                    p_norm = p.float().norm()
+                    u_norm = step_update.norm()
+                    new_p = p.float() - lr * step_update * (p_norm / (u_norm + 1e-10))
+                    new_p_norm = new_p.norm()
+                    p.copy_((new_p / (new_p_norm + 1e-10) * p_norm).to(p.dtype))
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+########################################
+#                Setup                 #
+########################################
+
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+assert 8 % dist.get_world_size() == 0
+
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#            Initialization            #
+########################################
+
+for name, param in model.named_parameters():
+    if param.ndim < 2:
+        continue
+    if "blocks" in name:
+        fan_in = param.size(1)
+        base_std = 1.0 / (3.0 * fan_in) ** 0.5
+        if "proj" in name and "mlp" in name:
+            std = base_std * 3.0
+        elif "fc" in name:
+            std = base_std * 1.5
+        elif "proj" in name and "attn" in name:
+            std = base_std * 1.25
+        else:
+            std = base_std * 1.0
+        param.data.normal_(0, std)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+
+hidden_matrix_params = [p for p in model.blocks.parameters() if p.ndim >= 2]
+embed_params = [model.embed.weight]
+head_params = [model.proj.weight]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+
+psgd_steady_lr = 0.025
+train_steps = 3400
+cooldown_frac = 1.0
+precond_lr = 1.0
+
+adam_base_lrs = [0.3, 1/320, 0.01]
+adam_param_groups = [dict(params=embed_params, lr=adam_base_lrs[0]),
+                    dict(params=head_params, lr=adam_base_lrs[1]),
+                    dict(params=scalar_params, lr=adam_base_lrs[2])]
+optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+optimizer2 = PSGDKron(hidden_matrix_params, lr=psgd_steady_lr, precond_lr=precond_lr, beta1=0.95)
+optimizers = [optimizer1, optimizer2]
+
+def get_psgd_lr(step: int):
+    cooldown_start = int(train_steps * (1 - cooldown_frac))
+    if step < cooldown_start:
+        return psgd_steady_lr
+    t = (step - cooldown_start) / (train_steps - cooldown_start)
+    return psgd_steady_lr * (1 - t)
+
+def get_adam_lr_scale(step: int):
+    adam_cooldown_start = int(train_steps * (1 - 0.5))
+    if step < adam_cooldown_start:
+        return 1.0
+    t = (step - adam_cooldown_start) / (train_steps - adam_cooldown_start)
+    return 1.0 - t * 0.9
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+val_interval = 125
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(train_steps + 1):
+
+    if step == train_steps or step % val_interval == 0:
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            num_val_mbs = len(val_inputs) // mbs
+            for i in range(num_val_mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        val_loss /= num_val_mbs
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms", console=True)
+        model.train()
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    inputs, targets = next(train_loader)
+    num_mbs = len(inputs) // mbs
+    for i in range(num_mbs):
+        (model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]) / num_mbs).backward()
+    for p in model.parameters():
+        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+    for group in optimizer2.param_groups:
+        group["lr"] = get_psgd_lr(step)
+    adam_scale = get_adam_lr_scale(step)
+    for group, base_lr in zip(optimizer1.param_groups, adam_base_lrs):
+        group["lr"] = base_lr * adam_scale
+
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+
+    approx_training_time = training_time + (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+           + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.12.0+cu130 compiled for CUDA 13.0 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3400 val_loss:11.00425 train_time:0.000s step_avg:0.11ms
+step:125/3400 val_loss:4.92190 train_time:25.959s step_avg:207.67ms
+step:250/3400 val_loss:4.24720 train_time:48.448s step_avg:193.79ms
+step:375/3400 val_loss:4.04880 train_time:70.887s step_avg:189.03ms
+step:500/3400 val_loss:3.94931 train_time:93.277s step_avg:186.55ms
+step:625/3400 val_loss:3.87543 train_time:115.742s step_avg:185.19ms
+step:750/3400 val_loss:3.83431 train_time:138.305s step_avg:184.41ms
+step:875/3400 val_loss:3.78568 train_time:160.854s step_avg:183.83ms
+step:1000/3400 val_loss:3.73961 train_time:183.262s step_avg:183.26ms
+step:1125/3400 val_loss:3.71711 train_time:205.554s step_avg:182.71ms
+step:1250/3400 val_loss:3.68948 train_time:227.863s step_avg:182.29ms
+step:1375/3400 val_loss:3.66753 train_time:250.156s step_avg:181.93ms
+step:1500/3400 val_loss:3.62487 train_time:272.421s step_avg:181.61ms
+step:1625/3400 val_loss:3.60511 train_time:294.687s step_avg:181.35ms
+step:1750/3400 val_loss:3.58104 train_time:316.962s step_avg:181.12ms
+step:1875/3400 val_loss:3.55130 train_time:339.215s step_avg:180.91ms
+step:2000/3400 val_loss:3.52139 train_time:361.470s step_avg:180.73ms
+step:2125/3400 val_loss:3.49834 train_time:383.769s step_avg:180.60ms
+step:2250/3400 val_loss:3.47253 train_time:406.009s step_avg:180.45ms
+step:2375/3400 val_loss:3.44851 train_time:428.286s step_avg:180.33ms
+step:2500/3400 val_loss:3.42626 train_time:450.546s step_avg:180.22ms
+step:2625/3400 val_loss:3.39936 train_time:472.792s step_avg:180.11ms
+step:2750/3400 val_loss:3.37703 train_time:495.162s step_avg:180.06ms
+step:2875/3400 val_loss:3.35457 train_time:517.432s step_avg:179.98ms
+step:3000/3400 val_loss:3.33155 train_time:539.636s step_avg:179.88ms
+step:3125/3400 val_loss:3.30969 train_time:561.919s step_avg:179.81ms
+step:3250/3400 val_loss:3.29049 train_time:584.284s step_avg:179.78ms
+step:3375/3400 val_loss:3.27762 train_time:606.592s step_avg:179.73ms
+step:3400/3400 val_loss:3.27640 train_time:611.057s step_avg:179.72ms

--- a/records/track_3_optimization/results/20260527_psgd/799f1179-3b89-437a-8447-a074a8864163.txt
+++ b/records/track_3_optimization/results/20260527_psgd/799f1179-3b89-437a-8447-a074a8864163.txt
@@ -1,0 +1,444 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+This script implements vanilla PSGD with Hyperball (and no trust-region based soft-clip update).
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read()
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="mean")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def init_psgd(grad: Tensor):
+    assert grad.ndim == 2
+    m, n = grad.shape
+    s = grad.float().abs().pow(4).mean().clamp(min=1e-24).pow(-1/32).item()
+    Q0 = torch.eye(m, dtype=torch.float32, device=grad.device) * s
+    Q1 = torch.eye(n, dtype=torch.float32, device=grad.device) * s
+    return Q0, Q1
+
+
+def spectral_norm(A: Tensor) -> Tensor:
+    # 1.5 power iterations; A is symmetric PSD at all call sites
+    scale = A.norm(float("inf"))
+    if scale == 0:
+        return scale
+    A = A / scale
+    x = A[:, (A * A).sum(0).argmax()]
+    x = A @ x
+    x = x / torch.linalg.vector_norm(x)
+    return scale * torch.linalg.vector_norm(A @ x)
+
+
+@torch.compile
+def psgd_update_precond(Q0: Tensor, Q1: Tensor, U: Tensor, v: Tensor, precond_lr=1.0) -> None:
+    # balance max absolute values of Q0, Q1
+    rescale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0.mul_(rescale_factor)
+    Q1.div_(rescale_factor)
+
+    # preconditioned update; A = Q0 U Q1^T
+    A = Q0 @ U @ Q1.mT
+    # preconditioned probe vector; B = Q0^{-T} v Q1^{-1}
+    B = torch.linalg.solve_triangular(Q0.mT, v, upper=False, left=True)
+    B = torch.linalg.solve_triangular(Q1, B, upper=True, left=False)
+
+    AAt = A @ A.mT
+    BBt = B @ B.mT
+    ell0 = spectral_norm(AAt + BBt)
+    Q0.sub_(precond_lr / ell0 * torch.triu(AAt - BBt) @ Q0)
+
+    AtA = A.mT @ A
+    BtB = B.mT @ B
+    ell1 = spectral_norm(AtA + BtB)
+    Q1.sub_(precond_lr / ell1 * torch.triu(AtA - BtB) @ Q1)
+
+
+class PSGDKron(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.025, precond_lr=1.0, beta1=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.numel(), reverse=True)
+        defaults = dict(lr=lr, precond_lr=precond_lr, beta1=beta1)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            beta1 = group["beta1"]
+            precond_lr = group["precond_lr"]
+            lr = group["lr"]
+            params = group["params"]
+            # pad so len is divisible by world_size
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    if grad is None:
+                        continue
+                    grad = grad.squeeze().float()
+                    state = self.state[p]
+                    if not state:
+                        state["Q0"], state["Q1"] = init_psgd(grad)
+                        state["step"] = 0
+                        state["exp_avg"] = torch.zeros_like(grad)
+                    state["step"] += 1
+                    # adam-style beta correction to warm up preconditioner
+                    state["exp_avg"].lerp_(grad, 1 - beta1)
+                    update = state["exp_avg"] / (1 - beta1 ** state["step"])
+
+                    v = torch.randn_like(update)
+                    nu = torch.randn_like(update)
+                    damping = torch.finfo(torch.float32).eps * update.abs()
+                    Q0, Q1 = state["Q0"], state["Q1"]
+                    psgd_update_precond(
+                        Q0, Q1, update + damping * nu, v,
+                        precond_lr=precond_lr,
+                    )
+
+                    step_update = (Q0.mT @ Q0) @ update @ (Q1.mT @ Q1)
+
+                    # hyperball: step on the sphere, preserve param norm
+                    step_update = step_update.view_as(p)
+                    p_norm = p.float().norm()
+                    u_norm = step_update.norm()
+                    new_p = p.float() - lr * step_update * (p_norm / (u_norm + 1e-10))
+                    new_p_norm = new_p.norm()
+                    p.copy_((new_p / (new_p_norm + 1e-10) * p_norm).to(p.dtype))
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+########################################
+#                Setup                 #
+########################################
+
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+assert 8 % dist.get_world_size() == 0
+
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#            Initialization            #
+########################################
+
+for name, param in model.named_parameters():
+    if param.ndim < 2:
+        continue
+    if "blocks" in name:
+        fan_in = param.size(1)
+        base_std = 1.0 / (3.0 * fan_in) ** 0.5
+        if "proj" in name and "mlp" in name:
+            std = base_std * 3.0
+        elif "fc" in name:
+            std = base_std * 1.5
+        elif "proj" in name and "attn" in name:
+            std = base_std * 1.25
+        else:
+            std = base_std * 1.0
+        param.data.normal_(0, std)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+
+hidden_matrix_params = [p for p in model.blocks.parameters() if p.ndim >= 2]
+embed_params = [model.embed.weight]
+head_params = [model.proj.weight]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+
+psgd_steady_lr = 0.025
+train_steps = 3400
+cooldown_frac = 1.0
+precond_lr = 1.0
+
+adam_base_lrs = [0.3, 1/320, 0.01]
+adam_param_groups = [dict(params=embed_params, lr=adam_base_lrs[0]),
+                    dict(params=head_params, lr=adam_base_lrs[1]),
+                    dict(params=scalar_params, lr=adam_base_lrs[2])]
+optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+optimizer2 = PSGDKron(hidden_matrix_params, lr=psgd_steady_lr, precond_lr=precond_lr, beta1=0.95)
+optimizers = [optimizer1, optimizer2]
+
+def get_psgd_lr(step: int):
+    cooldown_start = int(train_steps * (1 - cooldown_frac))
+    if step < cooldown_start:
+        return psgd_steady_lr
+    t = (step - cooldown_start) / (train_steps - cooldown_start)
+    return psgd_steady_lr * (1 - t)
+
+def get_adam_lr_scale(step: int):
+    adam_cooldown_start = int(train_steps * (1 - 0.5))
+    if step < adam_cooldown_start:
+        return 1.0
+    t = (step - adam_cooldown_start) / (train_steps - adam_cooldown_start)
+    return 1.0 - t * 0.9
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+val_interval = 125
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(train_steps + 1):
+
+    if step == train_steps or step % val_interval == 0:
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            num_val_mbs = len(val_inputs) // mbs
+            for i in range(num_val_mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        val_loss /= num_val_mbs
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms", console=True)
+        model.train()
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    inputs, targets = next(train_loader)
+    num_mbs = len(inputs) // mbs
+    for i in range(num_mbs):
+        (model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]) / num_mbs).backward()
+    for p in model.parameters():
+        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+    for group in optimizer2.param_groups:
+        group["lr"] = get_psgd_lr(step)
+    adam_scale = get_adam_lr_scale(step)
+    for group, base_lr in zip(optimizer1.param_groups, adam_base_lrs):
+        group["lr"] = base_lr * adam_scale
+
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+
+    approx_training_time = training_time + (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+           + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.12.0+cu130 compiled for CUDA 13.0 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3400 val_loss:11.03124 train_time:0.000s step_avg:0.16ms
+step:125/3400 val_loss:4.92621 train_time:25.749s step_avg:205.99ms
+step:250/3400 val_loss:4.24430 train_time:48.295s step_avg:193.18ms
+step:375/3400 val_loss:4.04682 train_time:70.685s step_avg:188.49ms
+step:500/3400 val_loss:3.94588 train_time:93.071s step_avg:186.14ms
+step:625/3400 val_loss:3.87674 train_time:115.505s step_avg:184.81ms
+step:750/3400 val_loss:3.82933 train_time:137.863s step_avg:183.82ms
+step:875/3400 val_loss:3.78661 train_time:160.254s step_avg:183.15ms
+step:1000/3400 val_loss:3.74573 train_time:182.612s step_avg:182.61ms
+step:1125/3400 val_loss:3.72157 train_time:205.014s step_avg:182.23ms
+step:1250/3400 val_loss:3.68593 train_time:227.436s step_avg:181.95ms
+step:1375/3400 val_loss:3.66264 train_time:249.799s step_avg:181.67ms
+step:1500/3400 val_loss:3.63058 train_time:272.132s step_avg:181.42ms
+step:1625/3400 val_loss:3.60703 train_time:294.485s step_avg:181.22ms
+step:1750/3400 val_loss:3.57998 train_time:316.832s step_avg:181.05ms
+step:1875/3400 val_loss:3.55514 train_time:339.074s step_avg:180.84ms
+step:2000/3400 val_loss:3.52515 train_time:361.531s step_avg:180.77ms
+step:2125/3400 val_loss:3.50029 train_time:383.780s step_avg:180.60ms
+step:2250/3400 val_loss:3.47496 train_time:406.116s step_avg:180.50ms
+step:2375/3400 val_loss:3.45113 train_time:428.374s step_avg:180.37ms
+step:2500/3400 val_loss:3.42714 train_time:450.625s step_avg:180.25ms
+step:2625/3400 val_loss:3.40183 train_time:472.842s step_avg:180.13ms
+step:2750/3400 val_loss:3.37822 train_time:495.089s step_avg:180.03ms
+step:2875/3400 val_loss:3.35597 train_time:517.473s step_avg:179.99ms
+step:3000/3400 val_loss:3.33266 train_time:539.702s step_avg:179.90ms
+step:3125/3400 val_loss:3.31092 train_time:561.979s step_avg:179.83ms
+step:3250/3400 val_loss:3.29193 train_time:584.235s step_avg:179.76ms
+step:3375/3400 val_loss:3.27901 train_time:606.448s step_avg:179.69ms
+step:3400/3400 val_loss:3.27766 train_time:610.899s step_avg:179.68ms

--- a/records/track_3_optimization/results/20260527_psgd/9b84bb73-7b63-4d12-b570-b292128f6377.txt
+++ b/records/track_3_optimization/results/20260527_psgd/9b84bb73-7b63-4d12-b570-b292128f6377.txt
@@ -1,0 +1,444 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+This script implements vanilla PSGD with Hyperball (and no trust-region based soft-clip update).
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read()
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="mean")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def init_psgd(grad: Tensor):
+    assert grad.ndim == 2
+    m, n = grad.shape
+    s = grad.float().abs().pow(4).mean().clamp(min=1e-24).pow(-1/32).item()
+    Q0 = torch.eye(m, dtype=torch.float32, device=grad.device) * s
+    Q1 = torch.eye(n, dtype=torch.float32, device=grad.device) * s
+    return Q0, Q1
+
+
+def spectral_norm(A: Tensor) -> Tensor:
+    # 1.5 power iterations; A is symmetric PSD at all call sites
+    scale = A.norm(float("inf"))
+    if scale == 0:
+        return scale
+    A = A / scale
+    x = A[:, (A * A).sum(0).argmax()]
+    x = A @ x
+    x = x / torch.linalg.vector_norm(x)
+    return scale * torch.linalg.vector_norm(A @ x)
+
+
+@torch.compile
+def psgd_update_precond(Q0: Tensor, Q1: Tensor, U: Tensor, v: Tensor, precond_lr=1.0) -> None:
+    # balance max absolute values of Q0, Q1
+    rescale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0.mul_(rescale_factor)
+    Q1.div_(rescale_factor)
+
+    # preconditioned update; A = Q0 U Q1^T
+    A = Q0 @ U @ Q1.mT
+    # preconditioned probe vector; B = Q0^{-T} v Q1^{-1}
+    B = torch.linalg.solve_triangular(Q0.mT, v, upper=False, left=True)
+    B = torch.linalg.solve_triangular(Q1, B, upper=True, left=False)
+
+    AAt = A @ A.mT
+    BBt = B @ B.mT
+    ell0 = spectral_norm(AAt + BBt)
+    Q0.sub_(precond_lr / ell0 * torch.triu(AAt - BBt) @ Q0)
+
+    AtA = A.mT @ A
+    BtB = B.mT @ B
+    ell1 = spectral_norm(AtA + BtB)
+    Q1.sub_(precond_lr / ell1 * torch.triu(AtA - BtB) @ Q1)
+
+
+class PSGDKron(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.025, precond_lr=1.0, beta1=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.numel(), reverse=True)
+        defaults = dict(lr=lr, precond_lr=precond_lr, beta1=beta1)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            beta1 = group["beta1"]
+            precond_lr = group["precond_lr"]
+            lr = group["lr"]
+            params = group["params"]
+            # pad so len is divisible by world_size
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    if grad is None:
+                        continue
+                    grad = grad.squeeze().float()
+                    state = self.state[p]
+                    if not state:
+                        state["Q0"], state["Q1"] = init_psgd(grad)
+                        state["step"] = 0
+                        state["exp_avg"] = torch.zeros_like(grad)
+                    state["step"] += 1
+                    # adam-style beta correction to warm up preconditioner
+                    state["exp_avg"].lerp_(grad, 1 - beta1)
+                    update = state["exp_avg"] / (1 - beta1 ** state["step"])
+
+                    v = torch.randn_like(update)
+                    nu = torch.randn_like(update)
+                    damping = torch.finfo(torch.float32).eps * update.abs()
+                    Q0, Q1 = state["Q0"], state["Q1"]
+                    psgd_update_precond(
+                        Q0, Q1, update + damping * nu, v,
+                        precond_lr=precond_lr,
+                    )
+
+                    step_update = (Q0.mT @ Q0) @ update @ (Q1.mT @ Q1)
+
+                    # hyperball: step on the sphere, preserve param norm
+                    step_update = step_update.view_as(p)
+                    p_norm = p.float().norm()
+                    u_norm = step_update.norm()
+                    new_p = p.float() - lr * step_update * (p_norm / (u_norm + 1e-10))
+                    new_p_norm = new_p.norm()
+                    p.copy_((new_p / (new_p_norm + 1e-10) * p_norm).to(p.dtype))
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+########################################
+#                Setup                 #
+########################################
+
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+assert 8 % dist.get_world_size() == 0
+
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#            Initialization            #
+########################################
+
+for name, param in model.named_parameters():
+    if param.ndim < 2:
+        continue
+    if "blocks" in name:
+        fan_in = param.size(1)
+        base_std = 1.0 / (3.0 * fan_in) ** 0.5
+        if "proj" in name and "mlp" in name:
+            std = base_std * 3.0
+        elif "fc" in name:
+            std = base_std * 1.5
+        elif "proj" in name and "attn" in name:
+            std = base_std * 1.25
+        else:
+            std = base_std * 1.0
+        param.data.normal_(0, std)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+
+hidden_matrix_params = [p for p in model.blocks.parameters() if p.ndim >= 2]
+embed_params = [model.embed.weight]
+head_params = [model.proj.weight]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+
+psgd_steady_lr = 0.025
+train_steps = 3400
+cooldown_frac = 1.0
+precond_lr = 1.0
+
+adam_base_lrs = [0.3, 1/320, 0.01]
+adam_param_groups = [dict(params=embed_params, lr=adam_base_lrs[0]),
+                    dict(params=head_params, lr=adam_base_lrs[1]),
+                    dict(params=scalar_params, lr=adam_base_lrs[2])]
+optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+optimizer2 = PSGDKron(hidden_matrix_params, lr=psgd_steady_lr, precond_lr=precond_lr, beta1=0.95)
+optimizers = [optimizer1, optimizer2]
+
+def get_psgd_lr(step: int):
+    cooldown_start = int(train_steps * (1 - cooldown_frac))
+    if step < cooldown_start:
+        return psgd_steady_lr
+    t = (step - cooldown_start) / (train_steps - cooldown_start)
+    return psgd_steady_lr * (1 - t)
+
+def get_adam_lr_scale(step: int):
+    adam_cooldown_start = int(train_steps * (1 - 0.5))
+    if step < adam_cooldown_start:
+        return 1.0
+    t = (step - adam_cooldown_start) / (train_steps - adam_cooldown_start)
+    return 1.0 - t * 0.9
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+val_interval = 125
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(train_steps + 1):
+
+    if step == train_steps or step % val_interval == 0:
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            num_val_mbs = len(val_inputs) // mbs
+            for i in range(num_val_mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        val_loss /= num_val_mbs
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms", console=True)
+        model.train()
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    inputs, targets = next(train_loader)
+    num_mbs = len(inputs) // mbs
+    for i in range(num_mbs):
+        (model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]) / num_mbs).backward()
+    for p in model.parameters():
+        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+    for group in optimizer2.param_groups:
+        group["lr"] = get_psgd_lr(step)
+    adam_scale = get_adam_lr_scale(step)
+    for group, base_lr in zip(optimizer1.param_groups, adam_base_lrs):
+        group["lr"] = base_lr * adam_scale
+
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+
+    approx_training_time = training_time + (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+           + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.12.0+cu130 compiled for CUDA 13.0 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3400 val_loss:11.01711 train_time:0.000s step_avg:0.10ms
+step:125/3400 val_loss:4.91689 train_time:25.728s step_avg:205.82ms
+step:250/3400 val_loss:4.23735 train_time:48.212s step_avg:192.85ms
+step:375/3400 val_loss:4.04896 train_time:70.566s step_avg:188.17ms
+step:500/3400 val_loss:3.94132 train_time:92.975s step_avg:185.95ms
+step:625/3400 val_loss:3.88052 train_time:115.351s step_avg:184.56ms
+step:750/3400 val_loss:3.82886 train_time:137.655s step_avg:183.54ms
+step:875/3400 val_loss:3.78041 train_time:160.083s step_avg:182.95ms
+step:1000/3400 val_loss:3.74826 train_time:182.379s step_avg:182.38ms
+step:1125/3400 val_loss:3.71520 train_time:204.715s step_avg:181.97ms
+step:1250/3400 val_loss:3.68414 train_time:227.180s step_avg:181.74ms
+step:1375/3400 val_loss:3.66456 train_time:250.849s step_avg:182.44ms
+step:1500/3400 val_loss:3.62960 train_time:273.127s step_avg:182.08ms
+step:1625/3400 val_loss:3.60651 train_time:295.443s step_avg:181.81ms
+step:1750/3400 val_loss:3.57901 train_time:317.880s step_avg:181.65ms
+step:1875/3400 val_loss:3.55299 train_time:340.127s step_avg:181.40ms
+step:2000/3400 val_loss:3.52273 train_time:362.413s step_avg:181.21ms
+step:2125/3400 val_loss:3.49794 train_time:384.709s step_avg:181.04ms
+step:2250/3400 val_loss:3.47219 train_time:406.956s step_avg:180.87ms
+step:2375/3400 val_loss:3.44978 train_time:429.340s step_avg:180.77ms
+step:2500/3400 val_loss:3.42550 train_time:451.621s step_avg:180.65ms
+step:2625/3400 val_loss:3.40004 train_time:473.842s step_avg:180.51ms
+step:2750/3400 val_loss:3.37677 train_time:496.085s step_avg:180.39ms
+step:2875/3400 val_loss:3.35430 train_time:518.380s step_avg:180.31ms
+step:3000/3400 val_loss:3.33156 train_time:540.628s step_avg:180.21ms
+step:3125/3400 val_loss:3.30993 train_time:562.836s step_avg:180.11ms
+step:3250/3400 val_loss:3.29096 train_time:585.048s step_avg:180.01ms
+step:3375/3400 val_loss:3.27800 train_time:607.243s step_avg:179.92ms
+step:3400/3400 val_loss:3.27678 train_time:611.704s step_avg:179.91ms

--- a/records/track_3_optimization/results/20260527_psgd/README.md
+++ b/records/track_3_optimization/results/20260527_psgd/README.md
@@ -1,0 +1,87 @@
+# Optimizer Baseline: PSGD
+
+This is an implementation of PSGD.
+
+## Details
+
+The standard (whitening, kronecker) PSGD update can be summarized in psuedocode as:
+
+```python
+def update(W, g, Q0, Q1, m, step_t, lr, precond_lr, beta):
+    """
+      - Q0, Q1 are L/R preconditioner estimates (kronecker factors)
+      - W, g, m are weight, gradient, momentum
+    """
+
+    # momentum w bias correction
+    m.lerp_(g, 1 - beta)
+    m_hat = m / (1 - beta ** step_t)
+
+    # balance preconditioner factors
+    scale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0 *= scale_factor
+    Q1 /= scale_factor
+
+    # update preconditioners
+    nu = randn_like(m_hat)
+    v = randn_like(m_hat)
+    #  A = Q0 U Q1^T, B = Q0^{-T} v Q1^{-1}
+    A = Q0 @ (m_hat + torch.eps * m_hat.abs() * nu) @ Q1.T
+    B = solve_triangular(Q1, solve_triangular(Q0.T, v, left=True), left=False)
+    # gradient descent scaled by spectral norm
+    Q0 -= (precond_lr / _spectral_norm(A@A.T + B@B.T)) * triu(A@A.T - B@B.T) @ Q0
+    Q1 -= (precond_lr / _spectral_norm(A.T@A + B.T@B)) * triu(A.T@A - B.T@B) @ Q1
+
+    # apply preconditioner
+    u = (Q0.T @ Q0) @ m_hat @ (Q1.T @ Q1)
+
+    # hyperball
+    u = u * (W.norm() / u.norm())
+    W_new = W - lr * u
+    W = W_new * (W.norm() / W_new.norm())
+```
+
+I put learning rate on a linearly descending schedule for 100% of the run, starting at `lr=0.025`.
+I also found optimal hyperparameters `precond_lr=1.0`, and `beta=0.95`.
+
+Instead of trust-region clipping, which is common in many PSGD implementations, I've opted to just use Hyperball. Carefully tuned trust-region clipping + weight decay may outperform hyperball, but will introduce extra hyperparameters.
+
+Many PSGD implementations use the previous iterate's spectral norm (or a rolling average) to smoothen or improve approximation quality, but I found that approximating it via power iterations each step is cheap and works well.
+
+
+## Validation
+
+At 3400 steps:
+
+```python
+import numpy as np
+
+losses = [3.2764, 3.2777, 3.2774, 3.2750, 3.2768]
+times = [611.1, 610.9, 610.8, 611.1, 611.7]
+
+print(np.mean(losses))
+# 3.2766600000000006
+print((3.28 - 3.09 * 0.0013 / np.sqrt(5)))
+# 3.2782035429868763
+```
+
+The step count can likely be safely decreased by 20+ steps.
+
+
+## References
+
+The following repositories served as important references:
+- [HomebrewML/HeavyBall](https://github.com/HomebrewML/HeavyBall)
+- [evanatyourservice/distributed_kron](https://github.com/evanatyourservice/distributed_kron)
+- [evanatyourservice/psgd_jax](https://github.com/evanatyourservice/psgd_jax)
+- [evanatyourservice/kron_torch](https://github.com/evanatyourservice/kron_torch)
+- [lixilinx/psgd_torch](https://github.com/lixilinx/psgd_torch)
+- [PSGD_Nuon](https://github.com/opooladz/PSGD_Nuon)
+
+
+As well as the original PSGD papers, including
+1. [Xi-Lin Li (2015)](https://arxiv.org/abs/1512.04202) — Preconditioned Stochastic Gradient Descent
+2. [Xi-Lin Li (2024)](https://arxiv.org/abs/2402.11858) — Stochastic Hessian Fittings with Lie Groups
+3. [Pooladzandi & Li (2024)](https://arxiv.org/abs/2402.04553) — Curvature-Informed SGD via General Purpose Lie-Group Preconditioners
+
+This submission would be totally impossible without the work of Xi-Lin Li, Omead Pooladzandi, Evan Walters, and Lucas Nestler.

--- a/records/track_3_optimization/results/20260527_psgd/f265c5cb-12c7-483c-9112-9a694e175e41.txt
+++ b/records/track_3_optimization/results/20260527_psgd/f265c5cb-12c7-483c-9112-9a694e175e41.txt
@@ -1,0 +1,444 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+This script implements vanilla PSGD with Hyperball (and no trust-region based soft-clip update).
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read()
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="mean")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def init_psgd(grad: Tensor):
+    assert grad.ndim == 2
+    m, n = grad.shape
+    s = grad.float().abs().pow(4).mean().clamp(min=1e-24).pow(-1/32).item()
+    Q0 = torch.eye(m, dtype=torch.float32, device=grad.device) * s
+    Q1 = torch.eye(n, dtype=torch.float32, device=grad.device) * s
+    return Q0, Q1
+
+
+def spectral_norm(A: Tensor) -> Tensor:
+    # 1.5 power iterations; A is symmetric PSD at all call sites
+    scale = A.norm(float("inf"))
+    if scale == 0:
+        return scale
+    A = A / scale
+    x = A[:, (A * A).sum(0).argmax()]
+    x = A @ x
+    x = x / torch.linalg.vector_norm(x)
+    return scale * torch.linalg.vector_norm(A @ x)
+
+
+@torch.compile
+def psgd_update_precond(Q0: Tensor, Q1: Tensor, U: Tensor, v: Tensor, precond_lr=1.0) -> None:
+    # balance max absolute values of Q0, Q1
+    rescale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0.mul_(rescale_factor)
+    Q1.div_(rescale_factor)
+
+    # preconditioned update; A = Q0 U Q1^T
+    A = Q0 @ U @ Q1.mT
+    # preconditioned probe vector; B = Q0^{-T} v Q1^{-1}
+    B = torch.linalg.solve_triangular(Q0.mT, v, upper=False, left=True)
+    B = torch.linalg.solve_triangular(Q1, B, upper=True, left=False)
+
+    AAt = A @ A.mT
+    BBt = B @ B.mT
+    ell0 = spectral_norm(AAt + BBt)
+    Q0.sub_(precond_lr / ell0 * torch.triu(AAt - BBt) @ Q0)
+
+    AtA = A.mT @ A
+    BtB = B.mT @ B
+    ell1 = spectral_norm(AtA + BtB)
+    Q1.sub_(precond_lr / ell1 * torch.triu(AtA - BtB) @ Q1)
+
+
+class PSGDKron(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.025, precond_lr=1.0, beta1=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.numel(), reverse=True)
+        defaults = dict(lr=lr, precond_lr=precond_lr, beta1=beta1)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            beta1 = group["beta1"]
+            precond_lr = group["precond_lr"]
+            lr = group["lr"]
+            params = group["params"]
+            # pad so len is divisible by world_size
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    if grad is None:
+                        continue
+                    grad = grad.squeeze().float()
+                    state = self.state[p]
+                    if not state:
+                        state["Q0"], state["Q1"] = init_psgd(grad)
+                        state["step"] = 0
+                        state["exp_avg"] = torch.zeros_like(grad)
+                    state["step"] += 1
+                    # adam-style beta correction to warm up preconditioner
+                    state["exp_avg"].lerp_(grad, 1 - beta1)
+                    update = state["exp_avg"] / (1 - beta1 ** state["step"])
+
+                    v = torch.randn_like(update)
+                    nu = torch.randn_like(update)
+                    damping = torch.finfo(torch.float32).eps * update.abs()
+                    Q0, Q1 = state["Q0"], state["Q1"]
+                    psgd_update_precond(
+                        Q0, Q1, update + damping * nu, v,
+                        precond_lr=precond_lr,
+                    )
+
+                    step_update = (Q0.mT @ Q0) @ update @ (Q1.mT @ Q1)
+
+                    # hyperball: step on the sphere, preserve param norm
+                    step_update = step_update.view_as(p)
+                    p_norm = p.float().norm()
+                    u_norm = step_update.norm()
+                    new_p = p.float() - lr * step_update * (p_norm / (u_norm + 1e-10))
+                    new_p_norm = new_p.norm()
+                    p.copy_((new_p / (new_p_norm + 1e-10) * p_norm).to(p.dtype))
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+########################################
+#                Setup                 #
+########################################
+
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+assert 8 % dist.get_world_size() == 0
+
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#            Initialization            #
+########################################
+
+for name, param in model.named_parameters():
+    if param.ndim < 2:
+        continue
+    if "blocks" in name:
+        fan_in = param.size(1)
+        base_std = 1.0 / (3.0 * fan_in) ** 0.5
+        if "proj" in name and "mlp" in name:
+            std = base_std * 3.0
+        elif "fc" in name:
+            std = base_std * 1.5
+        elif "proj" in name and "attn" in name:
+            std = base_std * 1.25
+        else:
+            std = base_std * 1.0
+        param.data.normal_(0, std)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+
+hidden_matrix_params = [p for p in model.blocks.parameters() if p.ndim >= 2]
+embed_params = [model.embed.weight]
+head_params = [model.proj.weight]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+
+psgd_steady_lr = 0.025
+train_steps = 3400
+cooldown_frac = 1.0
+precond_lr = 1.0
+
+adam_base_lrs = [0.3, 1/320, 0.01]
+adam_param_groups = [dict(params=embed_params, lr=adam_base_lrs[0]),
+                    dict(params=head_params, lr=adam_base_lrs[1]),
+                    dict(params=scalar_params, lr=adam_base_lrs[2])]
+optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+optimizer2 = PSGDKron(hidden_matrix_params, lr=psgd_steady_lr, precond_lr=precond_lr, beta1=0.95)
+optimizers = [optimizer1, optimizer2]
+
+def get_psgd_lr(step: int):
+    cooldown_start = int(train_steps * (1 - cooldown_frac))
+    if step < cooldown_start:
+        return psgd_steady_lr
+    t = (step - cooldown_start) / (train_steps - cooldown_start)
+    return psgd_steady_lr * (1 - t)
+
+def get_adam_lr_scale(step: int):
+    adam_cooldown_start = int(train_steps * (1 - 0.5))
+    if step < adam_cooldown_start:
+        return 1.0
+    t = (step - adam_cooldown_start) / (train_steps - adam_cooldown_start)
+    return 1.0 - t * 0.9
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+val_interval = 125
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(train_steps + 1):
+
+    if step == train_steps or step % val_interval == 0:
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            num_val_mbs = len(val_inputs) // mbs
+            for i in range(num_val_mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        val_loss /= num_val_mbs
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms", console=True)
+        model.train()
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    inputs, targets = next(train_loader)
+    num_mbs = len(inputs) // mbs
+    for i in range(num_mbs):
+        (model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]) / num_mbs).backward()
+    for p in model.parameters():
+        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+    for group in optimizer2.param_groups:
+        group["lr"] = get_psgd_lr(step)
+    adam_scale = get_adam_lr_scale(step)
+    for group, base_lr in zip(optimizer1.param_groups, adam_base_lrs):
+        group["lr"] = base_lr * adam_scale
+
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+
+    approx_training_time = training_time + (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+           + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.12.0+cu130 compiled for CUDA 13.0 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3400 val_loss:10.99582 train_time:0.000s step_avg:0.29ms
+step:125/3400 val_loss:4.92903 train_time:25.979s step_avg:207.83ms
+step:250/3400 val_loss:4.24469 train_time:48.659s step_avg:194.64ms
+step:375/3400 val_loss:4.04188 train_time:71.089s step_avg:189.57ms
+step:500/3400 val_loss:3.94589 train_time:93.553s step_avg:187.11ms
+step:625/3400 val_loss:3.87387 train_time:115.976s step_avg:185.56ms
+step:750/3400 val_loss:3.82933 train_time:138.379s step_avg:184.50ms
+step:875/3400 val_loss:3.78597 train_time:160.737s step_avg:183.70ms
+step:1000/3400 val_loss:3.74716 train_time:183.060s step_avg:183.06ms
+step:1125/3400 val_loss:3.72144 train_time:205.540s step_avg:182.70ms
+step:1250/3400 val_loss:3.68511 train_time:227.834s step_avg:182.27ms
+step:1375/3400 val_loss:3.66825 train_time:250.134s step_avg:181.92ms
+step:1500/3400 val_loss:3.62640 train_time:272.353s step_avg:181.57ms
+step:1625/3400 val_loss:3.60717 train_time:294.631s step_avg:181.31ms
+step:1750/3400 val_loss:3.58099 train_time:316.888s step_avg:181.08ms
+step:1875/3400 val_loss:3.55054 train_time:339.101s step_avg:180.85ms
+step:2000/3400 val_loss:3.52463 train_time:361.355s step_avg:180.68ms
+step:2125/3400 val_loss:3.50109 train_time:383.608s step_avg:180.52ms
+step:2250/3400 val_loss:3.47482 train_time:405.809s step_avg:180.36ms
+step:2375/3400 val_loss:3.45053 train_time:428.110s step_avg:180.26ms
+step:2500/3400 val_loss:3.42671 train_time:450.413s step_avg:180.17ms
+step:2625/3400 val_loss:3.40122 train_time:472.675s step_avg:180.07ms
+step:2750/3400 val_loss:3.37764 train_time:494.980s step_avg:179.99ms
+step:2875/3400 val_loss:3.35571 train_time:517.241s step_avg:179.91ms
+step:3000/3400 val_loss:3.33266 train_time:539.459s step_avg:179.82ms
+step:3125/3400 val_loss:3.31048 train_time:561.722s step_avg:179.75ms
+step:3250/3400 val_loss:3.29153 train_time:584.028s step_avg:179.70ms
+step:3375/3400 val_loss:3.27869 train_time:606.303s step_avg:179.65ms
+step:3400/3400 val_loss:3.27739 train_time:610.753s step_avg:179.63ms

--- a/records/track_3_optimization/results/20260527_psgd/train_psgd.py
+++ b/records/track_3_optimization/results/20260527_psgd/train_psgd.py
@@ -1,0 +1,411 @@
+"""
+train_gpt_simple.py
+
+This file descends from the [NanoGPT speedrun](https://github.com/KellerJordan/modded-nanogpt).
+It was prepared as a simplified version of the speedrun for use in neural net optimization research.
+
+This script implements vanilla PSGD with Hyperball (and no trust-region based soft-clip update).
+"""
+
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read()
+import uuid
+import time
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+########################################
+#              Dataloader              #
+########################################
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, seq_len=1024):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files)
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True)
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True)
+        pos += batch_size
+        yield inputs.view(-1, seq_len), targets.view(-1, seq_len)
+
+
+########################################
+#             Architecture             #
+########################################
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gains = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), weight=self.gains.type_as(x))
+
+class Linear(nn.Linear):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=True)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.type_as(x), self.bias.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        self.register_buffer("angular_freq", torch.cat([angular_freq, angular_freq.new_zeros(dim//4)]))
+
+    def forward(self, x_BTHD: Tensor):
+        pos = torch.arange(x_BTHD.size(1), dtype=torch.float32, device=x_BTHD.device)
+        theta = torch.outer(pos, self.angular_freq)[None, :, None, :]
+        cos, sin = theta.cos(), theta.sin()
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim=128):
+        super().__init__()
+        self.num_heads = dim // head_dim
+        self.head_dim = head_dim
+        hdim = self.num_heads * self.head_dim
+        self.q = Linear(dim, hdim)
+        self.k = Linear(dim, hdim)
+        self.v = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+        self.rotary = Rotary(head_dim)
+
+    def forward(self, x: Tensor):
+        B, T = x.size(0), x.size(1)
+        q = self.q(x).view(B, T, self.num_heads, self.head_dim)
+        k = self.k(x).view(B, T, self.num_heads, self.head_dim)
+        v = self.v(x).view(B, T, self.num_heads, self.head_dim)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        q, k = self.rotary(q), self.rotary(k)
+        y = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                           v.transpose(1, 2), scale=0.12, is_causal=True).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = self.proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc = Linear(dim, hdim)
+        self.proj = Linear(hdim, dim)
+
+    def forward(self, x: Tensor):
+        x = self.fc(x)
+        x = x.relu().square()
+        x = self.proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim)
+        self.mlp = MLP(dim)
+        self.norm1 = RMSNorm(dim)
+        self.norm2 = RMSNorm(dim)
+
+    def forward(self, x: Tensor):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim).bfloat16()
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
+        self.proj = Linear(model_dim, vocab_size)
+        self.norm1 = RMSNorm(model_dim)
+        self.norm2 = RMSNorm(model_dim)
+
+    def forward(self, inputs: Tensor, targets: Tensor):
+        x = self.norm1(self.embed(inputs))
+        for block in self.blocks:
+            x = block(x)
+        logits = self.proj(self.norm2(x)).float()
+        logits = 15 * logits * (logits.square() + 15**2).rsqrt()
+        return F.cross_entropy(logits.view(targets.numel(), -1), targets.view(-1), reduction="mean")
+
+
+########################################
+#              Optimizer               #
+########################################
+
+def init_psgd(grad: Tensor):
+    assert grad.ndim == 2
+    m, n = grad.shape
+    s = grad.float().abs().pow(4).mean().clamp(min=1e-24).pow(-1/32).item()
+    Q0 = torch.eye(m, dtype=torch.float32, device=grad.device) * s
+    Q1 = torch.eye(n, dtype=torch.float32, device=grad.device) * s
+    return Q0, Q1
+
+
+def spectral_norm(A: Tensor) -> Tensor:
+    # 1.5 power iterations; A is symmetric PSD at all call sites
+    scale = A.norm(float("inf"))
+    if scale == 0:
+        return scale
+    A = A / scale
+    x = A[:, (A * A).sum(0).argmax()]
+    x = A @ x
+    x = x / torch.linalg.vector_norm(x)
+    return scale * torch.linalg.vector_norm(A @ x)
+
+
+@torch.compile
+def psgd_update_precond(Q0: Tensor, Q1: Tensor, U: Tensor, v: Tensor, precond_lr=1.0) -> None:
+    # balance max absolute values of Q0, Q1
+    rescale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
+    Q0.mul_(rescale_factor)
+    Q1.div_(rescale_factor)
+
+    # preconditioned update; A = Q0 U Q1^T
+    A = Q0 @ U @ Q1.mT
+    # preconditioned probe vector; B = Q0^{-T} v Q1^{-1}
+    B = torch.linalg.solve_triangular(Q0.mT, v, upper=False, left=True)
+    B = torch.linalg.solve_triangular(Q1, B, upper=True, left=False)
+
+    AAt = A @ A.mT
+    BBt = B @ B.mT
+    ell0 = spectral_norm(AAt + BBt)
+    Q0.sub_(precond_lr / ell0 * torch.triu(AAt - BBt) @ Q0)
+
+    AtA = A.mT @ A
+    BtB = B.mT @ B
+    ell1 = spectral_norm(AtA + BtB)
+    Q1.sub_(precond_lr / ell1 * torch.triu(AtA - BtB) @ Q1)
+
+
+class PSGDKron(torch.optim.Optimizer):
+    def __init__(self, params, lr=0.025, precond_lr=1.0, beta1=0.95):
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.numel(), reverse=True)
+        defaults = dict(lr=lr, precond_lr=precond_lr, beta1=beta1)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        for group in self.param_groups:
+            beta1 = group["beta1"]
+            precond_lr = group["precond_lr"]
+            lr = group["lr"]
+            params = group["params"]
+            # pad so len is divisible by world_size
+            params_pad = params + [torch.empty_like(params[-1])] * (world_size - len(params) % world_size)
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    if grad is None:
+                        continue
+                    grad = grad.squeeze().float()
+                    state = self.state[p]
+                    if not state:
+                        state["Q0"], state["Q1"] = init_psgd(grad)
+                        state["step"] = 0
+                        state["exp_avg"] = torch.zeros_like(grad)
+                    state["step"] += 1
+                    # adam-style beta correction to warm up preconditioner
+                    state["exp_avg"].lerp_(grad, 1 - beta1)
+                    update = state["exp_avg"] / (1 - beta1 ** state["step"])
+
+                    v = torch.randn_like(update)
+                    nu = torch.randn_like(update)
+                    damping = torch.finfo(torch.float32).eps * update.abs()
+                    Q0, Q1 = state["Q0"], state["Q1"]
+                    psgd_update_precond(
+                        Q0, Q1, update + damping * nu, v,
+                        precond_lr=precond_lr,
+                    )
+
+                    step_update = (Q0.mT @ Q0) @ update @ (Q1.mT @ Q1)
+
+                    # hyperball: step on the sphere, preserve param norm
+                    step_update = step_update.view_as(p)
+                    p_norm = p.float().norm()
+                    u_norm = step_update.norm()
+                    new_p = p.float() - lr * step_update * (p_norm / (u_norm + 1e-10))
+                    new_p_norm = new_p.norm()
+                    p.copy_((new_p / (new_p_norm + 1e-10) * p_norm).to(p.dtype))
+                dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank])
+
+
+########################################
+#                Setup                 #
+########################################
+
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+assert 8 % dist.get_world_size() == 0
+
+if dist.get_rank() == 0:
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{uuid.uuid4()}.txt"
+    print(logfile)
+def print0(s, console=False, log=True):
+    if dist.get_rank() == 0:
+        if console:
+            print(s)
+        if log:
+            with open(logfile, "a") as f:
+                print(s, file=f)
+
+print0(code)
+print0("="*100)
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+       + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0("="*100)
+
+val_tokens = 20 * 524288
+batch_size = 8 * 64 * 1024
+mbs = 64
+val_inputs, val_targets = next(distributed_data_generator("data/fineweb10B/fineweb_val_*.bin", val_tokens))
+
+model = GPT(vocab_size=50304, num_layers=12, model_dim=768).cuda()
+model.compile(dynamic=False)
+
+
+########################################
+#            Initialization            #
+########################################
+
+for name, param in model.named_parameters():
+    if param.ndim < 2:
+        continue
+    if "blocks" in name:
+        fan_in = param.size(1)
+        base_std = 1.0 / (3.0 * fan_in) ** 0.5
+        if "proj" in name and "mlp" in name:
+            std = base_std * 3.0
+        elif "fc" in name:
+            std = base_std * 1.5
+        elif "proj" in name and "attn" in name:
+            std = base_std * 1.25
+        else:
+            std = base_std * 1.0
+        param.data.normal_(0, std)
+
+for p in model.parameters():
+    dist.broadcast(p.detach(), 0)
+
+hidden_matrix_params = [p for p in model.blocks.parameters() if p.ndim >= 2]
+embed_params = [model.embed.weight]
+head_params = [model.proj.weight]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+
+psgd_steady_lr = 0.025
+train_steps = 3400
+cooldown_frac = 1.0
+precond_lr = 1.0
+
+adam_base_lrs = [0.3, 1/320, 0.01]
+adam_param_groups = [dict(params=embed_params, lr=adam_base_lrs[0]),
+                    dict(params=head_params, lr=adam_base_lrs[1]),
+                    dict(params=scalar_params, lr=adam_base_lrs[2])]
+optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0, fused=True)
+optimizer2 = PSGDKron(hidden_matrix_params, lr=psgd_steady_lr, precond_lr=precond_lr, beta1=0.95)
+optimizers = [optimizer1, optimizer2]
+
+def get_psgd_lr(step: int):
+    cooldown_start = int(train_steps * (1 - cooldown_frac))
+    if step < cooldown_start:
+        return psgd_steady_lr
+    t = (step - cooldown_start) / (train_steps - cooldown_start)
+    return psgd_steady_lr * (1 - t)
+
+def get_adam_lr_scale(step: int):
+    adam_cooldown_start = int(train_steps * (1 - 0.5))
+    if step < adam_cooldown_start:
+        return 1.0
+    t = (step - adam_cooldown_start) / (train_steps - adam_cooldown_start)
+    return 1.0 - t * 0.9
+
+
+########################################
+#        Training and Validation       #
+########################################
+
+val_interval = 125
+train_loader = distributed_data_generator("data/fineweb10B/fineweb_train_*.bin", batch_size)
+training_time = 0
+dist.barrier()
+t0 = time.perf_counter()
+for step in range(train_steps + 1):
+
+    if step == train_steps or step % val_interval == 0:
+        dist.barrier()
+        training_time += time.perf_counter() - t0
+        model.eval()
+        val_loss = 0
+        with torch.no_grad():
+            num_val_mbs = len(val_inputs) // mbs
+            for i in range(num_val_mbs):
+                val_loss += model(val_inputs[i*mbs:(i+1)*mbs], val_targets[i*mbs:(i+1)*mbs])
+        val_loss /= num_val_mbs
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.5f} train_time:{training_time:.3f}s"
+               + f" step_avg:{1000*training_time/max(step, 1):.2f}ms", console=True)
+        model.train()
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if step == train_steps:
+        break
+
+    inputs, targets = next(train_loader)
+    num_mbs = len(inputs) // mbs
+    for i in range(num_mbs):
+        (model(inputs[i*mbs:(i+1)*mbs], targets[i*mbs:(i+1)*mbs]) / num_mbs).backward()
+    for p in model.parameters():
+        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+    for group in optimizer2.param_groups:
+        group["lr"] = get_psgd_lr(step)
+    adam_scale = get_adam_lr_scale(step)
+    for group, base_lr in zip(optimizer1.param_groups, adam_base_lrs):
+        group["lr"] = base_lr * adam_scale
+
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+
+    approx_training_time = training_time + (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time:.3f}s"
+           + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
+
+dist.destroy_process_group()


### PR DESCRIPTION
This is an implementation of PSGD.

## Details

The standard (whitening, kronecker) PSGD update can be summarized in psuedocode as:

```python
def update(W, g, Q0, Q1, m, step_t, lr, precond_lr, beta):
    """
      - Q0, Q1 are L/R preconditioner estimates (kronecker factors)
      - W, g, m are weight, gradient, momentum
    """

    # momentum w bias correction
    m.lerp_(g, 1 - beta)
    m_hat = m / (1 - beta ** step_t)

    # balance preconditioner factors
    scale_factor = (Q1.abs().amax() / Q0.abs().amax()).sqrt()
    Q0 *= scale_factor
    Q1 /= scale_factor

    # update preconditioners
    nu = randn_like(m_hat)
    v = randn_like(m_hat)
    #  A = Q0 U Q1^T, B = Q0^{-T} v Q1^{-1}
    A = Q0 @ (m_hat + torch.eps * m_hat.abs() * nu) @ Q1.T
    B = solve_triangular(Q1, solve_triangular(Q0.T, v, left=True), left=False)
    # gradient descent scaled by spectral norm
    Q0 -= (precond_lr / _spectral_norm(A@A.T + B@B.T)) * triu(A@A.T - B@B.T) @ Q0
    Q1 -= (precond_lr / _spectral_norm(A.T@A + B.T@B)) * triu(A.T@A - B.T@B) @ Q1

    # apply preconditioner
    u = (Q0.T @ Q0) @ m_hat @ (Q1.T @ Q1)

    # hyperball
    u = u * (W.norm() / u.norm())
    W_new = W - lr * u
    W = W_new * (W.norm() / W_new.norm())
```

I put learning rate on a linearly descending schedule for 100% of the run, starting at `lr=0.025`.
I also found optimal hyperparameters `precond_lr=1.0`, and `beta=0.95`.

Instead of trust-region clipping, which is common in many PSGD implementations, I've opted to just use Hyperball. Carefully tuned trust-region clipping + weight decay may outperform hyperball, but will introduce extra hyperparameters.

Many PSGD implementations use the previous iterate's spectral norm (or a rolling average) to smoothen or improve approximation quality, but I found that approximating it via power iterations each step is cheap and works well.


## Validation

At 3400 steps:

```python
import numpy as np

losses = [3.2764, 3.2777, 3.2774, 3.2750, 3.2768]
times = [611.1, 610.9, 610.8, 611.1, 611.7]

print(np.mean(losses))
# 3.2766600000000006
print((3.28 - 3.09 * 0.0013 / np.sqrt(5)))
# 3.2782035429868763
```

The step count can likely be safely decreased by 20+ steps.


## References

The following repositories served as important references:
- [HomebrewML/HeavyBall](https://github.com/HomebrewML/HeavyBall)
- [evanatyourservice/distributed_kron](https://github.com/evanatyourservice/distributed_kron)
- [evanatyourservice/psgd_jax](https://github.com/evanatyourservice/psgd_jax)
- [evanatyourservice/kron_torch](https://github.com/evanatyourservice/kron_torch)
- [lixilinx/psgd_torch](https://github.com/lixilinx/psgd_torch)
- [PSGD_Nuon](https://github.com/opooladz/PSGD_Nuon)


As well as the original PSGD papers, including
1. [Xi-Lin Li (2015)](https://arxiv.org/abs/1512.04202) — Preconditioned Stochastic Gradient Descent
2. [Xi-Lin Li (2024)](https://arxiv.org/abs/2402.11858) — Stochastic Hessian Fittings with Lie Groups
3. [Pooladzandi & Li (2024)](https://arxiv.org/abs/2402.04553) — Curvature-Informed SGD via General Purpose Lie-Group Preconditioners

This submission would be totally impossible without the work of Xi-Lin Li, Omead Pooladzandi, Evan Walters, and Lucas Nestler.
