### PR TITLE
Tune AdamW baseline to 4950 steps

### DIFF
--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/005c492b-1811-4ae6-ad46-0b364e379fc1.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/005c492b-1811-4ae6-ad46-0b364e379fc1.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=12
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/4950 val_loss:5.81381 train_time:20.278s step_avg:162.22ms
+step:250/4950 val_loss:4.79442 train_time:38.840s step_avg:148.49ms
+step:375/4950 val_loss:4.32992 train_time:57.500s step_avg:149.28ms
+step:500/4950 val_loss:4.09899 train_time:76.199s step_avg:149.59ms
+step:625/4950 val_loss:3.98682 train_time:94.900s step_avg:149.61ms
+step:750/4950 val_loss:3.91009 train_time:113.597s step_avg:149.58ms
+step:875/4950 val_loss:3.84792 train_time:132.312s step_avg:149.71ms
+step:1000/4950 val_loss:3.79993 train_time:151.023s step_avg:149.69ms
+step:1125/4950 val_loss:3.76990 train_time:169.768s step_avg:149.96ms
+step:1250/4950 val_loss:3.72974 train_time:188.454s step_avg:149.49ms
+step:1375/4950 val_loss:3.72709 train_time:207.161s step_avg:149.66ms
+step:1500/4950 val_loss:3.68272 train_time:225.869s step_avg:149.66ms
+step:1625/4950 val_loss:3.66272 train_time:244.550s step_avg:149.45ms
+step:1750/4950 val_loss:3.64296 train_time:263.252s step_avg:149.61ms
+step:1875/4950 val_loss:3.61711 train_time:281.926s step_avg:149.39ms
+step:2000/4950 val_loss:3.59932 train_time:300.615s step_avg:149.51ms
+step:2125/4950 val_loss:3.58113 train_time:319.307s step_avg:149.54ms
+step:2250/4950 val_loss:3.56542 train_time:337.997s step_avg:149.52ms
+step:2375/4950 val_loss:3.54712 train_time:356.690s step_avg:149.55ms
+step:2500/4950 val_loss:3.53393 train_time:375.382s step_avg:149.54ms
+step:2625/4950 val_loss:3.51749 train_time:394.055s step_avg:149.38ms
+step:2750/4950 val_loss:3.50485 train_time:412.737s step_avg:149.45ms
+step:2875/4950 val_loss:3.49440 train_time:431.409s step_avg:149.38ms
+step:3000/4950 val_loss:3.48056 train_time:450.051s step_avg:149.14ms
+step:3125/4950 val_loss:3.46539 train_time:468.671s step_avg:148.96ms
+step:3250/4950 val_loss:3.45091 train_time:487.293s step_avg:148.97ms
+step:3375/4950 val_loss:3.43832 train_time:505.918s step_avg:149.01ms
+step:3500/4950 val_loss:3.42600 train_time:524.545s step_avg:149.01ms
+step:3625/4950 val_loss:3.41168 train_time:543.194s step_avg:149.19ms
+step:3750/4950 val_loss:3.39873 train_time:561.832s step_avg:149.10ms
+step:3875/4950 val_loss:3.38474 train_time:580.450s step_avg:148.95ms
+step:4000/4950 val_loss:3.37029 train_time:599.067s step_avg:148.94ms
+step:4125/4950 val_loss:3.35706 train_time:617.691s step_avg:148.99ms
+step:4250/4950 val_loss:3.34517 train_time:636.312s step_avg:148.97ms
+step:4375/4950 val_loss:3.33065 train_time:654.934s step_avg:148.98ms
+step:4475/4950 val_loss:3.31847 train_time:669.830s step_avg:148.95ms
+step:4500/4950 val_loss:3.31599 train_time:673.552s step_avg:148.90ms
+step:4525/4950 val_loss:3.31229 train_time:677.279s step_avg:149.07ms
+step:4550/4950 val_loss:3.31013 train_time:681.002s step_avg:148.94ms
+step:4575/4950 val_loss:3.30800 train_time:684.730s step_avg:149.10ms
+step:4600/4950 val_loss:3.30453 train_time:688.459s step_avg:149.16ms
+step:4625/4950 val_loss:3.30200 train_time:692.186s step_avg:149.09ms
+step:4650/4950 val_loss:3.29919 train_time:695.916s step_avg:149.18ms
+step:4675/4950 val_loss:3.29620 train_time:699.650s step_avg:149.38ms
+step:4700/4950 val_loss:3.29350 train_time:703.388s step_avg:149.52ms
+step:4725/4950 val_loss:3.29158 train_time:707.125s step_avg:149.46ms
+step:4750/4950 val_loss:3.28838 train_time:710.867s step_avg:149.70ms
+step:4775/4950 val_loss:3.28620 train_time:714.657s step_avg:151.58ms
+step:4800/4950 val_loss:3.28388 train_time:718.397s step_avg:149.64ms
+step:4825/4950 val_loss:3.28190 train_time:722.132s step_avg:149.39ms
+step:4850/4950 val_loss:3.27992 train_time:725.882s step_avg:150.00ms
+step:4875/4950 val_loss:3.27835 train_time:729.625s step_avg:149.71ms
+step:4900/4950 val_loss:3.27682 train_time:733.367s step_avg:149.67ms
+step:4925/4950 val_loss:3.27572 train_time:737.100s step_avg:149.35ms
+step:4950/4950 val_loss:3.27519 train_time:740.838s step_avg:149.51ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/34b80e11-ff7c-4be6-99be-4dcf3eb3d2cb.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/34b80e11-ff7c-4be6-99be-4dcf3eb3d2cb.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=17
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/4950 val_loss:5.81272 train_time:20.013s step_avg:160.10ms
+step:250/4950 val_loss:4.81113 train_time:38.543s step_avg:148.24ms
+step:375/4950 val_loss:4.33502 train_time:57.136s step_avg:148.74ms
+step:500/4950 val_loss:4.11260 train_time:75.769s step_avg:149.06ms
+step:625/4950 val_loss:3.99606 train_time:94.412s step_avg:149.15ms
+step:750/4950 val_loss:3.91776 train_time:113.050s step_avg:149.10ms
+step:875/4950 val_loss:3.85106 train_time:131.691s step_avg:149.12ms
+step:1000/4950 val_loss:3.80088 train_time:150.328s step_avg:149.10ms
+step:1125/4950 val_loss:3.77483 train_time:168.968s step_avg:149.12ms
+step:1250/4950 val_loss:3.73481 train_time:187.606s step_avg:149.11ms
+step:1375/4950 val_loss:3.72745 train_time:206.239s step_avg:149.07ms
+step:1500/4950 val_loss:3.68634 train_time:224.866s step_avg:149.02ms
+step:1625/4950 val_loss:3.67091 train_time:243.486s step_avg:148.96ms
+step:1750/4950 val_loss:3.64247 train_time:262.101s step_avg:148.92ms
+step:1875/4950 val_loss:3.61660 train_time:280.719s step_avg:148.94ms
+step:2000/4950 val_loss:3.59877 train_time:299.337s step_avg:148.94ms
+step:2125/4950 val_loss:3.57949 train_time:317.954s step_avg:148.94ms
+step:2250/4950 val_loss:3.56662 train_time:336.556s step_avg:148.81ms
+step:2375/4950 val_loss:3.55268 train_time:355.169s step_avg:148.91ms
+step:2500/4950 val_loss:3.53806 train_time:373.779s step_avg:148.88ms
+step:2625/4950 val_loss:3.51961 train_time:392.388s step_avg:148.87ms
+step:2750/4950 val_loss:3.50610 train_time:410.984s step_avg:148.77ms
+step:2875/4950 val_loss:3.49711 train_time:429.582s step_avg:148.78ms
+step:3000/4950 val_loss:3.48247 train_time:448.199s step_avg:148.94ms
+step:3125/4950 val_loss:3.46980 train_time:466.798s step_avg:148.79ms
+step:3250/4950 val_loss:3.45184 train_time:485.389s step_avg:148.73ms
+step:3375/4950 val_loss:3.43875 train_time:504.000s step_avg:148.89ms
+step:3500/4950 val_loss:3.42803 train_time:522.612s step_avg:148.89ms
+step:3625/4950 val_loss:3.41348 train_time:541.221s step_avg:148.88ms
+step:3750/4950 val_loss:3.40041 train_time:559.831s step_avg:148.88ms
+step:3875/4950 val_loss:3.38650 train_time:578.434s step_avg:148.82ms
+step:4000/4950 val_loss:3.37243 train_time:597.013s step_avg:148.63ms
+step:4125/4950 val_loss:3.35855 train_time:615.607s step_avg:148.76ms
+step:4250/4950 val_loss:3.34675 train_time:634.200s step_avg:148.74ms
+step:4375/4950 val_loss:3.33263 train_time:652.796s step_avg:148.76ms
+step:4475/4950 val_loss:3.32032 train_time:667.683s step_avg:148.87ms
+step:4500/4950 val_loss:3.31782 train_time:671.404s step_avg:148.85ms
+step:4525/4950 val_loss:3.31422 train_time:675.127s step_avg:148.91ms
+step:4550/4950 val_loss:3.31198 train_time:678.846s step_avg:148.77ms
+step:4575/4950 val_loss:3.30964 train_time:682.565s step_avg:148.76ms
+step:4600/4950 val_loss:3.30625 train_time:686.291s step_avg:149.05ms
+step:4625/4950 val_loss:3.30363 train_time:690.019s step_avg:149.11ms
+step:4650/4950 val_loss:3.30094 train_time:693.741s step_avg:148.90ms
+step:4675/4950 val_loss:3.29819 train_time:697.465s step_avg:148.97ms
+step:4700/4950 val_loss:3.29514 train_time:701.188s step_avg:148.92ms
+step:4725/4950 val_loss:3.29343 train_time:704.914s step_avg:149.01ms
+step:4750/4950 val_loss:3.29033 train_time:708.637s step_avg:148.93ms
+step:4775/4950 val_loss:3.28793 train_time:712.398s step_avg:150.44ms
+step:4800/4950 val_loss:3.28565 train_time:716.123s step_avg:149.00ms
+step:4825/4950 val_loss:3.28365 train_time:719.849s step_avg:149.03ms
+step:4850/4950 val_loss:3.28158 train_time:723.574s step_avg:149.01ms
+step:4875/4950 val_loss:3.27998 train_time:727.295s step_avg:148.85ms
+step:4900/4950 val_loss:3.27851 train_time:731.016s step_avg:148.84ms
+step:4925/4950 val_loss:3.27744 train_time:734.732s step_avg:148.63ms
+step:4950/4950 val_loss:3.27686 train_time:738.460s step_avg:149.11ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/49cb7fdc-8744-4f01-abe0-10fb47ed7285.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/49cb7fdc-8744-4f01-abe0-10fb47ed7285.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=15
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.002s step_avg:nanms
+step:125/4950 val_loss:5.83929 train_time:20.408s step_avg:163.25ms
+step:250/4950 val_loss:4.83056 train_time:38.958s step_avg:148.40ms
+step:375/4950 val_loss:4.33016 train_time:57.549s step_avg:148.73ms
+step:500/4950 val_loss:4.12199 train_time:76.154s step_avg:148.84ms
+step:625/4950 val_loss:3.99485 train_time:94.787s step_avg:149.06ms
+step:750/4950 val_loss:3.90831 train_time:113.419s step_avg:149.05ms
+step:875/4950 val_loss:3.85133 train_time:132.048s step_avg:149.04ms
+step:1000/4950 val_loss:3.79399 train_time:150.678s step_avg:149.03ms
+step:1125/4950 val_loss:3.77324 train_time:169.294s step_avg:148.93ms
+step:1250/4950 val_loss:3.73560 train_time:187.916s step_avg:148.98ms
+step:1375/4950 val_loss:3.72996 train_time:206.529s step_avg:148.91ms
+step:1500/4950 val_loss:3.68888 train_time:225.151s step_avg:148.98ms
+step:1625/4950 val_loss:3.66347 train_time:243.761s step_avg:148.88ms
+step:1750/4950 val_loss:3.64110 train_time:262.381s step_avg:148.96ms
+step:1875/4950 val_loss:3.61398 train_time:280.985s step_avg:148.83ms
+step:2000/4950 val_loss:3.59457 train_time:299.579s step_avg:148.75ms
+step:2125/4950 val_loss:3.58017 train_time:318.164s step_avg:148.68ms
+step:2250/4950 val_loss:3.56568 train_time:336.748s step_avg:148.67ms
+step:2375/4950 val_loss:3.55000 train_time:355.323s step_avg:148.60ms
+step:2500/4950 val_loss:3.53543 train_time:373.932s step_avg:148.87ms
+step:2625/4950 val_loss:3.51635 train_time:392.524s step_avg:148.73ms
+step:2750/4950 val_loss:3.50464 train_time:411.115s step_avg:148.73ms
+step:2875/4950 val_loss:3.49477 train_time:429.704s step_avg:148.72ms
+step:3000/4950 val_loss:3.48174 train_time:448.280s step_avg:148.61ms
+step:3125/4950 val_loss:3.46461 train_time:466.873s step_avg:148.74ms
+step:3250/4950 val_loss:3.45001 train_time:485.471s step_avg:148.78ms
+step:3375/4950 val_loss:3.43680 train_time:504.050s step_avg:148.64ms
+step:3500/4950 val_loss:3.42590 train_time:522.645s step_avg:148.76ms
+step:3625/4950 val_loss:3.41327 train_time:541.238s step_avg:148.74ms
+step:3750/4950 val_loss:3.39916 train_time:559.830s step_avg:148.74ms
+step:3875/4950 val_loss:3.38508 train_time:578.403s step_avg:148.59ms
+step:4000/4950 val_loss:3.36980 train_time:596.991s step_avg:148.70ms
+step:4125/4950 val_loss:3.35710 train_time:615.571s step_avg:148.64ms
+step:4250/4950 val_loss:3.34410 train_time:634.161s step_avg:148.72ms
+step:4375/4950 val_loss:3.32985 train_time:652.745s step_avg:148.68ms
+step:4475/4950 val_loss:3.31809 train_time:667.608s step_avg:148.63ms
+step:4500/4950 val_loss:3.31551 train_time:671.323s step_avg:148.62ms
+step:4525/4950 val_loss:3.31189 train_time:675.041s step_avg:148.72ms
+step:4550/4950 val_loss:3.30962 train_time:678.756s step_avg:148.60ms
+step:4575/4950 val_loss:3.30767 train_time:682.474s step_avg:148.71ms
+step:4600/4950 val_loss:3.30397 train_time:686.196s step_avg:148.87ms
+step:4625/4950 val_loss:3.30144 train_time:689.922s step_avg:149.05ms
+step:4650/4950 val_loss:3.29849 train_time:693.636s step_avg:148.56ms
+step:4675/4950 val_loss:3.29599 train_time:697.353s step_avg:148.68ms
+step:4700/4950 val_loss:3.29295 train_time:701.080s step_avg:149.06ms
+step:4725/4950 val_loss:3.29114 train_time:704.799s step_avg:148.77ms
+step:4750/4950 val_loss:3.28819 train_time:708.525s step_avg:149.02ms
+step:4775/4950 val_loss:3.28553 train_time:712.292s step_avg:150.70ms
+step:4800/4950 val_loss:3.28332 train_time:716.010s step_avg:148.72ms
+step:4825/4950 val_loss:3.28134 train_time:719.729s step_avg:148.76ms
+step:4850/4950 val_loss:3.27939 train_time:723.446s step_avg:148.70ms
+step:4875/4950 val_loss:3.27776 train_time:727.172s step_avg:149.02ms
+step:4900/4950 val_loss:3.27622 train_time:730.893s step_avg:148.86ms
+step:4925/4950 val_loss:3.27515 train_time:734.611s step_avg:148.69ms
+step:4950/4950 val_loss:3.27459 train_time:738.334s step_avg:148.92ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/8b361414-7076-4cdd-8ac9-214796226a1b.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/8b361414-7076-4cdd-8ac9-214796226a1b.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=13
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.002s step_avg:nanms
+step:125/4950 val_loss:5.92790 train_time:20.523s step_avg:164.17ms
+step:250/4950 val_loss:4.87560 train_time:39.102s step_avg:148.63ms
+step:375/4950 val_loss:4.37574 train_time:57.729s step_avg:149.02ms
+step:500/4950 val_loss:4.14022 train_time:76.424s step_avg:149.56ms
+step:625/4950 val_loss:4.01084 train_time:95.154s step_avg:149.84ms
+step:750/4950 val_loss:3.92359 train_time:113.893s step_avg:149.91ms
+step:875/4950 val_loss:3.85605 train_time:132.635s step_avg:149.94ms
+step:1000/4950 val_loss:3.81025 train_time:151.359s step_avg:149.79ms
+step:1125/4950 val_loss:3.78392 train_time:170.032s step_avg:149.38ms
+step:1250/4950 val_loss:3.74337 train_time:188.700s step_avg:149.35ms
+step:1375/4950 val_loss:3.72485 train_time:207.373s step_avg:149.39ms
+step:1500/4950 val_loss:3.68849 train_time:226.029s step_avg:149.24ms
+step:1625/4950 val_loss:3.66795 train_time:244.680s step_avg:149.21ms
+step:1750/4950 val_loss:3.64920 train_time:263.330s step_avg:149.20ms
+step:1875/4950 val_loss:3.62007 train_time:281.981s step_avg:149.21ms
+step:2000/4950 val_loss:3.59948 train_time:300.615s step_avg:149.07ms
+step:2125/4950 val_loss:3.59033 train_time:319.226s step_avg:148.89ms
+step:2250/4950 val_loss:3.57155 train_time:337.841s step_avg:148.92ms
+step:2375/4950 val_loss:3.55145 train_time:356.459s step_avg:148.94ms
+step:2500/4950 val_loss:3.53779 train_time:375.088s step_avg:149.03ms
+step:2625/4950 val_loss:3.51898 train_time:393.693s step_avg:148.84ms
+step:2750/4950 val_loss:3.50561 train_time:412.291s step_avg:148.78ms
+step:2875/4950 val_loss:3.49628 train_time:430.898s step_avg:148.86ms
+step:3000/4950 val_loss:3.48059 train_time:449.519s step_avg:148.96ms
+step:3125/4950 val_loss:3.46566 train_time:468.140s step_avg:148.97ms
+step:3250/4950 val_loss:3.45078 train_time:486.755s step_avg:148.92ms
+step:3375/4950 val_loss:3.43849 train_time:505.366s step_avg:148.88ms
+step:3500/4950 val_loss:3.42653 train_time:523.962s step_avg:148.77ms
+step:3625/4950 val_loss:3.41282 train_time:542.564s step_avg:148.81ms
+step:3750/4950 val_loss:3.40002 train_time:561.168s step_avg:148.83ms
+step:3875/4950 val_loss:3.38548 train_time:579.772s step_avg:148.83ms
+step:4000/4950 val_loss:3.37102 train_time:598.374s step_avg:148.82ms
+step:4125/4950 val_loss:3.35813 train_time:616.982s step_avg:148.86ms
+step:4250/4950 val_loss:3.34521 train_time:635.592s step_avg:148.87ms
+step:4375/4950 val_loss:3.33069 train_time:654.211s step_avg:148.96ms
+step:4475/4950 val_loss:3.31871 train_time:669.095s step_avg:148.84ms
+step:4500/4950 val_loss:3.31612 train_time:672.819s step_avg:148.95ms
+step:4525/4950 val_loss:3.31247 train_time:676.551s step_avg:149.26ms
+step:4550/4950 val_loss:3.31045 train_time:680.277s step_avg:149.04ms
+step:4575/4950 val_loss:3.30829 train_time:684.002s step_avg:149.02ms
+step:4600/4950 val_loss:3.30475 train_time:687.725s step_avg:148.92ms
+step:4625/4950 val_loss:3.30215 train_time:691.453s step_avg:149.09ms
+step:4650/4950 val_loss:3.29936 train_time:695.179s step_avg:149.04ms
+step:4675/4950 val_loss:3.29653 train_time:698.904s step_avg:149.02ms
+step:4700/4950 val_loss:3.29366 train_time:702.628s step_avg:148.95ms
+step:4725/4950 val_loss:3.29176 train_time:706.356s step_avg:149.12ms
+step:4750/4950 val_loss:3.28850 train_time:710.084s step_avg:149.13ms
+step:4775/4950 val_loss:3.28622 train_time:713.857s step_avg:150.92ms
+step:4800/4950 val_loss:3.28390 train_time:717.584s step_avg:149.11ms
+step:4825/4950 val_loss:3.28206 train_time:721.309s step_avg:149.00ms
+step:4850/4950 val_loss:3.27995 train_time:725.038s step_avg:149.17ms
+step:4875/4950 val_loss:3.27829 train_time:728.764s step_avg:149.04ms
+step:4900/4950 val_loss:3.27682 train_time:732.491s step_avg:149.07ms
+step:4925/4950 val_loss:3.27572 train_time:736.217s step_avg:149.01ms
+step:4950/4950 val_loss:3.27514 train_time:739.941s step_avg:148.96ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/a4c8647b-0218-4134-93af-f9b085b2b788.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/a4c8647b-0218-4134-93af-f9b085b2b788.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=11
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.001s step_avg:nanms
+step:125/4950 val_loss:5.74102 train_time:20.242s step_avg:161.93ms
+step:250/4950 val_loss:4.79934 train_time:38.844s step_avg:148.81ms
+step:375/4950 val_loss:4.30379 train_time:57.604s step_avg:150.07ms
+step:500/4950 val_loss:4.10166 train_time:76.422s step_avg:150.55ms
+step:625/4950 val_loss:3.98221 train_time:95.276s step_avg:150.83ms
+step:750/4950 val_loss:3.90958 train_time:114.134s step_avg:150.86ms
+step:875/4950 val_loss:3.83783 train_time:132.974s step_avg:150.72ms
+step:1000/4950 val_loss:3.79741 train_time:151.780s step_avg:150.45ms
+step:1125/4950 val_loss:3.76633 train_time:170.559s step_avg:150.23ms
+step:1250/4950 val_loss:3.73209 train_time:189.330s step_avg:150.16ms
+step:1375/4950 val_loss:3.72138 train_time:208.104s step_avg:150.19ms
+step:1500/4950 val_loss:3.68469 train_time:226.865s step_avg:150.09ms
+step:1625/4950 val_loss:3.66135 train_time:245.612s step_avg:149.98ms
+step:1750/4950 val_loss:3.64408 train_time:264.370s step_avg:150.06ms
+step:1875/4950 val_loss:3.61418 train_time:283.120s step_avg:150.00ms
+step:2000/4950 val_loss:3.59448 train_time:301.869s step_avg:149.99ms
+step:2125/4950 val_loss:3.58121 train_time:320.623s step_avg:150.03ms
+step:2250/4950 val_loss:3.56582 train_time:339.375s step_avg:150.01ms
+step:2375/4950 val_loss:3.54828 train_time:358.125s step_avg:150.00ms
+step:2500/4950 val_loss:3.53346 train_time:376.862s step_avg:149.89ms
+step:2625/4950 val_loss:3.51732 train_time:395.612s step_avg:150.00ms
+step:2750/4950 val_loss:3.51068 train_time:414.365s step_avg:150.02ms
+step:2875/4950 val_loss:3.49308 train_time:433.093s step_avg:149.83ms
+step:3000/4950 val_loss:3.48117 train_time:451.777s step_avg:149.47ms
+step:3125/4950 val_loss:3.46811 train_time:470.471s step_avg:149.55ms
+step:3250/4950 val_loss:3.45326 train_time:489.140s step_avg:149.35ms
+step:3375/4950 val_loss:3.43881 train_time:507.795s step_avg:149.24ms
+step:3500/4950 val_loss:3.42741 train_time:526.415s step_avg:148.96ms
+step:3625/4950 val_loss:3.41408 train_time:545.073s step_avg:149.27ms
+step:3750/4950 val_loss:3.39946 train_time:563.757s step_avg:149.47ms
+step:3875/4950 val_loss:3.38538 train_time:582.448s step_avg:149.53ms
+step:4000/4950 val_loss:3.37228 train_time:601.122s step_avg:149.40ms
+step:4125/4950 val_loss:3.35784 train_time:619.798s step_avg:149.40ms
+step:4250/4950 val_loss:3.34522 train_time:638.471s step_avg:149.38ms
+step:4375/4950 val_loss:3.33017 train_time:657.116s step_avg:149.16ms
+step:4475/4950 val_loss:3.31873 train_time:672.031s step_avg:149.15ms
+step:4500/4950 val_loss:3.31643 train_time:675.763s step_avg:149.29ms
+step:4525/4950 val_loss:3.31280 train_time:679.495s step_avg:149.29ms
+step:4550/4950 val_loss:3.31076 train_time:683.217s step_avg:148.85ms
+step:4575/4950 val_loss:3.30862 train_time:686.948s step_avg:149.27ms
+step:4600/4950 val_loss:3.30471 train_time:690.674s step_avg:149.05ms
+step:4625/4950 val_loss:3.30220 train_time:694.400s step_avg:149.03ms
+step:4650/4950 val_loss:3.29951 train_time:698.129s step_avg:149.14ms
+step:4675/4950 val_loss:3.29659 train_time:701.861s step_avg:149.27ms
+step:4700/4950 val_loss:3.29374 train_time:705.603s step_avg:149.69ms
+step:4725/4950 val_loss:3.29192 train_time:709.336s step_avg:149.33ms
+step:4750/4950 val_loss:3.28877 train_time:713.068s step_avg:149.27ms
+step:4775/4950 val_loss:3.28656 train_time:716.848s step_avg:151.18ms
+step:4800/4950 val_loss:3.28425 train_time:720.581s step_avg:149.36ms
+step:4825/4950 val_loss:3.28239 train_time:724.320s step_avg:149.53ms
+step:4850/4950 val_loss:3.28036 train_time:728.051s step_avg:149.25ms
+step:4875/4950 val_loss:3.27873 train_time:731.783s step_avg:149.28ms
+step:4900/4950 val_loss:3.27722 train_time:735.516s step_avg:149.33ms
+step:4925/4950 val_loss:3.27615 train_time:739.252s step_avg:149.44ms
+step:4950/4950 val_loss:3.27560 train_time:742.982s step_avg:149.20ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/aeac2023-602e-4151-a161-934fe855c768.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/aeac2023-602e-4151-a161-934fe855c768.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=14
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.002s step_avg:nanms
+step:125/4950 val_loss:6.08757 train_time:20.491s step_avg:163.91ms
+step:250/4950 val_loss:4.93035 train_time:39.053s step_avg:148.50ms
+step:375/4950 val_loss:4.42346 train_time:57.701s step_avg:149.18ms
+step:500/4950 val_loss:4.16491 train_time:76.430s step_avg:149.83ms
+step:625/4950 val_loss:4.02046 train_time:95.140s step_avg:149.68ms
+step:750/4950 val_loss:3.92551 train_time:113.891s step_avg:150.01ms
+step:875/4950 val_loss:3.86240 train_time:132.621s step_avg:149.84ms
+step:1000/4950 val_loss:3.80738 train_time:151.353s step_avg:149.86ms
+step:1125/4950 val_loss:3.77906 train_time:170.085s step_avg:149.85ms
+step:1250/4950 val_loss:3.74024 train_time:188.815s step_avg:149.84ms
+step:1375/4950 val_loss:3.72735 train_time:207.545s step_avg:149.84ms
+step:1500/4950 val_loss:3.69076 train_time:226.277s step_avg:149.85ms
+step:1625/4950 val_loss:3.66739 train_time:245.004s step_avg:149.81ms
+step:1750/4950 val_loss:3.64559 train_time:263.728s step_avg:149.80ms
+step:1875/4950 val_loss:3.62025 train_time:282.446s step_avg:149.74ms
+step:2000/4950 val_loss:3.60026 train_time:301.151s step_avg:149.64ms
+step:2125/4950 val_loss:3.58433 train_time:319.883s step_avg:149.86ms
+step:2250/4950 val_loss:3.56773 train_time:338.601s step_avg:149.75ms
+step:2375/4950 val_loss:3.55115 train_time:357.315s step_avg:149.71ms
+step:2500/4950 val_loss:3.53887 train_time:376.039s step_avg:149.79ms
+step:2625/4950 val_loss:3.52155 train_time:394.727s step_avg:149.51ms
+step:2750/4950 val_loss:3.50832 train_time:413.399s step_avg:149.38ms
+step:2875/4950 val_loss:3.49801 train_time:432.086s step_avg:149.49ms
+step:3000/4950 val_loss:3.48499 train_time:450.753s step_avg:149.33ms
+step:3125/4950 val_loss:3.46760 train_time:469.414s step_avg:149.29ms
+step:3250/4950 val_loss:3.45386 train_time:488.043s step_avg:149.03ms
+step:3375/4950 val_loss:3.43930 train_time:506.676s step_avg:149.06ms
+step:3500/4950 val_loss:3.42869 train_time:525.344s step_avg:149.34ms
+step:3625/4950 val_loss:3.41618 train_time:544.015s step_avg:149.37ms
+step:3750/4950 val_loss:3.40119 train_time:562.663s step_avg:149.18ms
+step:3875/4950 val_loss:3.38812 train_time:581.358s step_avg:149.56ms
+step:4000/4950 val_loss:3.37277 train_time:600.048s step_avg:149.52ms
+step:4125/4950 val_loss:3.36041 train_time:618.730s step_avg:149.45ms
+step:4250/4950 val_loss:3.34700 train_time:637.416s step_avg:149.49ms
+step:4375/4950 val_loss:3.33232 train_time:656.094s step_avg:149.42ms
+step:4475/4950 val_loss:3.32066 train_time:671.065s step_avg:149.72ms
+step:4500/4950 val_loss:3.31817 train_time:674.805s step_avg:149.58ms
+step:4525/4950 val_loss:3.31476 train_time:678.547s step_avg:149.68ms
+step:4550/4950 val_loss:3.31229 train_time:682.285s step_avg:149.52ms
+step:4575/4950 val_loss:3.31038 train_time:686.019s step_avg:149.35ms
+step:4600/4950 val_loss:3.30667 train_time:689.754s step_avg:149.42ms
+step:4625/4950 val_loss:3.30391 train_time:693.488s step_avg:149.35ms
+step:4650/4950 val_loss:3.30162 train_time:697.228s step_avg:149.60ms
+step:4675/4950 val_loss:3.29852 train_time:700.968s step_avg:149.60ms
+step:4700/4950 val_loss:3.29570 train_time:704.708s step_avg:149.60ms
+step:4725/4950 val_loss:3.29387 train_time:708.448s step_avg:149.58ms
+step:4750/4950 val_loss:3.29069 train_time:712.198s step_avg:150.02ms
+step:4775/4950 val_loss:3.28827 train_time:715.972s step_avg:150.95ms
+step:4800/4950 val_loss:3.28607 train_time:719.702s step_avg:149.21ms
+step:4825/4950 val_loss:3.28412 train_time:723.433s step_avg:149.21ms
+step:4850/4950 val_loss:3.28215 train_time:727.161s step_avg:149.12ms
+step:4875/4950 val_loss:3.28048 train_time:730.892s step_avg:149.24ms
+step:4900/4950 val_loss:3.27902 train_time:734.618s step_avg:149.07ms
+step:4925/4950 val_loss:3.27789 train_time:738.347s step_avg:149.15ms
+step:4950/4950 val_loss:3.27733 train_time:742.083s step_avg:149.43ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/be291a4a-bcf4-42ff-bf94-ee377e9f5ac6.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/be291a4a-bcf4-42ff-bf94-ee377e9f5ac6.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=16
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.001s step_avg:nanms
+step:125/4950 val_loss:5.93616 train_time:20.298s step_avg:162.37ms
+step:250/4950 val_loss:4.87146 train_time:38.830s step_avg:148.26ms
+step:375/4950 val_loss:4.37392 train_time:57.475s step_avg:149.16ms
+step:500/4950 val_loss:4.14140 train_time:76.151s step_avg:149.41ms
+step:625/4950 val_loss:4.01644 train_time:94.859s step_avg:149.66ms
+step:750/4950 val_loss:3.94081 train_time:113.574s step_avg:149.72ms
+step:875/4950 val_loss:3.86834 train_time:132.292s step_avg:149.75ms
+step:1000/4950 val_loss:3.81530 train_time:151.011s step_avg:149.75ms
+step:1125/4950 val_loss:3.78805 train_time:169.727s step_avg:149.73ms
+step:1250/4950 val_loss:3.74226 train_time:188.452s step_avg:149.80ms
+step:1375/4950 val_loss:3.74199 train_time:207.148s step_avg:149.57ms
+step:1500/4950 val_loss:3.69222 train_time:225.857s step_avg:149.67ms
+step:1625/4950 val_loss:3.67398 train_time:244.544s step_avg:149.50ms
+step:1750/4950 val_loss:3.65090 train_time:263.235s step_avg:149.53ms
+step:1875/4950 val_loss:3.62904 train_time:281.953s step_avg:149.74ms
+step:2000/4950 val_loss:3.60669 train_time:300.641s step_avg:149.51ms
+step:2125/4950 val_loss:3.59122 train_time:319.362s step_avg:149.77ms
+step:2250/4950 val_loss:3.57295 train_time:338.060s step_avg:149.58ms
+step:2375/4950 val_loss:3.55679 train_time:356.759s step_avg:149.60ms
+step:2500/4950 val_loss:3.54288 train_time:375.442s step_avg:149.46ms
+step:2625/4950 val_loss:3.52537 train_time:394.138s step_avg:149.57ms
+step:2750/4950 val_loss:3.51035 train_time:412.860s step_avg:149.77ms
+step:2875/4950 val_loss:3.50150 train_time:431.564s step_avg:149.64ms
+step:3000/4950 val_loss:3.48568 train_time:450.254s step_avg:149.52ms
+step:3125/4950 val_loss:3.47094 train_time:468.928s step_avg:149.39ms
+step:3250/4950 val_loss:3.45661 train_time:487.605s step_avg:149.41ms
+step:3375/4950 val_loss:3.44364 train_time:506.315s step_avg:149.69ms
+step:3500/4950 val_loss:3.43068 train_time:525.005s step_avg:149.52ms
+step:3625/4950 val_loss:3.41703 train_time:543.699s step_avg:149.55ms
+step:3750/4950 val_loss:3.40348 train_time:562.403s step_avg:149.63ms
+step:3875/4950 val_loss:3.39010 train_time:581.115s step_avg:149.70ms
+step:4000/4950 val_loss:3.37523 train_time:599.851s step_avg:149.89ms
+step:4125/4950 val_loss:3.36159 train_time:618.545s step_avg:149.56ms
+step:4250/4950 val_loss:3.34862 train_time:637.230s step_avg:149.48ms
+step:4375/4950 val_loss:3.33465 train_time:655.894s step_avg:149.31ms
+step:4475/4950 val_loss:3.32258 train_time:670.817s step_avg:149.23ms
+step:4500/4950 val_loss:3.31991 train_time:674.547s step_avg:149.21ms
+step:4525/4950 val_loss:3.31641 train_time:678.277s step_avg:149.18ms
+step:4550/4950 val_loss:3.31441 train_time:682.009s step_avg:149.31ms
+step:4575/4950 val_loss:3.31220 train_time:685.744s step_avg:149.40ms
+step:4600/4950 val_loss:3.30851 train_time:689.470s step_avg:149.04ms
+step:4625/4950 val_loss:3.30577 train_time:693.210s step_avg:149.59ms
+step:4650/4950 val_loss:3.30321 train_time:696.941s step_avg:149.25ms
+step:4675/4950 val_loss:3.30053 train_time:700.678s step_avg:149.48ms
+step:4700/4950 val_loss:3.29749 train_time:704.415s step_avg:149.45ms
+step:4725/4950 val_loss:3.29547 train_time:708.148s step_avg:149.35ms
+step:4750/4950 val_loss:3.29220 train_time:711.883s step_avg:149.38ms
+step:4775/4950 val_loss:3.28978 train_time:715.662s step_avg:151.17ms
+step:4800/4950 val_loss:3.28759 train_time:719.399s step_avg:149.50ms
+step:4825/4950 val_loss:3.28561 train_time:723.133s step_avg:149.36ms
+step:4850/4950 val_loss:3.28354 train_time:726.863s step_avg:149.19ms
+step:4875/4950 val_loss:3.28197 train_time:730.609s step_avg:149.81ms
+step:4900/4950 val_loss:3.28048 train_time:734.344s step_avg:149.42ms
+step:4925/4950 val_loss:3.27938 train_time:738.073s step_avg:149.16ms
+step:4950/4950 val_loss:3.27881 train_time:741.810s step_avg:149.49ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/c81627cb-bb5f-4748-860b-b781b0b7a69a.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/c81627cb-bb5f-4748-860b-b781b0b7a69a.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=19
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.001s step_avg:nanms
+step:125/4950 val_loss:5.86350 train_time:20.090s step_avg:160.71ms
+step:250/4950 val_loss:4.82489 train_time:38.640s step_avg:148.40ms
+step:375/4950 val_loss:4.34650 train_time:57.304s step_avg:149.32ms
+step:500/4950 val_loss:4.12780 train_time:75.999s step_avg:149.56ms
+step:625/4950 val_loss:4.01189 train_time:94.727s step_avg:149.82ms
+step:750/4950 val_loss:3.94072 train_time:113.443s step_avg:149.73ms
+step:875/4950 val_loss:3.86452 train_time:132.173s step_avg:149.84ms
+step:1000/4950 val_loss:3.80964 train_time:150.876s step_avg:149.63ms
+step:1125/4950 val_loss:3.78850 train_time:169.581s step_avg:149.64ms
+step:1250/4950 val_loss:3.74833 train_time:188.287s step_avg:149.65ms
+step:1375/4950 val_loss:3.73745 train_time:206.997s step_avg:149.68ms
+step:1500/4950 val_loss:3.69529 train_time:225.720s step_avg:149.79ms
+step:1625/4950 val_loss:3.67615 train_time:244.423s step_avg:149.62ms
+step:1750/4950 val_loss:3.65001 train_time:263.121s step_avg:149.59ms
+step:1875/4950 val_loss:3.62911 train_time:281.824s step_avg:149.62ms
+step:2000/4950 val_loss:3.60897 train_time:300.523s step_avg:149.59ms
+step:2125/4950 val_loss:3.58987 train_time:319.230s step_avg:149.66ms
+step:2250/4950 val_loss:3.57649 train_time:337.920s step_avg:149.52ms
+step:2375/4950 val_loss:3.56127 train_time:356.629s step_avg:149.67ms
+step:2500/4950 val_loss:3.54552 train_time:375.349s step_avg:149.76ms
+step:2625/4950 val_loss:3.52537 train_time:394.069s step_avg:149.76ms
+step:2750/4950 val_loss:3.51616 train_time:412.782s step_avg:149.70ms
+step:2875/4950 val_loss:3.50499 train_time:431.501s step_avg:149.76ms
+step:3000/4950 val_loss:3.49334 train_time:450.234s step_avg:149.86ms
+step:3125/4950 val_loss:3.47479 train_time:468.939s step_avg:149.64ms
+step:3250/4950 val_loss:3.45905 train_time:487.643s step_avg:149.63ms
+step:3375/4950 val_loss:3.44713 train_time:506.332s step_avg:149.51ms
+step:3500/4950 val_loss:3.43385 train_time:525.001s step_avg:149.35ms
+step:3625/4950 val_loss:3.41960 train_time:543.692s step_avg:149.53ms
+step:3750/4950 val_loss:3.40692 train_time:562.378s step_avg:149.48ms
+step:3875/4950 val_loss:3.39292 train_time:581.077s step_avg:149.59ms
+step:4000/4950 val_loss:3.37828 train_time:599.788s step_avg:149.69ms
+step:4125/4950 val_loss:3.36503 train_time:618.474s step_avg:149.49ms
+step:4250/4950 val_loss:3.35296 train_time:637.155s step_avg:149.45ms
+step:4375/4950 val_loss:3.33812 train_time:655.853s step_avg:149.59ms
+step:4475/4950 val_loss:3.32623 train_time:670.807s step_avg:149.54ms
+step:4500/4950 val_loss:3.32354 train_time:674.547s step_avg:149.59ms
+step:4525/4950 val_loss:3.31979 train_time:678.287s step_avg:149.62ms
+step:4550/4950 val_loss:3.31772 train_time:682.023s step_avg:149.42ms
+step:4575/4950 val_loss:3.31558 train_time:685.772s step_avg:149.98ms
+step:4600/4950 val_loss:3.31226 train_time:689.512s step_avg:149.61ms
+step:4625/4950 val_loss:3.30944 train_time:693.249s step_avg:149.49ms
+step:4650/4950 val_loss:3.30680 train_time:696.998s step_avg:149.95ms
+step:4675/4950 val_loss:3.30403 train_time:700.740s step_avg:149.67ms
+step:4700/4950 val_loss:3.30085 train_time:704.475s step_avg:149.41ms
+step:4725/4950 val_loss:3.29903 train_time:708.224s step_avg:149.95ms
+step:4750/4950 val_loss:3.29586 train_time:711.968s step_avg:149.77ms
+step:4775/4950 val_loss:3.29353 train_time:715.750s step_avg:151.29ms
+step:4800/4950 val_loss:3.29126 train_time:719.497s step_avg:149.86ms
+step:4825/4950 val_loss:3.28930 train_time:723.235s step_avg:149.53ms
+step:4850/4950 val_loss:3.28738 train_time:726.969s step_avg:149.37ms
+step:4875/4950 val_loss:3.28574 train_time:730.712s step_avg:149.74ms
+step:4900/4950 val_loss:3.28424 train_time:734.454s step_avg:149.68ms
+step:4925/4950 val_loss:3.28314 train_time:738.202s step_avg:149.90ms
+step:4950/4950 val_loss:3.28255 train_time:741.943s step_avg:149.67ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/f5278211-4c8f-439c-b375-a2552d38cf8b.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/f5278211-4c8f-439c-b375-a2552d38cf8b.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=20
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/4950 val_loss:5.66297 train_time:20.614s step_avg:164.91ms
+step:250/4950 val_loss:4.74333 train_time:39.193s step_avg:148.63ms
+step:375/4950 val_loss:4.29761 train_time:57.792s step_avg:148.80ms
+step:500/4950 val_loss:4.10253 train_time:76.419s step_avg:149.01ms
+step:625/4950 val_loss:3.98855 train_time:95.060s step_avg:149.12ms
+step:750/4950 val_loss:3.91677 train_time:113.704s step_avg:149.16ms
+step:875/4950 val_loss:3.85051 train_time:132.348s step_avg:149.15ms
+step:1000/4950 val_loss:3.79949 train_time:151.002s step_avg:149.23ms
+step:1125/4950 val_loss:3.78048 train_time:169.646s step_avg:149.16ms
+step:1250/4950 val_loss:3.73333 train_time:188.295s step_avg:149.19ms
+step:1375/4950 val_loss:3.74004 train_time:206.921s step_avg:149.01ms
+step:1500/4950 val_loss:3.69259 train_time:225.533s step_avg:148.90ms
+step:1625/4950 val_loss:3.67175 train_time:244.157s step_avg:148.99ms
+step:1750/4950 val_loss:3.64617 train_time:262.777s step_avg:148.96ms
+step:1875/4950 val_loss:3.61932 train_time:281.393s step_avg:148.92ms
+step:2000/4950 val_loss:3.59894 train_time:300.025s step_avg:149.06ms
+step:2125/4950 val_loss:3.58527 train_time:318.642s step_avg:148.93ms
+step:2250/4950 val_loss:3.56909 train_time:337.275s step_avg:149.07ms
+step:2375/4950 val_loss:3.55500 train_time:355.905s step_avg:149.04ms
+step:2500/4950 val_loss:3.53806 train_time:374.535s step_avg:149.04ms
+step:2625/4950 val_loss:3.52301 train_time:393.172s step_avg:149.10ms
+step:2750/4950 val_loss:3.51222 train_time:411.804s step_avg:149.05ms
+step:2875/4950 val_loss:3.50011 train_time:430.445s step_avg:149.13ms
+step:3000/4950 val_loss:3.48533 train_time:449.068s step_avg:148.99ms
+step:3125/4950 val_loss:3.47183 train_time:467.721s step_avg:149.23ms
+step:3250/4950 val_loss:3.45640 train_time:486.370s step_avg:149.19ms
+step:3375/4950 val_loss:3.44193 train_time:505.011s step_avg:149.12ms
+step:3500/4950 val_loss:3.43072 train_time:523.646s step_avg:149.09ms
+step:3625/4950 val_loss:3.41728 train_time:542.291s step_avg:149.15ms
+step:3750/4950 val_loss:3.40356 train_time:560.937s step_avg:149.17ms
+step:3875/4950 val_loss:3.39059 train_time:579.572s step_avg:149.09ms
+step:4000/4950 val_loss:3.37540 train_time:598.217s step_avg:149.16ms
+step:4125/4950 val_loss:3.36233 train_time:616.853s step_avg:149.09ms
+step:4250/4950 val_loss:3.35028 train_time:635.504s step_avg:149.21ms
+step:4375/4950 val_loss:3.33579 train_time:654.152s step_avg:149.18ms
+step:4475/4950 val_loss:3.32333 train_time:669.067s step_avg:149.15ms
+step:4500/4950 val_loss:3.32174 train_time:672.794s step_avg:149.10ms
+step:4525/4950 val_loss:3.31719 train_time:676.534s step_avg:149.59ms
+step:4550/4950 val_loss:3.31547 train_time:680.264s step_avg:149.20ms
+step:4575/4950 val_loss:3.31318 train_time:683.995s step_avg:149.24ms
+step:4600/4950 val_loss:3.30959 train_time:687.728s step_avg:149.32ms
+step:4625/4950 val_loss:3.30693 train_time:691.460s step_avg:149.28ms
+step:4650/4950 val_loss:3.30447 train_time:695.192s step_avg:149.25ms
+step:4675/4950 val_loss:3.30163 train_time:698.923s step_avg:149.26ms
+step:4700/4950 val_loss:3.29870 train_time:702.650s step_avg:149.08ms
+step:4725/4950 val_loss:3.29673 train_time:706.381s step_avg:149.24ms
+step:4750/4950 val_loss:3.29379 train_time:710.113s step_avg:149.26ms
+step:4775/4950 val_loss:3.29144 train_time:713.889s step_avg:151.05ms
+step:4800/4950 val_loss:3.28924 train_time:717.617s step_avg:149.14ms
+step:4825/4950 val_loss:3.28720 train_time:721.348s step_avg:149.22ms
+step:4850/4950 val_loss:3.28516 train_time:725.072s step_avg:148.98ms
+step:4875/4950 val_loss:3.28349 train_time:728.802s step_avg:149.17ms
+step:4900/4950 val_loss:3.28203 train_time:732.537s step_avg:149.40ms
+step:4925/4950 val_loss:3.28100 train_time:736.272s step_avg:149.41ms
+step:4950/4950 val_loss:3.28043 train_time:740.000s step_avg:149.11ms

