### PR TITLE
Tune train_gpt_simple baseline hyperparameters

### DIFF
--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/263ea3c4-2b13-4adf-8a71-0410386b20e1.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/263ea3c4-2b13-4adf-8a71-0410386b20e1.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.58616 train_time:21.243s step_avg:169.94ms
+step:250/3250 val_loss:4.09849 train_time:40.598s step_avg:154.84ms
+step:375/3250 val_loss:3.92504 train_time:59.829s step_avg:153.84ms
+step:500/3250 val_loss:3.82779 train_time:79.109s step_avg:154.24ms
+step:625/3250 val_loss:3.76474 train_time:98.395s step_avg:154.29ms
+step:750/3250 val_loss:3.72403 train_time:117.652s step_avg:154.05ms
+step:875/3250 val_loss:3.68169 train_time:136.952s step_avg:154.40ms
+step:1000/3250 val_loss:3.65220 train_time:156.249s step_avg:154.38ms
+step:1125/3250 val_loss:3.62363 train_time:175.514s step_avg:154.12ms
+step:1250/3250 val_loss:3.59053 train_time:194.804s step_avg:154.32ms
+step:1375/3250 val_loss:3.56588 train_time:214.097s step_avg:154.34ms
+step:1500/3250 val_loss:3.53846 train_time:233.356s step_avg:154.07ms
+step:1625/3250 val_loss:3.51673 train_time:252.657s step_avg:154.41ms
+step:1750/3250 val_loss:3.49613 train_time:271.946s step_avg:154.31ms
+step:1875/3250 val_loss:3.47333 train_time:291.183s step_avg:153.89ms
+step:2000/3250 val_loss:3.45381 train_time:310.463s step_avg:154.24ms
+step:2125/3250 val_loss:3.43509 train_time:329.737s step_avg:154.20ms
+step:2250/3250 val_loss:3.41597 train_time:348.978s step_avg:153.92ms
+step:2375/3250 val_loss:3.39790 train_time:368.260s step_avg:154.26ms
+step:2500/3250 val_loss:3.37930 train_time:387.533s step_avg:154.18ms
+step:2625/3250 val_loss:3.35959 train_time:406.774s step_avg:153.93ms
+step:2750/3250 val_loss:3.34080 train_time:426.047s step_avg:154.19ms
+step:2875/3250 val_loss:3.32194 train_time:445.328s step_avg:154.25ms
+step:2925/3250 val_loss:3.31393 train_time:453.025s step_avg:153.93ms
+step:2950/3250 val_loss:3.31049 train_time:456.875s step_avg:154.01ms
+step:2975/3250 val_loss:3.30669 train_time:460.726s step_avg:154.07ms
+step:3000/3250 val_loss:3.30352 train_time:464.577s step_avg:154.02ms
+step:3025/3250 val_loss:3.29917 train_time:468.431s step_avg:154.16ms
+step:3050/3250 val_loss:3.29585 train_time:472.319s step_avg:155.52ms
+step:3075/3250 val_loss:3.29269 train_time:476.176s step_avg:154.29ms
+step:3100/3250 val_loss:3.28959 train_time:480.025s step_avg:153.94ms
+step:3125/3250 val_loss:3.28679 train_time:483.871s step_avg:153.85ms
+step:3150/3250 val_loss:3.28388 train_time:487.731s step_avg:154.40ms
+step:3175/3250 val_loss:3.28146 train_time:491.582s step_avg:154.02ms
+step:3200/3250 val_loss:3.27940 train_time:495.436s step_avg:154.18ms
+step:3225/3250 val_loss:3.27788 train_time:499.288s step_avg:154.05ms
+step:3250/3250 val_loss:3.27722 train_time:503.169s step_avg:155.25ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/556e61b9-efe1-44af-a16c-58e4a3371aea.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/556e61b9-efe1-44af-a16c-58e4a3371aea.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.56003 train_time:21.311s step_avg:170.49ms
+step:250/3250 val_loss:4.09734 train_time:40.678s step_avg:154.94ms
+step:375/3250 val_loss:3.92459 train_time:59.941s step_avg:154.11ms
+step:500/3250 val_loss:3.82796 train_time:79.247s step_avg:154.45ms
+step:625/3250 val_loss:3.76737 train_time:98.539s step_avg:154.33ms
+step:750/3250 val_loss:3.72156 train_time:117.812s step_avg:154.19ms
+step:875/3250 val_loss:3.68180 train_time:137.116s step_avg:154.43ms
+step:1000/3250 val_loss:3.65161 train_time:156.410s step_avg:154.35ms
+step:1125/3250 val_loss:3.62614 train_time:175.675s step_avg:154.12ms
+step:1250/3250 val_loss:3.59161 train_time:194.973s step_avg:154.39ms
+step:1375/3250 val_loss:3.56699 train_time:214.266s step_avg:154.34ms
+step:1500/3250 val_loss:3.54204 train_time:233.525s step_avg:154.07ms
+step:1625/3250 val_loss:3.51930 train_time:252.823s step_avg:154.38ms
+step:1750/3250 val_loss:3.49842 train_time:272.116s step_avg:154.34ms
+step:1875/3250 val_loss:3.47653 train_time:291.361s step_avg:153.97ms
+step:2000/3250 val_loss:3.45597 train_time:310.640s step_avg:154.23ms
+step:2125/3250 val_loss:3.43771 train_time:329.924s step_avg:154.27ms
+step:2250/3250 val_loss:3.41809 train_time:349.163s step_avg:153.91ms
+step:2375/3250 val_loss:3.40026 train_time:368.435s step_avg:154.18ms
+step:2500/3250 val_loss:3.38165 train_time:387.710s step_avg:154.20ms
+step:2625/3250 val_loss:3.36181 train_time:406.947s step_avg:153.90ms
+step:2750/3250 val_loss:3.34331 train_time:426.228s step_avg:154.24ms
+step:2875/3250 val_loss:3.32387 train_time:445.496s step_avg:154.15ms
+step:2925/3250 val_loss:3.31599 train_time:453.191s step_avg:153.90ms
+step:2950/3250 val_loss:3.31261 train_time:457.037s step_avg:153.85ms
+step:2975/3250 val_loss:3.30901 train_time:460.888s step_avg:154.02ms
+step:3000/3250 val_loss:3.30571 train_time:464.736s step_avg:153.94ms
+step:3025/3250 val_loss:3.30140 train_time:468.583s step_avg:153.87ms
+step:3050/3250 val_loss:3.29807 train_time:472.467s step_avg:155.37ms
+step:3075/3250 val_loss:3.29480 train_time:476.318s step_avg:154.05ms
+step:3100/3250 val_loss:3.29167 train_time:480.170s step_avg:154.05ms
+step:3125/3250 val_loss:3.28887 train_time:484.022s step_avg:154.07ms
+step:3150/3250 val_loss:3.28596 train_time:487.876s step_avg:154.17ms
+step:3175/3250 val_loss:3.28364 train_time:491.728s step_avg:154.11ms
+step:3200/3250 val_loss:3.28163 train_time:495.581s step_avg:154.10ms
+step:3225/3250 val_loss:3.28007 train_time:499.435s step_avg:154.15ms
+step:3250/3250 val_loss:3.27941 train_time:503.323s step_avg:155.52ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/55cb8434-a6e6-4056-aeca-e105682c8ff7.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/55cb8434-a6e6-4056-aeca-e105682c8ff7.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.58955 train_time:21.645s step_avg:173.16ms
+step:250/3250 val_loss:4.10156 train_time:41.028s step_avg:155.07ms
+step:375/3250 val_loss:3.92547 train_time:60.268s step_avg:153.92ms
+step:500/3250 val_loss:3.82805 train_time:79.569s step_avg:154.41ms
+step:625/3250 val_loss:3.76845 train_time:98.863s step_avg:154.35ms
+step:750/3250 val_loss:3.71793 train_time:118.129s step_avg:154.13ms
+step:875/3250 val_loss:3.68183 train_time:137.422s step_avg:154.34ms
+step:1000/3250 val_loss:3.65040 train_time:156.709s step_avg:154.29ms
+step:1125/3250 val_loss:3.62287 train_time:175.973s step_avg:154.11ms
+step:1250/3250 val_loss:3.59430 train_time:195.263s step_avg:154.32ms
+step:1375/3250 val_loss:3.56602 train_time:214.547s step_avg:154.27ms
+step:1500/3250 val_loss:3.53946 train_time:233.796s step_avg:154.00ms
+step:1625/3250 val_loss:3.51781 train_time:253.085s step_avg:154.31ms
+step:1750/3250 val_loss:3.49664 train_time:272.375s step_avg:154.32ms
+step:1875/3250 val_loss:3.47502 train_time:291.628s step_avg:154.02ms
+step:2000/3250 val_loss:3.45386 train_time:310.923s step_avg:154.36ms
+step:2125/3250 val_loss:3.43565 train_time:330.186s step_avg:154.11ms
+step:2250/3250 val_loss:3.41658 train_time:349.417s step_avg:153.85ms
+step:2375/3250 val_loss:3.39826 train_time:368.685s step_avg:154.15ms
+step:2500/3250 val_loss:3.37939 train_time:387.962s step_avg:154.21ms
+step:2625/3250 val_loss:3.35973 train_time:407.193s step_avg:153.85ms
+step:2750/3250 val_loss:3.34088 train_time:426.473s step_avg:154.24ms
+step:2875/3250 val_loss:3.32170 train_time:445.761s step_avg:154.31ms
+step:2925/3250 val_loss:3.31390 train_time:453.457s step_avg:153.91ms
+step:2950/3250 val_loss:3.31033 train_time:457.308s step_avg:154.03ms
+step:2975/3250 val_loss:3.30659 train_time:461.158s step_avg:154.02ms
+step:3000/3250 val_loss:3.30323 train_time:465.000s step_avg:153.67ms
+step:3025/3250 val_loss:3.29911 train_time:468.851s step_avg:154.04ms
+step:3050/3250 val_loss:3.29571 train_time:472.739s step_avg:155.53ms
+step:3075/3250 val_loss:3.29255 train_time:476.583s step_avg:153.77ms
+step:3100/3250 val_loss:3.28939 train_time:480.431s step_avg:153.89ms
+step:3125/3250 val_loss:3.28649 train_time:484.279s step_avg:153.95ms
+step:3150/3250 val_loss:3.28363 train_time:488.128s step_avg:153.96ms
+step:3175/3250 val_loss:3.28122 train_time:491.980s step_avg:154.08ms
+step:3200/3250 val_loss:3.27922 train_time:495.827s step_avg:153.87ms
+step:3225/3250 val_loss:3.27764 train_time:499.677s step_avg:153.99ms
+step:3250/3250 val_loss:3.27699 train_time:503.556s step_avg:155.18ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/629ead24-9ba5-4853-b60f-2fc4344fe066.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/629ead24-9ba5-4853-b60f-2fc4344fe066.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.60071 train_time:21.300s step_avg:170.40ms
+step:250/3250 val_loss:4.10120 train_time:40.651s step_avg:154.81ms
+step:375/3250 val_loss:3.92494 train_time:59.889s step_avg:153.90ms
+step:500/3250 val_loss:3.82822 train_time:79.178s step_avg:154.31ms
+step:625/3250 val_loss:3.76749 train_time:98.456s step_avg:154.23ms
+step:750/3250 val_loss:3.72710 train_time:117.707s step_avg:154.00ms
+step:875/3250 val_loss:3.68428 train_time:136.985s step_avg:154.22ms
+step:1000/3250 val_loss:3.65240 train_time:156.267s step_avg:154.26ms
+step:1125/3250 val_loss:3.62507 train_time:175.519s step_avg:154.02ms
+step:1250/3250 val_loss:3.59598 train_time:194.816s step_avg:154.38ms
+step:1375/3250 val_loss:3.56908 train_time:214.093s step_avg:154.22ms
+step:1500/3250 val_loss:3.54059 train_time:233.356s step_avg:154.10ms
+step:1625/3250 val_loss:3.51998 train_time:252.644s step_avg:154.30ms
+step:1750/3250 val_loss:3.49839 train_time:271.917s step_avg:154.19ms
+step:1875/3250 val_loss:3.47806 train_time:291.161s step_avg:153.95ms
+step:2000/3250 val_loss:3.45759 train_time:310.430s step_avg:154.16ms
+step:2125/3250 val_loss:3.43892 train_time:329.704s step_avg:154.19ms
+step:2250/3250 val_loss:3.42025 train_time:348.941s step_avg:153.90ms
+step:2375/3250 val_loss:3.40167 train_time:368.213s step_avg:154.18ms
+step:2500/3250 val_loss:3.38330 train_time:387.476s step_avg:154.10ms
+step:2625/3250 val_loss:3.36352 train_time:406.715s step_avg:153.91ms
+step:2750/3250 val_loss:3.34486 train_time:425.998s step_avg:154.26ms
+step:2875/3250 val_loss:3.32577 train_time:445.264s step_avg:154.13ms
+step:2925/3250 val_loss:3.31772 train_time:452.968s step_avg:154.08ms
+step:2950/3250 val_loss:3.31401 train_time:456.824s step_avg:154.24ms
+step:2975/3250 val_loss:3.31054 train_time:460.676s step_avg:154.08ms
+step:3000/3250 val_loss:3.30707 train_time:464.534s step_avg:154.32ms
+step:3025/3250 val_loss:3.30288 train_time:468.383s step_avg:153.97ms
+step:3050/3250 val_loss:3.29949 train_time:472.272s step_avg:155.55ms
+step:3075/3250 val_loss:3.29638 train_time:476.123s step_avg:154.04ms
+step:3100/3250 val_loss:3.29331 train_time:479.971s step_avg:153.92ms
+step:3125/3250 val_loss:3.29042 train_time:483.823s step_avg:154.10ms
+step:3150/3250 val_loss:3.28753 train_time:487.679s step_avg:154.23ms
+step:3175/3250 val_loss:3.28518 train_time:491.533s step_avg:154.16ms
+step:3200/3250 val_loss:3.28311 train_time:495.377s step_avg:153.77ms
+step:3225/3250 val_loss:3.28156 train_time:499.222s step_avg:153.81ms
+step:3250/3250 val_loss:3.28091 train_time:503.104s step_avg:155.26ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/78db13a0-5ec8-46bd-871c-8a19e9f61015.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/78db13a0-5ec8-46bd-871c-8a19e9f61015.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.59396 train_time:21.446s step_avg:171.56ms
+step:250/3250 val_loss:4.09508 train_time:40.833s step_avg:155.10ms
+step:375/3250 val_loss:3.92874 train_time:60.113s step_avg:154.24ms
+step:500/3250 val_loss:3.82729 train_time:79.438s step_avg:154.60ms
+step:625/3250 val_loss:3.76442 train_time:98.756s step_avg:154.54ms
+step:750/3250 val_loss:3.72275 train_time:118.046s step_avg:154.32ms
+step:875/3250 val_loss:3.68477 train_time:137.369s step_avg:154.59ms
+step:1000/3250 val_loss:3.65374 train_time:156.684s step_avg:154.52ms
+step:1125/3250 val_loss:3.62583 train_time:175.969s step_avg:154.27ms
+step:1250/3250 val_loss:3.59303 train_time:195.290s step_avg:154.57ms
+step:1375/3250 val_loss:3.56911 train_time:214.582s step_avg:154.33ms
+step:1500/3250 val_loss:3.53840 train_time:233.854s step_avg:154.18ms
+step:1625/3250 val_loss:3.51859 train_time:253.163s step_avg:154.47ms
+step:1750/3250 val_loss:3.49782 train_time:272.463s step_avg:154.41ms
+step:1875/3250 val_loss:3.47637 train_time:291.725s step_avg:154.09ms
+step:2000/3250 val_loss:3.45478 train_time:311.021s step_avg:154.37ms
+step:2125/3250 val_loss:3.43728 train_time:330.303s step_avg:154.26ms
+step:2250/3250 val_loss:3.41740 train_time:349.548s step_avg:153.96ms
+step:2375/3250 val_loss:3.39998 train_time:368.834s step_avg:154.29ms
+step:2500/3250 val_loss:3.38123 train_time:388.121s step_avg:154.29ms
+step:2625/3250 val_loss:3.36098 train_time:407.383s step_avg:154.10ms
+step:2750/3250 val_loss:3.34205 train_time:426.678s step_avg:154.36ms
+step:2875/3250 val_loss:3.32314 train_time:445.970s step_avg:154.33ms
+step:2925/3250 val_loss:3.31505 train_time:453.670s step_avg:154.00ms
+step:2950/3250 val_loss:3.31173 train_time:457.533s step_avg:154.51ms
+step:2975/3250 val_loss:3.30802 train_time:461.395s step_avg:154.47ms
+step:3000/3250 val_loss:3.30458 train_time:465.244s step_avg:153.97ms
+step:3025/3250 val_loss:3.30036 train_time:469.101s step_avg:154.30ms
+step:3050/3250 val_loss:3.29680 train_time:472.992s step_avg:155.61ms
+step:3075/3250 val_loss:3.29371 train_time:476.845s step_avg:154.12ms
+step:3100/3250 val_loss:3.29061 train_time:480.695s step_avg:154.00ms
+step:3125/3250 val_loss:3.28776 train_time:484.546s step_avg:154.05ms
+step:3150/3250 val_loss:3.28485 train_time:488.401s step_avg:154.21ms
+step:3175/3250 val_loss:3.28248 train_time:492.256s step_avg:154.18ms
+step:3200/3250 val_loss:3.28041 train_time:496.108s step_avg:154.09ms
+step:3225/3250 val_loss:3.27887 train_time:499.967s step_avg:154.36ms
+step:3250/3250 val_loss:3.27822 train_time:503.854s step_avg:155.49ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/a7c375e8-c0f3-404b-8522-7b1fd91c7236.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/a7c375e8-c0f3-404b-8522-7b1fd91c7236.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.58411 train_time:21.536s step_avg:172.29ms
+step:250/3250 val_loss:4.08980 train_time:40.894s step_avg:154.87ms
+step:375/3250 val_loss:3.92700 train_time:60.162s step_avg:154.14ms
+step:500/3250 val_loss:3.82868 train_time:79.472s step_avg:154.48ms
+step:625/3250 val_loss:3.76550 train_time:98.776s step_avg:154.43ms
+step:750/3250 val_loss:3.72440 train_time:118.054s step_avg:154.22ms
+step:875/3250 val_loss:3.68744 train_time:137.353s step_avg:154.40ms
+step:1000/3250 val_loss:3.65681 train_time:156.652s step_avg:154.39ms
+step:1125/3250 val_loss:3.62628 train_time:175.914s step_avg:154.10ms
+step:1250/3250 val_loss:3.59519 train_time:195.211s step_avg:154.37ms
+step:1375/3250 val_loss:3.56908 train_time:214.510s step_avg:154.39ms
+step:1500/3250 val_loss:3.54122 train_time:233.751s step_avg:153.93ms
+step:1625/3250 val_loss:3.52195 train_time:253.040s step_avg:154.31ms
+step:1750/3250 val_loss:3.49979 train_time:272.336s step_avg:154.37ms
+step:1875/3250 val_loss:3.47756 train_time:291.596s step_avg:154.08ms
+step:2000/3250 val_loss:3.45724 train_time:310.901s step_avg:154.44ms
+step:2125/3250 val_loss:3.43933 train_time:330.190s step_avg:154.32ms
+step:2250/3250 val_loss:3.41951 train_time:349.466s step_avg:154.21ms
+step:2375/3250 val_loss:3.40196 train_time:368.773s step_avg:154.46ms
+step:2500/3250 val_loss:3.38351 train_time:388.078s step_avg:154.44ms
+step:2625/3250 val_loss:3.36291 train_time:407.340s step_avg:154.10ms
+step:2750/3250 val_loss:3.34437 train_time:426.629s step_avg:154.31ms
+step:2875/3250 val_loss:3.32510 train_time:445.921s step_avg:154.34ms
+step:2925/3250 val_loss:3.31735 train_time:453.632s step_avg:154.23ms
+step:2950/3250 val_loss:3.31385 train_time:457.489s step_avg:154.25ms
+step:2975/3250 val_loss:3.31029 train_time:461.342s step_avg:154.14ms
+step:3000/3250 val_loss:3.30680 train_time:465.196s step_avg:154.16ms
+step:3025/3250 val_loss:3.30246 train_time:469.053s step_avg:154.27ms
+step:3050/3250 val_loss:3.29902 train_time:472.946s step_avg:155.72ms
+step:3075/3250 val_loss:3.29588 train_time:476.798s step_avg:154.09ms
+step:3100/3250 val_loss:3.29279 train_time:480.649s step_avg:154.05ms
+step:3125/3250 val_loss:3.28987 train_time:484.509s step_avg:154.41ms
+step:3150/3250 val_loss:3.28700 train_time:488.364s step_avg:154.19ms
+step:3175/3250 val_loss:3.28466 train_time:492.221s step_avg:154.26ms
+step:3200/3250 val_loss:3.28259 train_time:496.080s step_avg:154.36ms
+step:3225/3250 val_loss:3.28102 train_time:499.937s step_avg:154.30ms
+step:3250/3250 val_loss:3.28034 train_time:503.825s step_avg:155.53ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/b199590f-f4a3-47a6-bc5a-aeef94b92000.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/b199590f-f4a3-47a6-bc5a-aeef94b92000.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.57590 train_time:21.483s step_avg:171.86ms
+step:250/3250 val_loss:4.09525 train_time:40.872s step_avg:155.12ms
+step:375/3250 val_loss:3.92682 train_time:60.155s step_avg:154.26ms
+step:500/3250 val_loss:3.82891 train_time:79.486s step_avg:154.65ms
+step:625/3250 val_loss:3.76335 train_time:98.817s step_avg:154.65ms
+step:750/3250 val_loss:3.72345 train_time:118.119s step_avg:154.42ms
+step:875/3250 val_loss:3.68440 train_time:137.454s step_avg:154.68ms
+step:1000/3250 val_loss:3.65274 train_time:156.772s step_avg:154.54ms
+step:1125/3250 val_loss:3.62403 train_time:176.051s step_avg:154.24ms
+step:1250/3250 val_loss:3.59226 train_time:195.380s step_avg:154.63ms
+step:1375/3250 val_loss:3.56901 train_time:214.691s step_avg:154.49ms
+step:1500/3250 val_loss:3.53971 train_time:233.969s step_avg:154.22ms
+step:1625/3250 val_loss:3.51860 train_time:253.275s step_avg:154.44ms
+step:1750/3250 val_loss:3.49684 train_time:272.582s step_avg:154.46ms
+step:1875/3250 val_loss:3.47590 train_time:291.844s step_avg:154.10ms
+step:2000/3250 val_loss:3.45598 train_time:311.167s step_avg:154.59ms
+step:2125/3250 val_loss:3.43676 train_time:330.487s step_avg:154.56ms
+step:2250/3250 val_loss:3.41779 train_time:349.763s step_avg:154.20ms
+step:2375/3250 val_loss:3.39954 train_time:369.091s step_avg:154.63ms
+step:2500/3250 val_loss:3.38082 train_time:388.409s step_avg:154.55ms
+step:2625/3250 val_loss:3.36113 train_time:407.688s step_avg:154.23ms
+step:2750/3250 val_loss:3.34247 train_time:427.003s step_avg:154.52ms
+step:2875/3250 val_loss:3.32354 train_time:446.314s step_avg:154.48ms
+step:2925/3250 val_loss:3.31549 train_time:454.024s step_avg:154.21ms
+step:2950/3250 val_loss:3.31208 train_time:457.879s step_avg:154.19ms
+step:2975/3250 val_loss:3.30854 train_time:461.740s step_avg:154.42ms
+step:3000/3250 val_loss:3.30509 train_time:465.596s step_avg:154.26ms
+step:3025/3250 val_loss:3.30086 train_time:469.447s step_avg:154.02ms
+step:3050/3250 val_loss:3.29741 train_time:473.342s step_avg:155.83ms
+step:3075/3250 val_loss:3.29413 train_time:477.196s step_avg:154.14ms
+step:3100/3250 val_loss:3.29100 train_time:481.046s step_avg:153.99ms
+step:3125/3250 val_loss:3.28818 train_time:484.899s step_avg:154.11ms
+step:3150/3250 val_loss:3.28532 train_time:488.753s step_avg:154.19ms
+step:3175/3250 val_loss:3.28298 train_time:492.610s step_avg:154.26ms
+step:3200/3250 val_loss:3.28090 train_time:496.464s step_avg:154.15ms
+step:3225/3250 val_loss:3.27937 train_time:500.318s step_avg:154.18ms
+step:3250/3250 val_loss:3.27873 train_time:504.208s step_avg:155.61ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/c67512ee-2070-4733-9769-573116e14ad5.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/c67512ee-2070-4733-9769-573116e14ad5.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.56785 train_time:21.464s step_avg:171.71ms
+step:250/3250 val_loss:4.09500 train_time:40.834s step_avg:154.96ms
+step:375/3250 val_loss:3.93037 train_time:60.110s step_avg:154.20ms
+step:500/3250 val_loss:3.82723 train_time:79.421s step_avg:154.49ms
+step:625/3250 val_loss:3.76758 train_time:98.755s step_avg:154.67ms
+step:750/3250 val_loss:3.72332 train_time:118.040s step_avg:154.28ms
+step:875/3250 val_loss:3.68797 train_time:137.364s step_avg:154.59ms
+step:1000/3250 val_loss:3.65500 train_time:156.688s step_avg:154.59ms
+step:1125/3250 val_loss:3.62787 train_time:175.967s step_avg:154.24ms
+step:1250/3250 val_loss:3.59372 train_time:195.292s step_avg:154.60ms
+step:1375/3250 val_loss:3.57022 train_time:214.611s step_avg:154.55ms
+step:1500/3250 val_loss:3.54095 train_time:233.888s step_avg:154.22ms
+step:1625/3250 val_loss:3.52190 train_time:253.194s step_avg:154.45ms
+step:1750/3250 val_loss:3.49922 train_time:272.498s step_avg:154.43ms
+step:1875/3250 val_loss:3.47816 train_time:291.775s step_avg:154.22ms
+step:2000/3250 val_loss:3.45661 train_time:311.093s step_avg:154.55ms
+step:2125/3250 val_loss:3.43821 train_time:330.395s step_avg:154.42ms
+step:2250/3250 val_loss:3.41857 train_time:349.657s step_avg:154.10ms
+step:2375/3250 val_loss:3.40121 train_time:368.968s step_avg:154.49ms
+step:2500/3250 val_loss:3.38175 train_time:388.280s step_avg:154.49ms
+step:2625/3250 val_loss:3.36247 train_time:407.548s step_avg:154.14ms
+step:2750/3250 val_loss:3.34341 train_time:426.854s step_avg:154.45ms
+step:2875/3250 val_loss:3.32418 train_time:446.161s step_avg:154.45ms
+step:2925/3250 val_loss:3.31606 train_time:453.875s step_avg:154.29ms
+step:2950/3250 val_loss:3.31263 train_time:457.736s step_avg:154.46ms
+step:2975/3250 val_loss:3.30905 train_time:461.593s step_avg:154.27ms
+step:3000/3250 val_loss:3.30565 train_time:465.450s step_avg:154.25ms
+step:3025/3250 val_loss:3.30135 train_time:469.302s step_avg:154.11ms
+step:3050/3250 val_loss:3.29797 train_time:473.201s step_avg:155.93ms
+step:3075/3250 val_loss:3.29479 train_time:477.063s step_avg:154.50ms
+step:3100/3250 val_loss:3.29161 train_time:480.933s step_avg:154.79ms
+step:3125/3250 val_loss:3.28891 train_time:484.788s step_avg:154.19ms
+step:3150/3250 val_loss:3.28594 train_time:488.647s step_avg:154.39ms
+step:3175/3250 val_loss:3.28355 train_time:492.506s step_avg:154.36ms
+step:3200/3250 val_loss:3.28150 train_time:496.365s step_avg:154.35ms
+step:3225/3250 val_loss:3.27996 train_time:500.221s step_avg:154.26ms
+step:3250/3250 val_loss:3.27932 train_time:504.109s step_avg:155.49ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/f0bcca7d-a146-4cf8-a7c3-ba36733928f4.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/f0bcca7d-a146-4cf8-a7c3-ba36733928f4.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.60460 train_time:21.253s step_avg:170.02ms
+step:250/3250 val_loss:4.09938 train_time:40.590s step_avg:154.69ms
+step:375/3250 val_loss:3.92807 train_time:59.820s step_avg:153.85ms
+step:500/3250 val_loss:3.83088 train_time:79.090s step_avg:154.16ms
+step:625/3250 val_loss:3.76479 train_time:98.363s step_avg:154.19ms
+step:750/3250 val_loss:3.72322 train_time:117.606s step_avg:153.94ms
+step:875/3250 val_loss:3.68328 train_time:136.875s step_avg:154.15ms
+step:1000/3250 val_loss:3.65381 train_time:156.150s step_avg:154.20ms
+step:1125/3250 val_loss:3.62416 train_time:175.397s step_avg:153.97ms
+step:1250/3250 val_loss:3.59514 train_time:194.678s step_avg:154.25ms
+step:1375/3250 val_loss:3.56708 train_time:213.961s step_avg:154.26ms
+step:1500/3250 val_loss:3.53882 train_time:233.194s step_avg:153.87ms
+step:1625/3250 val_loss:3.51913 train_time:252.460s step_avg:154.13ms
+step:1750/3250 val_loss:3.49672 train_time:271.721s step_avg:154.09ms
+step:1875/3250 val_loss:3.47524 train_time:290.956s step_avg:153.88ms
+step:2000/3250 val_loss:3.45454 train_time:310.241s step_avg:154.28ms
+step:2125/3250 val_loss:3.43622 train_time:329.531s step_avg:154.32ms
+step:2250/3250 val_loss:3.41626 train_time:348.787s step_avg:154.05ms
+step:2375/3250 val_loss:3.39866 train_time:368.059s step_avg:154.18ms
+step:2500/3250 val_loss:3.37997 train_time:387.345s step_avg:154.28ms
+step:2625/3250 val_loss:3.35987 train_time:406.602s step_avg:154.06ms
+step:2750/3250 val_loss:3.34107 train_time:425.880s step_avg:154.22ms
+step:2875/3250 val_loss:3.32228 train_time:445.157s step_avg:154.22ms
+step:2925/3250 val_loss:3.31424 train_time:452.862s step_avg:154.09ms
+step:2950/3250 val_loss:3.31086 train_time:456.714s step_avg:154.10ms
+step:2975/3250 val_loss:3.30713 train_time:460.565s step_avg:154.02ms
+step:3000/3250 val_loss:3.30377 train_time:464.421s step_avg:154.23ms
+step:3025/3250 val_loss:3.29938 train_time:468.277s step_avg:154.26ms
+step:3050/3250 val_loss:3.29608 train_time:472.165s step_avg:155.50ms
+step:3075/3250 val_loss:3.29268 train_time:476.017s step_avg:154.10ms
+step:3100/3250 val_loss:3.28964 train_time:479.872s step_avg:154.20ms
+step:3125/3250 val_loss:3.28679 train_time:483.725s step_avg:154.10ms
+step:3150/3250 val_loss:3.28387 train_time:487.574s step_avg:153.97ms
+step:3175/3250 val_loss:3.28150 train_time:491.432s step_avg:154.31ms
+step:3200/3250 val_loss:3.27948 train_time:495.286s step_avg:154.16ms
+step:3225/3250 val_loss:3.27786 train_time:499.137s step_avg:154.06ms
+step:3250/3250 val_loss:3.27720 train_time:503.021s step_avg:155.34ms

