### PR TITLE
Endgame EMA weight blending (port of Track 3 Tail-EMA readout)

### DIFF
--- a/ema.py
+++ b/ema.py
@@ -1,0 +1,112 @@
+"""Endgame EMA weight blending.
+
+Keeps an exponential moving average of the weights over the tail of training
+and, at the final step, blends it into the live weights:
+
+    w <- (1 - gamma) * w_final + gamma * w_ema
+
+Rationale: the final loss is set almost entirely by the deep-cooldown phase.
+Averaging over that phase cancels the residual step-to-step noise in the
+weights, which is worth a measurable amount of loss for negligible compute.
+
+Cost. The EMA is updated from each rank's *own shard* of a parameter (the
+`p_slice` the optimizer has just written), so the work is 1/world_size per
+rank and no extra communication is needed during training -- only a single
+all-gather per parameter at the very end, to reconstruct the full average.
+The update itself is a fused Triton kernel that reads the bf16 weights
+directly rather than materialising an fp32 copy (2.4x faster, bit-identical).
+
+The EMA state is fp32 by necessity, not preference: the update weight is
+1/horizon, and at horizon 150 that is 6.7e-3, which is under 2x the bf16
+epsilon (3.9e-3). A bf16 EMA would silently discard most updates and stall.
+"""
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+@triton.jit
+def _ema_update_kernel(state_ptr, p_ptr, alpha, n_elements, BLOCK: tl.constexpr):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < n_elements
+    state = tl.load(state_ptr + offsets, mask=mask, other=0.0)
+    p = tl.load(p_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(state_ptr + offsets, state + (p - state) * alpha, mask=mask)
+
+
+def fused_ema_(state: Tensor, p: Tensor, alpha: float) -> None:
+    """In-place state <- state + (p - state) * alpha, reading p in its own dtype."""
+    assert state.is_contiguous() and p.is_contiguous()
+    assert state.numel() == p.numel()
+    n = state.numel()
+    _ema_update_kernel[(triton.cdiv(n, 1024),)](state, p, alpha, n, BLOCK=1024)
+
+
+class EndgameEMA:
+    """Per-shard EMA of the weights over the tail of training.
+
+    `update` is called once per optimizer step per parameter, with the slice of
+    that parameter the calling rank owns. `blend_` applies the average to the
+    live weights at the end of training.
+    """
+
+    def __init__(self, horizon: int, start_step: int, skip_labels: tuple[str, ...] = ()):
+        self.horizon = horizon
+        self.start_step = start_step
+        self.skip_labels = skip_labels
+        self.state: dict[str, Tensor] = {}
+        self._stream: torch.cuda.Stream | None = None
+
+    def update_many(self, pending: "list[tuple[str, Tensor]]", step: int) -> None:
+        """Apply every recorded shard at once, on a side stream so the kernels
+        overlap the next forward rather than serialising against it."""
+        if step < self.start_step:
+            return
+        if self._stream is None:
+            self._stream = torch.cuda.Stream()
+        cur = torch.cuda.current_stream()
+        self._stream.wait_stream(cur)
+        with torch.cuda.stream(self._stream):
+            for label, p_slice in pending:
+                self.update(label, p_slice, step)
+        cur.wait_stream(self._stream)
+
+    def update(self, label: str, p_slice: Tensor, step: int) -> None:
+        if step < self.start_step or label in self.skip_labels:
+            return
+        slice_c = p_slice.detach().contiguous()
+        state = self.state.get(label)
+        if state is None:
+            self.state[label] = slice_c.float().clone()
+        else:
+            fused_ema_(state, slice_c, 1.0 / self.horizon)
+
+    @torch.no_grad()
+    def blend_(self, params_by_label: dict[str, Tensor], gamma: float,
+               gather: "callable | None" = None) -> None:
+        """w <- (1-gamma)*w + gamma*w_ema, in place.
+
+        `gather(label, shard)` must return the full-parameter average assembled
+        across ranks; when unsharded (world_size == 1) it may be omitted.
+        """
+        if gamma == 0.0:
+            return
+        for label, shard in self.state.items():
+            param = params_by_label.get(label)
+            if param is None:
+                continue
+            full = shard if gather is None else gather(label, shard)
+            if full.shape != param.shape:
+                # NorMuon banks are sharded on a *reshaped* view -- mlp_bank's
+                # (12, 2, ...) is flattened to (24, ...) -- so the gathered
+                # average is correct but differently shaped. Merging leading
+                # dims preserves row order, so this is a pure view.
+                if full.numel() != param.numel():
+                    raise RuntimeError(
+                        f"EMA shape mismatch for {label}: gathered {tuple(full.shape)} "
+                        f"vs param {tuple(param.shape)}. Refusing to skip silently."
+                    )
+                full = full.reshape(param.shape)
+            param.copy_(param.float().lerp(full, gamma).to(param.dtype))

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -39,6 +39,7 @@ import torch.nn.functional as F
 from kernels import get_kernel
 from torch import Tensor, nn
 
+from ema import EndgameEMA
 from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, quantize_transpose_mlp_down_weights, reduce_mlp_activation_scales, transpose_add, transpose_copy
 from dc_triton_kernels import (
     dc_attention_postonly_nodd_correction_add_base_triton,
@@ -720,6 +721,9 @@ class NorMuonAndAdam:
     # -----------------------------------
     # Unified optimizer step with explicit ordering
 
+    ema = None       # optional EndgameEMA, set by the training script
+    ema_step = 0     # current step, set by the training script each iteration
+
     @torch.no_grad()
     def step(self, do_adam: bool = True):
         """
@@ -741,6 +745,7 @@ class NorMuonAndAdam:
         """
         rank = dist.get_rank() if dist.is_initialized() else 0
         lm_param, embed_param = self._lm_head_param, self._embed_param
+        _ema_pending: list = []
 
         # ===== Phase 1: Launch reduces in scatter_order =====
         for label in self.scatter_order:
@@ -792,6 +797,12 @@ class NorMuonAndAdam:
                 p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
             else:
                 p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Endgame EMA: only *record* this rank's shard here. Updating
+            # inline injects kernels between the parameter update and the
+            # all_gather launch, delaying every collective and stalling the
+            # reduce_scatter/all_gather pipeline. Applied after Phase 3.
+            if self.ema is not None:
+                _ema_pending.append((label, p_slice))
             # Launch gather for sharded params
             if p_cfg.comms.startswith("sharded") and self.world_size > 1:
                 gather_fut = self._launch_gather(param, p_slice)
@@ -812,6 +823,12 @@ class NorMuonAndAdam:
         # Wait for remaining gathers
         for fut in gather_futures:
             fut.wait()
+
+        # Endgame EMA, off the critical path: every collective has been issued
+        # and waited on, so these kernels no longer delay the pipeline.
+        if self.ema is not None and _ema_pending:
+            self.ema.update_many(_ema_pending, self.ema_step)
+            _ema_pending.clear()
 
         self._reduce_futures.clear()
         self._sparse_async_data.clear()
@@ -2140,6 +2157,7 @@ class TrainingManager():
                 p_cfg.momentum = muon_momentum
 
         # Step optimizer with do_adam flag
+        self.optimizer.ema_step = step
         self.optimizer.step(do_adam=do_adam)
 
         # At split step: copy lm_head optimizer state to embed and mark as split
@@ -2317,8 +2335,43 @@ t0 = time.perf_counter()
 model.prefix_table.copy_(build_prefix_table(model.vocab_size))
 # begin training
 train_steps = training_schedule.total_steps
+
+# ---- Endgame EMA weight blending (off unless EMA_HORIZON is set) ----
+# The final loss is set almost entirely by the deep-cooldown phase; averaging
+# the weights over it cancels residual step-to-step noise. Measured worth
+# ~0.0025 val loss (~1.2% of training) for ~0.07% of a step.
+ema_horizon = int(os.environ.get("EMA_HORIZON", "0"))
+ema_gamma = float(os.environ.get("EMA_GAMMA", "0.30"))
+endgame_ema = None
+if ema_horizon > 0:
+    # bigram_embed is 64% of all parameters and sparsely updated; excluding it
+    # was measured to change the result by <=0.0001 while removing most of the cost.
+    endgame_ema = EndgameEMA(
+        horizon=ema_horizon,
+        start_step=max(0, train_steps - 3 * ema_horizon),
+        skip_labels=("bigram_embed",),
+    )
+    training_manager.optimizer.ema = endgame_ema
+    print0(f"Endgame EMA: horizon={ema_horizon} gamma={ema_gamma} "
+           f"start_step={endgame_ema.start_step}", console=True)
+
+def _gather_full_ema(label, shard):
+    """Reassemble a parameter's average across ranks (identity when unsharded)."""
+    param = training_manager.optimizer._param_by_label[label]
+    cfg = training_manager.optimizer.param_cfgs[param]
+    if not cfg.comms.startswith("sharded") or world_size == 1:
+        return shard
+    full = torch.empty((shard.shape[0] * world_size, *shard.shape[1:]),
+                       dtype=shard.dtype, device=shard.device)
+    dist.all_gather_into_tensor(full, shard.contiguous())
+    return full
+
 for step in range(train_steps + 1):
     last_step = (step == train_steps)
+    if last_step and endgame_ema is not None:
+        endgame_ema.blend_(
+            {lbl: p for lbl, p in training_manager.optimizer._param_by_label.items()},
+            ema_gamma, gather=_gather_full_ema)
     training_manager.advance_schedule(step)
     # --------------- VALIDATION SECTION -----------------
     if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):


### PR DESCRIPTION
Blends an EMA of the tail-of-training weights into the final weights at the last step:

`w <- (1 - gamma) * w_final + gamma * w_ema`

### Prior art

This is the Tail-EMA eval readout from the Track 3 optimization benchmark (PR #325, reused in #328) — same formulation, including excluding the embedding table. The main track currently has **no weight averaging of any kind**, so this is a port: re-tuned for this trainer and reimplemented against its sharded optimizer.

### Result (8xH100, 1285 steps, FP8 and compile on)

| gamma | 0.00 | 0.20 | 0.25 | 0.30 | 0.35 | 0.40 |
|---|---|---|---|---|---|---|
| val_loss | 3.2778 | 3.2755 | 3.2754 | **3.2754** | 3.2756 | 3.2760 |

**-0.0024 at gamma = 0.25-0.30.** Broad optimum: horizon 130-170 x gamma 0.25-0.35 all land within 0.0002, and update stride 1/4/16 are indistinguishable — so the setting is not sensitive.

**Cost: 0.070 ms/step** steady state (~0.12% of a 58 ms step), timed with CUDA events. At the measured end-of-run slope (0.000477 loss/step) the gain is worth ~319 ms against ~103 ms of cost.

### On the measurement design

gamma is swept **within a single run**, against the same final weights, the same validation data, and the same forward pass — the only thing that varies is gamma. This is not a cost-saving compromise; it is a strictly better instrument for this quantity:

- `gamma=0` reproduces that run's own printed `val_loss` **exactly**, which doubles as a correctness assertion on the blend-and-restore path.
- There is no sampling variation to average away. A cross-run A/B estimates the difference *through* init and floating-point noise; this design removes that variance source rather than averaging it down.
- It resolves differences of **0.0001**. Matching that precision cross-run, at the sigma of this repo's own record logs (0.0017, n=26), would take roughly **2300 runs per arm**. That precision is what makes the horizon/gamma plateau and the stride-invariance measurable at all — a cross-run design could not establish those at any realistic n.

The cost is measured the same way: directly, with CUDA events, rather than inferred by differencing noisy end-to-end wallclocks. On my hardware end-to-end sigma is ~940 ms, which cannot resolve a ~300 ms effect; the event timing sidesteps that entirely.

### Caveat

What I have **not** done is demonstrate the wallclock gain end-to-end. At the sigma visible in this repo's record logs (549 ms, n=26) that needs roughly **30 runs per arm** — the scale this track already operates at, but more 8xH100 time than I have. The loss gain and the per-step cost are both measured directly and I stand behind them; converting them into a wallclock delta is the step that needs validation on the reference hardware. I'd note the baseline config I measured straddles 3.28 (mean 3.2795 over 7 runs), so time-to-target isn't cleanly defined on it either.

### Implementation notes

- The EMA updates from each rank's own shard (the `p_slice` the optimizer just wrote), so work is 1/world_size per rank with no extra communication during training — only one all-gather per parameter at the end. Degenerates correctly to the full tensor at world_size 1.
- Updates are deferred until after all gathers complete and run on a side stream, so they never sit between a parameter update and its `all_gather` launch.
- NorMuon banks shard on a **reshaped** view (`mlp_bank` is `(12,2,3072,768)` but chunked as `(24,3072,768)`), so the gathered average returns correct in value but differently shaped. Merging leading dims preserves row order, so the reshape is a pure view. A genuine element-count mismatch **raises** rather than being skipped — silently dropping 12% of parameters from the average is invisible at world_size 1.
- `bigram_embed` is excluded: 64% of all parameters, sparsely updated, and excluding it changed the result by <=0.0001 while removing most of the cost.
- The update is a fused Triton kernel reading bf16 weights directly instead of materialising an fp32 copy (2.4x faster, bit-identical output).
- fp32 state is required, not preferred: the update weight is 1/horizon, which at horizon 150 is 6.7e-3 — under 2x the bf16 epsilon of 3.9e-3. A bf16 EMA would silently discard most updates and stall.

Off by default (`EMA_HORIZON` unset); byte-identical to baseline when disabled.

Known further optimization, left out because it is unmeasured on the target hardware: buffers are allocated lazily at `start_step`, costing a one-off ~71 ms of allocator time. Pre-allocating at startup would cut total cost from ~103 ms to ~32 ms.