--- a/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/fda2f0ac-636c-4301-b29a-090d364983b8.txt
+++ b/records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/fda2f0ac-636c-4301-b29a-090d364983b8.txt
@@ -20,6 +20,16 @@ import torch.nn.functional as F
 import torch.distributed as dist
 
 
+def _get_env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else float(value)
+
+
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return default if value is None or value == "" else int(value)
+
+
 ########################################
 #              Dataloader              #
 ########################################
@@ -160,8 +170,9 @@ class GPT(nn.Module):
 #              Optimizer               #
 ########################################
 
-# AdamW is used for every parameter. Block matrices have a separate parameter
-# group because their scale calls for different hyperparameters.
+# This baseline uses plain AdamW for all parameters. The block 2D matrix
+# parameters get their own param group for tuning; no Muon/Newton-Schulz step
+# is applied.
 
 
 ########################################
@@ -169,8 +180,11 @@ class GPT(nn.Module):
 ########################################
 
 # torchrun sets these env variables
+SEED = int(os.environ.get("SEED", os.environ.get("FIXED_SEED", "0")))
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
+torch.manual_seed(SEED)
+torch.cuda.manual_seed_all(SEED)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
 # this code can be run equivalently with 1, 2, 4, or 8 gpus.
@@ -178,8 +192,9 @@ assert 8 % dist.get_world_size() == 0
 
 # logging setup
 if dist.get_rank() == 0:
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{uuid.uuid4()}.txt"
+    logfile = os.environ.get("LOGFILE") or f"logs/{uuid.uuid4()}.txt"
+    logdir = os.path.dirname(logfile) or "."
+    os.makedirs(logdir, exist_ok=True)
     print(logfile)
 def print0(s, console=False, log=True):
     if dist.get_rank() == 0:
@@ -194,6 +209,8 @@ print0(code)
 print0("="*100)
 print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
        + f" on {torch.cuda.get_device_name(device)} with world_size {dist.get_world_size()}")
+print0(f"Using seed={SEED}")
+print0("Variant=adamw_matrix")
 print0("="*100)
 
 val_tokens = 20 * 524288
@@ -215,7 +232,7 @@ for _ in range(num_trials):
     ########################################
 
     # we want to minimize this while still reaching 3.28 val loss
-    train_steps = 4950
+    train_steps = _get_env_int("TRAIN_STEPS", 3250)
 
     # initialize model parameters
     for name, p in model.named_parameters():
@@ -234,15 +251,38 @@ for _ in range(num_trials):
         else:
             raise Exception(f"Uninitialized parameter: {name}")
 
-    # create the optimizer
-    optimizer = AdamW([
-        dict(params=[model.embed.weight], lr=0.7, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[model.proj.weight], lr=0.004, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.parameters() if p.ndim < 2],
-             lr=0.015, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.002),
-        dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
-             lr=0.001, betas=(0.9, 0.9), eps=1e-8, weight_decay=1.0),
-    ], fused=True)
+    # create a single AdamW optimizer with separate param groups
+    # The auxiliary groups keep the tuned baseline beta1/eps; the 2D block-matrix
+    # group is plain AdamW with beta1=0.9 and eps=1e-8 for LR/WD tuning.
+    adamw_matrix_lr = _get_env_float("ADAMW_MATRIX_LR", 0.0015)
+    adamw_matrix_weight_decay = _get_env_float("ADAMW_MATRIX_WEIGHT_DECAY", 0.1)
+    adamw_matrix_warmup_steps = _get_env_int("ADAMW_MATRIX_WARMUP_STEPS", _get_env_int("WARMUP_STEPS", 0))
+    adamw_matrix_warmup_start_lr = 1e-7
+    lr_embed = 0.7
+    lr_proj = 0.004
+    lr_1d = 0.015
+    wd2 = 0.002
+    if adamw_matrix_warmup_steps < 0:
+        raise ValueError(f"ADAMW_MATRIX_WARMUP_STEPS must be >= 0, got {adamw_matrix_warmup_steps}")
+    print0(
+        "Hyperparameters: "
+        + f"adamw_matrix_lr={adamw_matrix_lr} "
+        + f"adamw_matrix_weight_decay={adamw_matrix_weight_decay} "
+        + f"adamw_matrix_warmup_steps={adamw_matrix_warmup_steps} "
+        + f"adamw_matrix_warmup_start_lr={adamw_matrix_warmup_start_lr}"
+        + f"adamw_embed_lr={lr_embed}"
+        + f"adamw_proj_lr={lr_proj}"
+        + f"adamw_1d_lr={lr_1d}"
+        + f"adamw_non_matrix_weight_decay={wd2}"
+    )
+
+    optimizer = AdamW([dict(params=[model.embed.weight], lr=lr_embed, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[model.proj.weight], lr=lr_proj, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.parameters() if p.ndim < 2], lr=lr_1d, betas=(0.8, 0.95), eps=1e-10, weight_decay=wd2),
+                       dict(params=[p for p in model.blocks.parameters() if p.ndim >= 2],
+                            lr=adamw_matrix_lr, betas=(0.9, 0.9), eps=1e-8,
+                            weight_decay=adamw_matrix_weight_decay)],
+                      fused=True)
     optimizers = [optimizer]
     assert set(p for opt in optimizers for group in opt.param_groups
                for p in group["params"]) == set(model.parameters())