--- a/records/track_3_optimization/results/20260610_tuned_baseline_3250/fc5b73a0-d67d-4b00-a5dc-934fa01c1505.txt
+++ b/records/track_3_optimization/results/20260610_tuned_baseline_3250/fc5b73a0-d67d-4b00-a5dc-934fa01c1505.txt
@@ -370,3 +370,45 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+====================================================================================================
+step:0/3250 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/3250 val_loss:4.59125 train_time:21.703s step_avg:173.62ms
+step:250/3250 val_loss:4.10531 train_time:41.010s step_avg:154.46ms
+step:375/3250 val_loss:3.92544 train_time:60.195s step_avg:153.48ms
+step:500/3250 val_loss:3.82714 train_time:79.418s step_avg:153.78ms
+step:625/3250 val_loss:3.76319 train_time:98.629s step_avg:153.69ms
+step:750/3250 val_loss:3.72145 train_time:117.835s step_avg:153.65ms
+step:875/3250 val_loss:3.68357 train_time:137.090s step_avg:154.04ms
+step:1000/3250 val_loss:3.65201 train_time:156.337s step_avg:153.97ms
+step:1125/3250 val_loss:3.62340 train_time:175.558s step_avg:153.77ms
+step:1250/3250 val_loss:3.59320 train_time:194.829s step_avg:154.16ms
+step:1375/3250 val_loss:3.56572 train_time:214.081s step_avg:154.02ms
+step:1500/3250 val_loss:3.53872 train_time:233.303s step_avg:153.77ms
+step:1625/3250 val_loss:3.51994 train_time:252.566s step_avg:154.10ms
+step:1750/3250 val_loss:3.49699 train_time:271.837s step_avg:154.17ms
+step:1875/3250 val_loss:3.47532 train_time:291.061s step_avg:153.79ms
+step:2000/3250 val_loss:3.45517 train_time:310.327s step_avg:154.13ms
+step:2125/3250 val_loss:3.43661 train_time:329.591s step_avg:154.12ms
+step:2250/3250 val_loss:3.41765 train_time:348.823s step_avg:153.86ms
+step:2375/3250 val_loss:3.39959 train_time:368.101s step_avg:154.23ms
+step:2500/3250 val_loss:3.38074 train_time:387.374s step_avg:154.18ms
+step:2625/3250 val_loss:3.36042 train_time:406.622s step_avg:153.99ms
+step:2750/3250 val_loss:3.34196 train_time:425.916s step_avg:154.35ms
+step:2875/3250 val_loss:3.32291 train_time:445.199s step_avg:154.26ms
+step:2925/3250 val_loss:3.31490 train_time:452.900s step_avg:154.02ms
+step:2950/3250 val_loss:3.31148 train_time:456.752s step_avg:154.08ms
+step:2975/3250 val_loss:3.30785 train_time:460.602s step_avg:154.00ms
+step:3000/3250 val_loss:3.30445 train_time:464.459s step_avg:154.28ms
+step:3025/3250 val_loss:3.30032 train_time:468.304s step_avg:153.83ms
+step:3050/3250 val_loss:3.29692 train_time:472.204s step_avg:155.96ms
+step:3075/3250 val_loss:3.29377 train_time:476.055s step_avg:154.07ms
+step:3100/3250 val_loss:3.29054 train_time:479.906s step_avg:154.04ms
+step:3125/3250 val_loss:3.28770 train_time:483.758s step_avg:154.05ms
+step:3150/3250 val_loss:3.28483 train_time:487.611s step_avg:154.15ms
+step:3175/3250 val_loss:3.28246 train_time:491.461s step_avg:153.98ms
+step:3200/3250 val_loss:3.28047 train_time:495.313s step_avg:154.07ms
+step:3225/3250 val_loss:3.27892 train_time:499.172s step_avg:154.39ms
+step:3250/3250 val_loss:3.27825 train_time:503.059s step_avg:155.49ms


### PR DESCRIPTION
Changes:
  - `train_steps`: `3350 -> 3250`
  - AdamW learning rates:
    - embedding: `0.3 -> 0.7`
    - projection: `1/320 -> 0.004`
    - 1D params: `0.01 -> 0.015`
  - AdamW weight decay: `0 -> 0.001`
  - Muon:
    - learning rate: `0.035 -> 0.025`
    - weight decay: `0.025 -> 0.05`

  Validation logs are included in:

  `records/track_3_optimization/results/20260610_tuned_baseline_3250/`

  10-run result at 3250 steps:
  - mean val loss: `3.278659`
  - median val loss: `3.278490`
  - std: `0.001343`
  - min: `3.276990`
  - max: `3.280910`

  README significance criterion:

  ```text
  (3.28 - mean) * sqrt(10) = 0.004241
```
  which passes the required >= 0.004.