### PR TITLE
Make key-offset shifts deterministic

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1092,7 +1092,7 @@ class CausalSelfAttention(nn.Module):
 
             if key_offset:
                 # shift keys forward for the stationary head dims. Enables 1-layer induction.
-                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:].clone()
 
             if aux_v is not None:
                 v = v + aux_v.view_as(v)

--- a/train_gpt_medium.py
+++ b/train_gpt_medium.py
@@ -969,8 +969,8 @@ class CausalSelfAttention(nn.Module):
         q, k = rotary(q, cos, sin), rotary(k, cos, sin)
         if key_offset:
             # shift keys forward for the stationary head dims. Enables 1-layer induction.
-            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
-            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2].clone()
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:].clone()
         if ve is not None:
             ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
             v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977


### PR DESCRIPTION
## What changed

- Clone the source slice before each in-place key-offset shift in `train_gpt.py` and `train_gpt_medium.py`.
- Keep the intended one-token shift unchanged while removing source/destination aliasing.

## Root cause

The assignments write `k[:, 1:]` while reading the overlapping `k[:, :-1]` view on CUDA. The copy kernel can observe values that another thread has already overwritten, so the result depends on execution order instead of representing a stable one-token shift.

At the record-84 tensor shape on an H100, eight repeated runs from the same input produced a maximum element delta of `7.28125` with the overlapping assignment. Cloning the RHS produced `0.0` repeat delta.

## Impact

Key-offset attention becomes deterministic and matches the shift described by the surrounding comment. This affects the long-window key-offset paths in both training scripts.

## Validation

- H100 overlap reproduction at shape `[1, 16384, 6, 128]`: overlap repeat delta `7.28125`; cloned RHS `0.0`
- `python3 -m py_compile train_gpt.py train_gpt_medium.py`
- `git diff --check`