@@ -250,10 +290,8 @@ for _ in range(num_trials):
         for group in opt.param_groups:
             group["initial_lr"] = group["lr"]
 
-    # learning rate schedule: linear warmup, stable, then decay
+    # learning rate schedule: optional linear warmup, stable, then decay
     def set_hparams(step, cooldown_frac=0.7):
-        warmup_steps = 100
-        warmup_start_lr = 1e-7
         progress = step / train_steps
         assert 0 <= progress < 1
         if progress < 1 - cooldown_frac:
@@ -263,9 +301,14 @@ for _ in range(num_trials):
         for opt in optimizers:
             for group in opt.param_groups:
                 top_lr = group["initial_lr"]
-                warmup_frac = step / warmup_steps
-                warmup_eta = (warmup_start_lr + warmup_frac * (top_lr - warmup_start_lr)) / top_lr
-                group["lr"] = top_lr * min(warmup_eta, cooldown_eta)
+                if adamw_matrix_warmup_steps > 0:
+                    warmup_frac = step / adamw_matrix_warmup_steps
+                    warmup_eta = (adamw_matrix_warmup_start_lr
+                                  + warmup_frac * (top_lr - adamw_matrix_warmup_start_lr)) / top_lr
+                    eta = min(warmup_eta, cooldown_eta)
+                else:
+                    eta = cooldown_eta
+                group["lr"] = top_lr * eta
 
 
     ########################################
@@ -328,3 +371,66 @@ for _ in range(num_trials):
                + f" step_avg:{1000*approx_training_time/(step + 1):.2f}ms", console=True, log=False)
 
 dist.destroy_process_group()
+
+====================================================================================================
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8 on NVIDIA H100 80GB HBM3 with world_size 8
+Using seed=18
+Variant=adamw_matrix
+====================================================================================================
+Hyperparameters: adamw_matrix_lr=0.001 adamw_matrix_weight_decay=1.0 adamw_matrix_warmup_steps=100 adamw_matrix_warmup_start_lr=1e-07adamw_embed_lr=0.7adamw_proj_lr=0.004adamw_1d_lr=0.015adamw_non_matrix_weight_decay=0.002
+step:0/4950 val_loss:10.82584 train_time:0.000s step_avg:nanms
+step:125/4950 val_loss:5.90029 train_time:20.016s step_avg:160.13ms
+step:250/4950 val_loss:4.83830 train_time:38.568s step_avg:148.41ms
+step:375/4950 val_loss:4.38032 train_time:57.206s step_avg:149.10ms
+step:500/4950 val_loss:4.13957 train_time:75.876s step_avg:149.37ms
+step:625/4950 val_loss:4.01655 train_time:94.564s step_avg:149.50ms
+step:750/4950 val_loss:3.92725 train_time:113.260s step_avg:149.57ms
+step:875/4950 val_loss:3.85916 train_time:131.957s step_avg:149.58ms
+step:1000/4950 val_loss:3.81108 train_time:150.645s step_avg:149.50ms
+step:1125/4950 val_loss:3.78033 train_time:169.337s step_avg:149.53ms
+step:1250/4950 val_loss:3.74964 train_time:188.011s step_avg:149.39ms
+step:1375/4950 val_loss:3.73914 train_time:206.708s step_avg:149.58ms
+step:1500/4950 val_loss:3.69401 train_time:225.385s step_avg:149.42ms
+step:1625/4950 val_loss:3.67361 train_time:244.067s step_avg:149.46ms
+step:1750/4950 val_loss:3.65108 train_time:262.750s step_avg:149.46ms
+step:1875/4950 val_loss:3.61861 train_time:281.431s step_avg:149.45ms
+step:2000/4950 val_loss:3.60151 train_time:300.106s step_avg:149.39ms
+step:2125/4950 val_loss:3.58578 train_time:318.811s step_avg:149.65ms
+step:2250/4950 val_loss:3.56791 train_time:337.499s step_avg:149.50ms
+step:2375/4950 val_loss:3.55474 train_time:356.189s step_avg:149.52ms
+step:2500/4950 val_loss:3.53927 train_time:374.880s step_avg:149.53ms
+step:2625/4950 val_loss:3.52383 train_time:393.585s step_avg:149.64ms
+step:2750/4950 val_loss:3.51384 train_time:412.276s step_avg:149.52ms
+step:2875/4950 val_loss:3.49890 train_time:430.967s step_avg:149.53ms
+step:3000/4950 val_loss:3.48441 train_time:449.660s step_avg:149.55ms
+step:3125/4950 val_loss:3.46937 train_time:468.360s step_avg:149.59ms
+step:3250/4950 val_loss:3.45447 train_time:487.045s step_avg:149.48ms
+step:3375/4950 val_loss:3.44196 train_time:505.729s step_avg:149.47ms
+step:3500/4950 val_loss:3.43150 train_time:524.414s step_avg:149.48ms
+step:3625/4950 val_loss:3.41693 train_time:543.088s step_avg:149.39ms
+step:3750/4950 val_loss:3.40234 train_time:561.732s step_avg:149.15ms
+step:3875/4950 val_loss:3.38862 train_time:580.388s step_avg:149.25ms
+step:4000/4950 val_loss:3.37505 train_time:599.065s step_avg:149.42ms
+step:4125/4950 val_loss:3.36244 train_time:617.746s step_avg:149.45ms
+step:4250/4950 val_loss:3.34949 train_time:636.374s step_avg:149.02ms
+step:4375/4950 val_loss:3.33530 train_time:654.998s step_avg:148.99ms
+step:4475/4950 val_loss:3.32292 train_time:669.909s step_avg:149.11ms
+step:4500/4950 val_loss:3.32071 train_time:673.641s step_avg:149.26ms
+step:4525/4950 val_loss:3.31696 train_time:677.379s step_avg:149.54ms
+step:4550/4950 val_loss:3.31494 train_time:681.114s step_avg:149.40ms
+step:4575/4950 val_loss:3.31295 train_time:684.846s step_avg:149.27ms
+step:4600/4950 val_loss:3.30919 train_time:688.584s step_avg:149.50ms
+step:4625/4950 val_loss:3.30662 train_time:692.316s step_avg:149.30ms
+step:4650/4950 val_loss:3.30381 train_time:696.051s step_avg:149.41ms
+step:4675/4950 val_loss:3.30085 train_time:699.787s step_avg:149.42ms
+step:4700/4950 val_loss:3.29787 train_time:703.523s step_avg:149.44ms
+step:4725/4950 val_loss:3.29606 train_time:707.255s step_avg:149.28ms
+step:4750/4950 val_loss:3.29304 train_time:710.994s step_avg:149.57ms
+step:4775/4950 val_loss:3.29052 train_time:714.760s step_avg:150.65ms
+step:4800/4950 val_loss:3.28835 train_time:718.484s step_avg:148.96ms
+step:4825/4950 val_loss:3.28631 train_time:722.206s step_avg:148.89ms
+step:4850/4950 val_loss:3.28432 train_time:725.934s step_avg:149.09ms
+step:4875/4950 val_loss:3.28265 train_time:729.661s step_avg:149.08ms
+step:4900/4950 val_loss:3.28124 train_time:733.385s step_avg:148.95ms
+step:4925/4950 val_loss:3.28013 train_time:737.110s step_avg:149.02ms
+step:4950/4950 val_loss:3.27954 train_time:740.836s step_avg:149.05ms


### PR DESCRIPTION
## Changes

- `train_steps`: 3250 -> 4950
- Replace Muon on the 2D block-matrix parameters with AdamW
- AdamW learning rates:
  - embedding: 0.7
  - projection: 0.004
  - 1D parameters: 0.015
  - 2D block matrices: 0.001
- AdamW weight decay:
  - embedding, projection, and 1D parameters: 0.001 -> 0.002
  - 2D block matrices: 1.0
- 2D block-matrix AdamW betas: `(0.9, 0.9)`
- Add a 100-step linear warmup from `1e-7`

Validation logs are included in:

`records/track_3_optimization/results/20260701_tuned_adamw_steps_4950_wd_1_wd2_0.002_matrix_b2_0.9/`

## 10-run result at 4950 steps

- mean val loss: 3.277604
- median val loss: 3.277095
- std: 0.002516
- min: 3.274590
- max: 3.282550

## README significance criterion

```text
(3.28 - mean) * sqrt(10) = 0.007577
```

This passes the required `>= 0.004`.
